### PR TITLE
Configure confirm button disabled when clicked

### DIFF
--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -427,7 +427,7 @@ class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             self.set_input_parameters(DEFAULT_PARAMETERS)
 
     def confirm(self, _=None):
-        self.confirm_button.disabled = False
+        self.confirm_button.disabled = True
         self.state = self.State.SUCCESS
 
     @traitlets.default("state")


### PR DESCRIPTION
In configure step, after the `confirm` button is clicked and goes to the next step, the button should be disabled. 
This is a very trivial issue that literally impacts nothing if the user does not go back to modify the workchain setting once confirmed. 

I think here we need to decide whether we allowed users to modify the workchain setting once confirmed. If we allow them to do so, once they change settings the button should be activated again. It is currently update for `relax_type`, `bands_run`, `dos_run`, but not for the widgets that not callback `_update_state`.