### PR TITLE
IMPROVE: Rework resource specification

### DIFF
--- a/aiidalab_qe/setup_codes.py
+++ b/aiidalab_qe/setup_codes.py
@@ -82,7 +82,7 @@ def _setup_code(code_name, computer_name="localhost"):
                 "--computer",
                 computer_name,
                 "--prepend-text",
-                f"conda activate {CONDA_ENV_PREFIX}",
+                f"conda activate {CONDA_ENV_PREFIX}\nexport OMP_NUM_THREADS=1",
                 "--remote-abs-path",
                 CONDA_ENV_PREFIX.joinpath("bin", f"{code_name}.x"),
             ],

--- a/aiidalab_qe/widgets.py
+++ b/aiidalab_qe/widgets.py
@@ -389,31 +389,72 @@ class ResourceSelectionWidget(ipw.VBox):
     prompt = ipw.HTML(
         """<div style="line-height:120%; padding-top:0px">
         <p style="padding-bottom:10px">
-        Specify the number of MPI tasks for this calculation.
-        In general, larger structures will require a larger number of tasks.
+        Specify the resources to use for the pw.x calculation.
         </p></div>"""
     )
 
     def __init__(self, **kwargs):
         extra = {
             "style": {"description_width": "150px"},
-            # "layout": {"max_width": "200px"},
-            "layout": {"min_width": "310px"},
+            "layout": {"min_width": "180px"},
         }
-
-        self.num_mpi_tasks = ipw.BoundedIntText(
-            value=1, step=1, min=1, description="# MPI tasks", **extra
+        self.num_nodes = ipw.BoundedIntText(
+            value=1, step=1, min=1, max=1000, description="Nodes", **extra
+        )
+        self.num_cpus = ipw.BoundedIntText(
+            value=1, step=1, min=1, description="CPUs", **extra
         )
 
         super().__init__(
             children=[
                 self.title,
-                ipw.HBox(children=[self.prompt, self.num_mpi_tasks]),
+                ipw.HBox(
+                    children=[self.prompt, self.num_nodes, self.num_cpus],
+                    layout=ipw.Layout(justify_content="space-between"),
+                ),
             ]
         )
 
     def reset(self):
-        self.num_mpi_tasks.value = 1
+        self.num_nodes.value = 1
+        self.num_cpus.value = 1
+
+
+class ParallelizationSettings(ipw.VBox):
+    """Widget for setting the parallelization settings."""
+
+    title = ipw.HTML(
+        """<div style="padding-top: 0px; padding-bottom: 0px">
+        <h4>Parallelization</h4>
+    </div>"""
+    )
+    prompt = ipw.HTML(
+        """<div style="line-height:120%; padding-top:0px">
+        <p style="padding-bottom:10px">
+        Specify the number of k-points pools for the calculations.
+        </p></div>"""
+    )
+
+    def __init__(self, **kwargs):
+        extra = {
+            "style": {"description_width": "150px"},
+            "layout": {"min_width": "180px"},
+        }
+        self.npools = ipw.BoundedIntText(
+            value=1, step=1, min=1, max=128, description="Number of k-pools", **extra
+        )
+        super().__init__(
+            children=[
+                self.title,
+                ipw.HBox(
+                    children=[self.prompt, self.npools],
+                    layout=ipw.Layout(justify_content="space-between"),
+                ),
+            ]
+        )
+
+    def reset(self):
+        self.npools.value = 1
 
 
 class ProgressBar(ipw.HBox):


### PR DESCRIPTION
Fixes #83 
Fixes #163
Fixes #79

Slight overhaul of the resource specification for the work chain:

* Disable the PDOS codes if the property is not calculated.
* Add a check to make sure that all codes are run on the same computer
if the PDOS is calculated.
* Allow the user to specify both #nodes and #CPUs for remote codes.
For the localhost codes the "nodes" widget is disabled. Defaults and
maxima of the number of CPUs is set based on the number of CPUs and the
default number of MPI processes.
* Allow to specify the parallelization. A default value is set to try
and avoid parallelization issues with too many MPI processes.
* Add `export OMP_NUM_THREADS=1` to `localhost` code setup.

Beside these changes, the builder is now properly updated to use the
specified resources and parallelization settings.