### PR TITLE
Revise the LogOutputWidget

### DIFF
--- a/aiidalab_qe/widgets.py
+++ b/aiidalab_qe/widgets.py
@@ -162,7 +162,7 @@ class FilenameDisplayWidget(ipw.Box):
         """
 
 
-class LogOutputWidget(ipw.HBox):
+class LogOutputWidget(ipw.VBox):
 
     filename = traitlets.Unicode()
     value = traitlets.Unicode()
@@ -178,7 +178,7 @@ class LogOutputWidget(ipw.HBox):
         )
 
         self._filename_display = FilenameDisplayWidget(
-            layout=ipw.Layout(width="auto"), max_width="50em"
+            layout=ipw.Layout(width="auto"), max_width="55em"
         )
         ipw.dlink(
             (self, "filename"),
@@ -223,7 +223,10 @@ class LogOutputWidget(ipw.HBox):
         )
 
         super().__init__(
-            [ipw.VBox([self._filename_display, self._rolling_output]), self._btns],
+            [
+                self._filename_display,
+                ipw.HBox([self._rolling_output, self._btns]),
+            ],
             **kwargs,
         )
 


### PR DESCRIPTION
Update the LogOutputWidget used for displaying calcjob outputs.

- Slight refactor, the RollingOutput widget is used only for displaying the
  rolling terminal output and has a "scroll to bottom" function, but does not
  handle any logic with respect to what is displayed and how to download it.
- The LogOutputWidget has additional logic for toggleable auto-scrolling and a
  button that allows for direct scroll to bottom. Note: It is not trivial to
  determine whether scrolling is necessary so both buttons are always enabled
  as long as there is any content.
- The download button allows for downloading the complete content of the
  displayed output, not just the part that is currently displayed.

Fixes #88.

Screenshot:
![Screen Shot 2021-10-26 at 11 35 54](https://user-images.githubusercontent.com/1441208/138852120-c90be9b9-95b9-4c43-9056-77ccd62c079c.png)


