### PR TITLE
🐛 FIX: use primitive structure for PDOS `nscf` restart

### DIFF
--- a/src/aiidalab_qe_workchain/__init__.py
+++ b/src/aiidalab_qe_workchain/__init__.py
@@ -262,10 +262,9 @@ class QeAppWorkChain(WorkChain):
             )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_BANDS
 
-        scf = workchain.get_outgoing(
-            WorkChainNode, link_label_filter="scf"
-        ).all_nodes()[0]
+        scf = workchain.get_outgoing(WorkChainNode, link_label_filter="scf").one().node
         self.ctx.scf_parent_folder = scf.outputs.remote_folder
+        self.ctx.current_structure = workchain.outputs.primitive_structure
 
     def should_run_pdos(self):
         """Check if the projected density of states should be calculated."""


### PR DESCRIPTION
Fixes #195 

When both the band structure and PDOS are calculated, the
`QeAppWorkChain` will restart the `nscf` for the `PdosWorkchain` from
the `scf` calculation in the `PwBandsWorkChain`. However, the
`PwBandsWorkChain` will also primitivize the structure via Seek-path.
This meant that the input structure for the `nscf` calculation did not
match the one that Quantum ESPRESSO finds in the `data-file-schema.xml`
for the restart, causing the calculation to crash.

Here we set the `current_structure` in the work chain context to the
primitive one obtained from SeeK-path in the `inspect_bands` step of the
outline.