### PR TITLE
♻️ REFACTOR: defaults and widgets of the steps

### DIFF
--- a/aiidalab_qe/parameters/__init__.py
+++ b/aiidalab_qe/parameters/__init__.py
@@ -1,0 +1,6 @@
+import yaml
+
+from importlib import resources
+from aiidalab_qe import parameters
+
+DEFAULT_PARAMETERS = yaml.safe_load(resources.read_text(parameters, "qeapp.yaml"))

--- a/aiidalab_qe/parameters/qeapp.yaml
+++ b/aiidalab_qe/parameters/qeapp.yaml
@@ -1,0 +1,20 @@
+# Default builder parameters for the QeAppWorkChain
+
+## Properties
+relax_type: positions_cell
+run_bands: false
+run_pdos: false
+
+## Codes
+dos_code: dos@localhost
+projwfc_code: projwfc@localhost
+pw_code: pw@localhost
+
+## Material settings
+spin_type: none
+electronic_type: metal
+
+## Calculation settings
+protocol: moderate
+kpoints_distance_override: null
+pseudo_family: SSSP/1.1/PBEsol/efficiency

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -238,7 +238,7 @@ class KpointSettings(ipw.VBox):
         )
 
 
-class CodesConfig(ipw.VBox):
+class CodeSettings(ipw.VBox):
 
     codes_title = ipw.HTML(
         """<div style="padding-top: 0px; padding-bottom: 0px">
@@ -313,7 +313,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         self.material_settings = MaterialSettings()
         self.kpoints_settings = KpointSettings()
         self.pseudo_family_selector = PseudoFamilySelector()
-        self.codes_selector = CodesConfig()
+        self.codes_selector = CodeSettings()
         self.resources_config = ResourceSelectionWidget()
 
         self.set_trait("builder_parameters", self._default_builder_parameters())

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     aiidalab-qe-workchain @ https://github.com/aiidalab/aiidalab-qe/raw/develop/src/dist/aiidalab_qe_workchain-1.0-py3-none-any.whl
     aiidalab-widgets-base~=1.0b
     widget_bandsplot~=0.2.1
+    importlib_resources~=5.1.4
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
     aiidalab-qe-workchain @ https://github.com/aiidalab/aiidalab-qe/raw/develop/src/dist/aiidalab_qe_workchain-1.0-py3-none-any.whl
     aiidalab-widgets-base~=1.0b
     widget_bandsplot~=0.2.1
-    importlib_resources~=5.1.4
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Fixes #67 

Several changes are made to clean up/refactor/modularize the widgets:

* Move defaults into `.yaml` that is read and used consistently. Use
`importlib_resources` for importing this into modules.
* Try to add consistency between the order of these default in the .yaml
file and how they are ordered in several commands of ths
`SubmitQeAppWorkChainStep`.
* Rename `configs` to `settings` (save for `code`, this was included in
PR #71).
* Fix issue where _both_ `OptionsConfig` (now `AdvancedSettings`) and
`SubmitQeAppWorkChainStep` would intialize a `PseudoFamilySelector`,
leading to issues in correctly assigning the pseudos.

Note that there is a small change in UI: The Materials Settings have
been moved outside of expert mode, since the layman usually can still
understand/decide whether their structure is magnetic/insulating or not.

This also seems to have fixed the issue we were having with the UI
breaking when disabling expert mode on the "Select Codes" tab.