### PR TITLE
Update metadata.json.in

### DIFF
--- a/metadata/templates/metadata.json.in
+++ b/metadata/templates/metadata.json.in
@@ -6,6 +6,6 @@
     "logo": "miscellaneous/logos/QE.jpg",
     "state": "development",
     "requires": {
-      {{ ">=20.09" | get_requirements(version="v20.11.0") }}
+      {{ ">=20.09" | get_requirements(version="v20.11.2") }}
     }
 }


### PR DESCRIPTION
Since v20.11.0 aiidalab-optimade was removed from the requirements, which is I assume is the source of the incompatibility I'm getting:

- https://github.com/aiidalab/aiidalab-qe/blob/v20.11.0/requirements.txt
- https://github.com/aiidalab/aiidalab-qe/blob/v20.11.2/requirements.txt

Another point this raises is that when an app is listed as "App incompatible", it should be possible to retrieve the source of this incompatibility (or at list what the requirements are), which I don't think is possible at present