### PR TITLE
Temporary fix for the code selection.

### DIFF
--- a/qe.ipynb
+++ b/qe.ipynb
@@ -35,7 +35,8 @@
     "ipw.dlink((relax_step, 'output_structure'), (compute_bands_step, 'input_structure'))\n",
     "\n",
     "# Propagate the configuration from the relax step to the compute band gaps step.\n",
-    "ipw.dlink((relax_step.code_group.dropdown, 'value'), (compute_bands_step.code_group.dropdown, 'value'))\n",
+    "# TODO: uncomment when https://github.com/aiidalab/aiidalab-widgets-base/issues/60 is fixed.\n",
+    "#ipw.dlink((relax_step.code_group, 'selected_code'), (compute_bands_step.code_group, 'selected_code'))\n",
     "ipw.dlink((relax_step.pseudo_family, 'value'), (compute_bands_step.pseudo_family, 'value'))\n",
     "ipw.dlink((relax_step.number_of_nodes, 'value'), (compute_bands_step.number_of_nodes, 'value'))\n",
     "ipw.dlink((relax_step.cpus_per_node, 'value'), (compute_bands_step.cpus_per_node, 'value'))\n",
@@ -69,7 +70,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Currently it is no possible to link `selected_code` traits of
CodeDropdown widget. Commenting it out till the issue is fixed.
Link: https://github.com/aiidalab/aiidalab-widgets-base/issues/60