### PR TITLE
aiidalab-registry expect list for categories in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/aiidalab/aiidalab-qe
-author = Carl Simon Adorf, Aliaksandr Yakutovich, Marnik Bercx
+author = Carl Simon Adorf, Aliaksandr Yakutovich, Marnik Bercx, Jusong Yu
 author_email = aiidalab@materialscloud.org
 classifiers =
     License :: OSI Approved :: MIT License

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,8 @@ dev =
 [aiidalab]
 title = Quantum ESPRESSO
 description = Perform Quantum ESPRESSO calculations
-categories = quantum
+categories =
+    quantum
 
 [flake8]
 ignore =


### PR DESCRIPTION
Metadata read by aiidalab-registry expect a list for `categories` in `setup.cfg`. This is subtle mistake and hard to find when writing metadata.
We'd better then add an example in the documentation for this field. Or you think it is possible to add a schema check somewhere for it? @csadorf 

EDIT: Add my name to the author list.