### PR TITLE
CalcJobOutputFollower: Fetch retrieved output file if available

### DIFF
--- a/aiidalab_qe/widgets.py
+++ b/aiidalab_qe/widgets.py
@@ -296,7 +296,15 @@ class CalcJobOutputFollower(traitlets.HasTraits):
 
     def _fetch_output(self, calcjob):
         assert isinstance(calcjob, CalcJobNode)
-        if "remote_folder" in calcjob.outputs:
+        if "retrieved" in calcjob.outputs:
+            try:
+                self.filename = calcjob.attributes["output_filename"]
+                with calcjob.outputs.retrieved.open(self.filename) as f:
+                    return f.read().splitlines()
+            except OSError:
+                return list()
+
+        elif "remote_folder" in calcjob.outputs:
             try:
                 fn_out = calcjob.attributes["output_filename"]
                 self.filename = fn_out


### PR DESCRIPTION
When the CalcJob is finished, we can fetch the output file from the `retrieved` folder instead of always going through the `remote_folder`. Besides performance reasons, this works better when the remote folder is cleared.

Note that I have tested this only in the context of my own AiiDAlab app where I am reusing this code, but I see no reason why it shouldn't work here as well (please test).