### PR TITLE
Fix: Leftover reset of input_structure in ConfigureStep

### DIFF
--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -436,7 +436,6 @@ class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
 
     def reset(self):
         with self.hold_trait_notifications():
-            self.input_structure = None
             self.set_input_parameters(DEFAULT_PARAMETERS)
 
 


### PR DESCRIPTION
There is no such attribute `input_structure` of class `ConfigureQeAppWorkChainStep`. Although this cause nothing when reset in the configure step (I am surprised this does not raise any exception🧐), anyway should be deleted. 