### PR TITLE
🐛 FIX: OptimadeQueryWidget moved to aiidalab_widgets_base

### DIFF
--- a/qe.ipynb
+++ b/qe.ipynb
@@ -11,7 +11,7 @@
     "import ipywidgets as ipw\n",
     "from aiidalab_widgets_base import CodQueryWidget, SmilesWidget, StructureExamplesWidget\n",
     "from aiidalab_widgets_base import StructureBrowserWidget, StructureManagerWidget, StructureUploadWidget\n",
-    "from aiidalab_optimade import OptimadeQueryWidget\n",
+    "from aiidalab_widgets_base import OptimadeQueryWidget\n",
     "\n",
     "from wizard import WizardApp\n",
     "from structures import StructureSelectionStep\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiida-core~=1.0
-aiidalab-optimade~=1.1
 aiidalab-widgets-base~=1.0b
 aiida-quantumespresso~=3.2
 ase~=3.18


### PR DESCRIPTION
According to https://github.com/aiidalab/aiidalab-optimade/blob/83fdcb60cfb1d87faba48038f7ba3cba771f2c83/aiidalab_optimade/widget.py#L12