### PR TITLE
FIX: Reporting when only PDOS is calculated

### DIFF
--- a/aiidalab_qe/report.py
+++ b/aiidalab_qe/report.py
@@ -90,6 +90,12 @@ def _generate_report_dict(qeapp_wc):
             scf_kpoints_distance = qeapp_wc.inputs.bands.scf.kpoints_distance.value
         bands_kpoints_distance = qeapp_wc.inputs.bands.bands_kpoints_distance.value
     if run_pdos:
+        scf_kpoints_distance = (
+            scf_kpoints_distance or qeapp_wc.inputs.pdos.scf.kpoints_distance.value
+        )
+        pw_parameters = (
+            pw_parameters or qeapp_wc.inputs.pdos.scf.pw.parameters.get_dict()
+        )
         nscf_kpoints_distance = qeapp_wc.inputs.pdos.nscf.kpoints_distance.value
 
     if pw_parameters:


### PR DESCRIPTION
Fixes #204 

Fix two issues when calculating only the PDOS:

* Show the correct energy cutoffs and k-points distance for the SCF.
* Properly show the "Electronic Structure" output, which currently isn't
shown because the `_update_view` method only checks for the
`band_structure` output.