### PR TITLE
Update results report of inputs params

### DIFF
--- a/node_view.py
+++ b/node_view.py
@@ -205,11 +205,11 @@ class SummaryView(ipw.VBox):
                     <td>{{ pseudo_family }}</td>
                 </tr>
                 <tr>
-                    <td>Plane wave energy cutoff (wave functions):</td>
+                    <td>Energy cutoff (wave functions):</td>
                     <td>{{ energy_cutoff_wfc }}</td>
                 </tr>
                 <tr>
-                    <td>Plane wave energy cutoff (charge density):</td>
+                    <td>Energy cutoff (charge density):</td>
                     <td>{{ energy_cutoff_rho }}</td>
                 </tr>
                 <tr>

--- a/node_view.py
+++ b/node_view.py
@@ -201,12 +201,8 @@ class SummaryView(ipw.VBox):
                     <td>{{ relaxed | fmt_yes_no }}</td>
                 </tr>
                 <tr>
-                    <td>Bands computed:</td>
-                    <td>{{ bands_computed | fmt_yes_no }}</td>
-                </tr>
-                <tr>
-                    <td>Density of State (DoS) computed:</td>
-                    <td>{{ pdos_computed |fmt_yes_no }}</td>
+                    <td>Pseudopotential library:</td>
+                    <td>{{ pseudo_family }}</td>
                 </tr>
                 <tr>
                     <td>Plane wave energy cutoff (wave functions):</td>

--- a/node_view.py
+++ b/node_view.py
@@ -197,7 +197,7 @@ class SummaryView(ipw.VBox):
             <pre style="{style}">
             <table>
                 <tr>
-                    <td>Structure relaxation:</td>
+                    <td>Structure geometry optimized:</td>
                     <td>{{ relaxed | fmt_yes_no }}</td>
                 </tr>
                 <tr>
@@ -209,10 +209,24 @@ class SummaryView(ipw.VBox):
                     <td>{{ pdos_computed |fmt_yes_no }}</td>
                 </tr>
                 <tr>
+                    <td>Plane wave energy cutoff (wave functions):</td>
+                    <td>{{ energy_cutoff_wfc }}</td>
+                </tr>
+                <tr>
+                    <td>Plane wave energy cutoff (charge density):</td>
+                    <td>{{ energy_cutoff_rho }}</td>
+                </tr>
+                <tr>
                     <td>K-point mesh distance (SCF):</td>
                     <td>{{ scf_kpoints_distance }}</td>
                 </tr>
                 {% if bands_computed %}
+                <tr>
+                    <td>K-point line distance (Bands)</td>
+                    <td>{{ bands_kpoints_distance }}</td>
+                </tr>
+                {% endif %}
+                {% if pdos_computed %}
                 <tr>
                     <td>K-point mesh distance (NSCF)</td>
                     <td>{{ nscf_kpoints_distance }}</td>

--- a/report.py
+++ b/report.py
@@ -48,8 +48,8 @@ def _generate_report_dict(qeapp_wc):
         if energy_cutoffs is None:
             try:
                 parameters = work_chain.inputs.base__pw__parameters.get_dict()
-                energy_cutoff_wfc = parameters["SYSTEM"]["ecutwfc"]
-                energy_cutoff_rho = parameters["SYSTEM"]["ecutrho"]
+                energy_cutoff_wfc = round(parameters["SYSTEM"]["ecutwfc"])
+                energy_cutoff_rho = round(parameters["SYSTEM"]["ecutrho"])
             except NotExistentAttributeError:
                 pass
 


### PR DESCRIPTION
A couple of changes are made to the report of the input parameters:

* Add the plane wave energy cutoffs to the report. In order to do this, separate the `yield`ed energy cutoffs so they aren't reported as a dict. (Since I didn't know if that would work in the jinja template 😅 ) 
* Show the k-points line distance of the `'bands'` calculation in case the band structure is computed.
* Show the k-points mesh distance of the `'nscf'` calculation in case the PDOS is computed.
* In case the pseudo family isn't provided (i.e. equal to `None`), use the `protocol` to determine the `pseudo_family`.