### PR TITLE
Running PDOS workchain and plot bands + pdos

### DIFF
--- a/aiidalab_qe/node_view.py
+++ b/aiidalab_qe/node_view.py
@@ -428,7 +428,7 @@ class WorkChainViewer(ipw.VBox):
             layout=ipw.Layout(min_height="380px"),
         )
         self.bands_tab = ipw.VBox(
-            [ipw.Label("Band structure not available.")],
+            [ipw.Label("Electronic Structure not available.")],
             layout=ipw.Layout(min_height="380px"),
         )
         self.result_tabs = ipw.Tab(
@@ -437,7 +437,7 @@ class WorkChainViewer(ipw.VBox):
 
         self.result_tabs.set_title(0, "Workflow Summary")
         self.result_tabs.set_title(1, "Final Geometry (n/a)")
-        self.result_tabs.set_title(2, "Band Structure (n/a)")
+        self.result_tabs.set_title(2, "Electronic Structure (n/a)")
 
         # An ugly fix to the structure appearance problem
         # https://github.com/aiidalab/aiidalab-qe/issues/69
@@ -498,11 +498,14 @@ class WorkChainViewer(ipw.VBox):
         self.result_tabs.set_title(1, "Final Geometry")
 
     def _show_band_structure(self):
+        data = export_data(self.node)
+        bands_data = data.get("bands", None)
+        dos_data = data.get("dos", None)
         self._bands_plot_view = BandsPlotWidget(
-            bands=[export_bands_data(self.node)], plot_fermilevel=True
+            bands=[bands_data], dos=dos_data, plot_fermilevel=True
         )
         self.result_tabs.children[2].children = [self._bands_plot_view]
-        self.result_tabs.set_title(2, "Band Structure")
+        self.result_tabs.set_title(2, "Electronic Structure")
 
     def _show_workflow_output(self):
         self.workflows_output = WorkChainOutputs(self.node)

--- a/qe.ipynb
+++ b/qe.ipynb
@@ -137,7 +137,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,12 @@ packages = find:
 install_requires =
     Jinja2~=2.11.3
     aiida-core~=1.0
-    aiida-quantumespresso~=3.4
+    aiida-quantumespresso~=3.5
     aiidalab-qe-workchain@https://github.com/aiidalab/aiidalab-qe/raw/v21.07.0b3/src/dist/aiidalab_qe_workchain-1.0-py3-none-any.whl
-    aiidalab-widgets-base~=1.1
+    aiidalab-widgets-base>=1.2.0,<2
     filelock~=3.3.0
     importlib-resources~=5.2.2
-    widget-bandsplot~=0.2.1
+    widget-bandsplot~=0.2.5
 python_requires = >=3.7
 
 [options.extras_require]


### PR DESCRIPTION
Fixes #62

- [x] The PR is blocked by https://github.com/aiidalab/aiidalab-widgets-base/issues/262 since pdos workchain have outputs in namespace.
- [x] Clean `qe.ipynb`
- [x] add checkbox and able to run PDOS workchain when the box checked
- [x] newly added `pdos` and `projwfc` code setting will break backward compatibility. 
- [x] newly added codes is not default set for the code dropdown widget.
- [x] Dependency: new `aiida-quantumespresso` plugin otherwise will raise `tetrahydro` setting error.
- [x] bands+pdos plot 
- [x] `show_band_structure` widget tab name change. When only one bands or pdos calculation run.
- [x]  aiida-quantumespresso 3.5.0 for the tetrahedra override