### PR TITLE
Monkeypatch the pybel import path.

### DIFF
--- a/qe.ipynb
+++ b/qe.ipynb
@@ -3,6 +3,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fix pybel import path\n",
+    "try:\n",
+    "    import sys\n",
+    "    sys.modules['pybel'] = __import__('openbabel', globals(), locals(), ['pybel']).pybel\n",
+    "except Exception:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": false
    },


### PR DESCRIPTION
The pybel module must be imported as

	from openbabel import pybel

instead of

	import pybel

This monkeypatch enables the second import as well.