### PR TITLE
Deps: update widget-bandsplot to 0.2.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     aiidalab-widgets-base~=1.3.0
     filelock~=3.3.0
     importlib-resources~=5.2.2
-    widget-bandsplot~=0.2.5
+    widget-bandsplot~=0.2.8
 python_requires = >=3.7
 
 [options.extras_require]


### PR DESCRIPTION
Thanks for @dou-du 's work, we can now distinguish up and down spins in red and black lines when showing the band structure. 