### PR TITLE
CI: temporarily disable pre commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
                   python-version: 3.8
 
             - name: Install dependencies
+              # TODO: Remove virtualenv after ci issue described in https://github.com/aiidalab/aiidalab-qe/pull/206#issuecomment-1081661847 fixed
               run: |
+                  python -m pip install virtualenv==20.0.33
                   python -m pip install pre-commit==2.11.1
 
             - name: Run pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
           - id: yamlfmt
 
     - repo: https://github.com/psf/black
-      rev: 22.1.0
+      rev: 22.3.0
       hooks:
           - id: black
             language_version: python3 # Should be a command that runs python3.6+


### PR DESCRIPTION
As described in https://github.com/aiidalab/aiidalab-qe/pull/206#issuecomment-1081661847, the ci test failed since an installation issue. ~~Temporarily disabled it and enable it after it is fixed on pre-commit side.~~ Pining virtualenv version to workaround, which needs to be removed after issue fixed.