### PR TITLE
DOC: no need to use edit mode even for developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [src/README.md](src/README.md) for instructions on how to update the `aiidal
 
 ## For maintainers
 
-To create a new release, clone the repository, install development dependencies with `pip install -e '.[dev]'`, and then execute `bumpver update`.
+To create a new release, clone the repository, install development dependencies with `pip install '.[dev]'`, and then execute `bumpver update`.
 This will:
 
   1. Create a tagged release with bumped version and push it to the repository.


### PR DESCRIPTION
For aiidalab app development, the changes in a notebook will show after the page refresh and all imported libraries will reload if there are any latest changes. pip install the package with edit mode has the issue that it is going to write files into `/opt/conda/lib` which raise permission disallowed exception. 