### PR TITLE
Update browser window title to human-readable name.

### DIFF
--- a/qe.ipynb
+++ b/qe.ipynb
@@ -9,7 +9,8 @@
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
     "    return false;\n",
-    "}"
+    "}\n",
+    "document.title='AiiDAlab QE app'"
    ]
   },
   {


### PR DESCRIPTION
Instead of displaying the cryptic .qe-0.ipynb, etc.

Fixes #185.