### PR TITLE
Set relax type none and no properites to run SCF only

### DIFF
--- a/aiidalab_qe/process.py
+++ b/aiidalab_qe/process.py
@@ -82,22 +82,25 @@ class WorkChainSelector(ipw.HBox):
         )
 
         for process in projected[1:]:
-            pk = process[0]
-            formula = load_node(pk).inputs.structure.get_formula()
+            workchain = load_node(process[0])
+            formula = workchain.inputs.structure.get_formula()
 
             properties = []
-            if "pdos" in load_node(pk).inputs:
+            if "pdos" in workchain.inputs:
                 properties.append("pdos")
-            if "bands" in load_node(pk).inputs:
+            if "bands" in workchain.inputs:
                 properties.append("bands")
 
-            if "relax" not in load_node(pk).inputs:
+            if "relax" in workchain.inputs:
+                builder_parameters = workchain.get_extra("builder_parameters", {})
+                relax_type = builder_parameters.get("relax_type")
+
+                if relax_type != "none":
+                    relax_info = "structure is not relaxed"
+                else:
+                    relax_info = "static SCF calculation on structure"
+            else:
                 relax_info = "structure is not relaxed"
-            if "relax" in load_node(pk).inputs and properties:
-                relax_info = "structure is relaxed"
-            if "relax" in load_node(pk).inputs and not properties:
-                relax_info = "structure is not relaxed"
-                properties = ["SCF only"]
 
             if not properties:
                 properties_info = ""

--- a/aiidalab_qe/process.py
+++ b/aiidalab_qe/process.py
@@ -96,7 +96,7 @@ class WorkChainSelector(ipw.HBox):
                 relax_type = builder_parameters.get("relax_type")
 
                 if relax_type != "none":
-                    relax_info = "structure is not relaxed"
+                    relax_info = "structure is relaxed"
                 else:
                     relax_info = "static SCF calculation on structure"
             else:

--- a/aiidalab_qe/process.py
+++ b/aiidalab_qe/process.py
@@ -90,7 +90,7 @@ class WorkChainSelector(ipw.HBox):
                 properties.append("pdos")
             if "bands" in load_node(pk).inputs:
                 properties.append("bands")
-                
+
             if "relax" not in load_node(pk).inputs:
                 relax_info = "structure is not relaxed"
             if "relax" in load_node(pk).inputs and properties:
@@ -103,7 +103,7 @@ class WorkChainSelector(ipw.HBox):
                 properties_info = ""
             else:
                 properties_info = f"properties on {', '.join(properties)}"
-                
+
             yield cls.WorkChainData(
                 formula=formula,
                 relax_info=relax_info,

--- a/aiidalab_qe/process.py
+++ b/aiidalab_qe/process.py
@@ -84,21 +84,26 @@ class WorkChainSelector(ipw.HBox):
         for process in projected[1:]:
             pk = process[0]
             formula = load_node(pk).inputs.structure.get_formula()
-            if "relax" in load_node(pk).inputs:
-                relax_info = "structure is relaxed"
-            else:
-                relax_info = "structure is not relaxed"
 
             properties = []
             if "pdos" in load_node(pk).inputs:
                 properties.append("pdos")
             if "bands" in load_node(pk).inputs:
                 properties.append("bands")
+                
+            if "relax" not in load_node(pk).inputs:
+                relax_info = "structure is not relaxed"
+            if "relax" in load_node(pk).inputs and properties:
+                relax_info = "structure is relaxed"
+            if "relax" in load_node(pk).inputs and not properties:
+                relax_info = "structure is not relaxed"
+                properties = ["SCF only"]
 
             if not properties:
                 properties_info = ""
             else:
                 properties_info = f"properties on {', '.join(properties)}"
+                
             yield cls.WorkChainData(
                 formula=formula,
                 relax_info=relax_info,

--- a/aiidalab_qe/report.py
+++ b/aiidalab_qe/report.py
@@ -1,3 +1,4 @@
+from aiida.common.exceptions import NotExistentAttributeError
 from aiida.plugins import WorkflowFactory
 
 PwBaseWorkChain = WorkflowFactory("quantumespresso.pw.base")
@@ -98,27 +99,27 @@ def _generate_report_dict(qeapp_wc):
         # read default from protocol
         smearing = default_params["smearing"]
 
-    if run_relax:
+    try:
         pw_parameters = qeapp_wc.inputs.relax.base.pw.parameters.get_dict()
         if scf_kpoints_distance is None:
             scf_kpoints_distance = qeapp_wc.inputs.relax.base.kpoints_distance.value
-    if run_bands:
-        pw_parameters = qeapp_wc.inputs.bands.scf.pw.parameters.get_dict()
-        if scf_kpoints_distance is None:
-            scf_kpoints_distance = qeapp_wc.inputs.bands.scf.kpoints_distance.value
-        bands_kpoints_distance = qeapp_wc.inputs.bands.bands_kpoints_distance.value
-    if run_pdos:
-        scf_kpoints_distance = (
-            scf_kpoints_distance or qeapp_wc.inputs.pdos.scf.kpoints_distance.value
-        )
-        pw_parameters = (
-            pw_parameters or qeapp_wc.inputs.pdos.scf.pw.parameters.get_dict()
-        )
-        nscf_kpoints_distance = qeapp_wc.inputs.pdos.nscf.kpoints_distance.value
+    except NotExistentAttributeError:
+        if run_bands:
+            pw_parameters = qeapp_wc.inputs.bands.scf.pw.parameters.get_dict()
+            if scf_kpoints_distance is None:
+                scf_kpoints_distance = qeapp_wc.inputs.bands.scf.kpoints_distance.value
+            bands_kpoints_distance = qeapp_wc.inputs.bands.bands_kpoints_distance.value
+        if run_pdos:
+            scf_kpoints_distance = (
+                scf_kpoints_distance or qeapp_wc.inputs.pdos.scf.kpoints_distance.value
+            )
+            pw_parameters = (
+                pw_parameters or qeapp_wc.inputs.pdos.scf.pw.parameters.get_dict()
+            )
+            nscf_kpoints_distance = qeapp_wc.inputs.pdos.nscf.kpoints_distance.value
 
-    if pw_parameters:
-        energy_cutoff_wfc = round(pw_parameters["SYSTEM"]["ecutwfc"])
-        energy_cutoff_rho = round(pw_parameters["SYSTEM"]["ecutrho"])
+    energy_cutoff_wfc = round(pw_parameters["SYSTEM"]["ecutwfc"])
+    energy_cutoff_rho = round(pw_parameters["SYSTEM"]["ecutrho"])
 
     yield "energy_cutoff_wfc", energy_cutoff_wfc
     yield "energy_cutoff_rho", energy_cutoff_rho

--- a/aiidalab_qe/report.py
+++ b/aiidalab_qe/report.py
@@ -1,4 +1,3 @@
-from aiida.common.exceptions import NotExistentAttributeError
 from aiida.plugins import WorkflowFactory
 
 PwBaseWorkChain = WorkflowFactory("quantumespresso.pw.base")
@@ -99,24 +98,23 @@ def _generate_report_dict(qeapp_wc):
         # read default from protocol
         smearing = default_params["smearing"]
 
-    try:
-        pw_parameters = qeapp_wc.inputs.relax.base.pw.parameters.get_dict()
+    pw_parameters = qeapp_wc.inputs.relax.base.pw.parameters.get_dict()
+    if scf_kpoints_distance is None:
+        scf_kpoints_distance = qeapp_wc.inputs.relax.base.kpoints_distance.value
+
+    if run_bands:
+        pw_parameters = qeapp_wc.inputs.bands.scf.pw.parameters.get_dict()
         if scf_kpoints_distance is None:
-            scf_kpoints_distance = qeapp_wc.inputs.relax.base.kpoints_distance.value
-    except NotExistentAttributeError:
-        if run_bands:
-            pw_parameters = qeapp_wc.inputs.bands.scf.pw.parameters.get_dict()
-            if scf_kpoints_distance is None:
-                scf_kpoints_distance = qeapp_wc.inputs.bands.scf.kpoints_distance.value
-            bands_kpoints_distance = qeapp_wc.inputs.bands.bands_kpoints_distance.value
-        if run_pdos:
-            scf_kpoints_distance = (
-                scf_kpoints_distance or qeapp_wc.inputs.pdos.scf.kpoints_distance.value
-            )
-            pw_parameters = (
-                pw_parameters or qeapp_wc.inputs.pdos.scf.pw.parameters.get_dict()
-            )
-            nscf_kpoints_distance = qeapp_wc.inputs.pdos.nscf.kpoints_distance.value
+            scf_kpoints_distance = qeapp_wc.inputs.bands.scf.kpoints_distance.value
+        bands_kpoints_distance = qeapp_wc.inputs.bands.bands_kpoints_distance.value
+    if run_pdos:
+        scf_kpoints_distance = (
+            scf_kpoints_distance or qeapp_wc.inputs.pdos.scf.kpoints_distance.value
+        )
+        pw_parameters = (
+            pw_parameters or qeapp_wc.inputs.pdos.scf.pw.parameters.get_dict()
+        )
+        nscf_kpoints_distance = qeapp_wc.inputs.pdos.nscf.kpoints_distance.value
 
     energy_cutoff_wfc = round(pw_parameters["SYSTEM"]["ecutwfc"])
     energy_cutoff_rho = round(pw_parameters["SYSTEM"]["ecutrho"])

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -6,7 +6,6 @@ Authors:
     * Carl Simon Adorf <simon.adorf@epfl.ch>
 """
 import os
-from pickle import NONE
 
 import ipywidgets as ipw
 import traitlets

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -864,9 +864,11 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             builder.degauss_override = Float(parameters["degauss_override"])
         if "smearing_override" in parameters:
             builder.smearing_override = Str(parameters["smearing_override"])
-            
+
         # skip relax sub-worflow only when RelaxType is NONE and has property calculated.
-        if RelaxType(parameters["relax_type"]) is RelaxType.NONE and (parameters["run_bands"] or parameters["run_pdos"]):
+        if RelaxType(parameters["relax_type"]) is RelaxType.NONE and (
+            parameters["run_bands"] or parameters["run_pdos"]
+        ):
             builder.pop("relax")
 
         if not parameters.get("run_bands", False):

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -865,7 +865,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         if "smearing_override" in parameters:
             builder.smearing_override = Str(parameters["smearing_override"])
 
-        # skip relax sub-worflow only when RelaxType is NONE and has property calculated.
+        # skip relax sub-workflow only when RelaxType is NONE and has property calculated.
         if RelaxType(parameters["relax_type"]) is RelaxType.NONE and (
             parameters["run_bands"] or parameters["run_pdos"]
         ):

--- a/src/aiidalab_qe_workchain/__init__.py
+++ b/src/aiidalab_qe_workchain/__init__.py
@@ -108,25 +108,22 @@ class QeAppWorkChain(WorkChain):
         builder = cls.get_builder()
         builder.structure = structure
 
-        if relax_type is not RelaxType.NONE:
-            relax_overrides = overrides.get("relax", {})
-            if pseudo_family is not None:
-                relax_overrides.setdefault("base", {})["pseudo_family"] = pseudo_family
+        relax_overrides = overrides.get("relax", {})
+        if pseudo_family is not None:
+            relax_overrides.setdefault("base", {})["pseudo_family"] = pseudo_family
 
-            relax = PwRelaxWorkChain.get_builder_from_protocol(
-                code=pw_code,
-                structure=structure,
-                protocol=protocol,
-                overrides=relax_overrides,
-                relax_type=relax_type,
-                **kwargs,
-            )
-            relax.pop("structure", None)
-            relax.pop("clean_workdir", None)
-            relax.pop("base_final_scf", None)
-            builder.relax = relax
-        else:
-            builder.pop("relax", None)
+        relax = PwRelaxWorkChain.get_builder_from_protocol(
+            code=pw_code,
+            structure=structure,
+            protocol=protocol,
+            overrides=relax_overrides,
+            relax_type=relax_type,
+            **kwargs,
+        )
+        relax.pop("structure", None)
+        relax.pop("clean_workdir", None)
+        relax.pop("base_final_scf", None)
+        builder.relax = relax
 
         bands_overrides = overrides.get("bands", {})
         if pseudo_family is not None:
@@ -236,11 +233,12 @@ class QeAppWorkChain(WorkChain):
             )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_RELAX
 
-        self.ctx.current_structure = workchain.outputs.output_structure
-        self.ctx.current_number_of_bands = (
-            workchain.outputs.output_parameters.get_attribute("number_of_bands")
-        )
-        self.out("structure", self.ctx.current_structure)
+        if "output_structure" in workchain.outputs:
+            self.ctx.current_structure = workchain.outputs.output_structure
+            self.ctx.current_number_of_bands = (
+                workchain.outputs.output_parameters.get_attribute("number_of_bands")
+            )
+            self.out("structure", self.ctx.current_structure)
 
     def should_run_bands(self):
         """Check if the band structure should be calculated."""


### PR DESCRIPTION
fixes #264 

Using `RelaxType.NONE` for relax workchain to run the SCF only. 
The builder is constructed with all three workchain input parameters port, `relax`, `bands`, `pdos`.
Whether to run  sub-workchain is controlled by popping the input key out from the builder, right after the builder is created. 
Also, the relax/properties infos of workchain selector is changed to show this newly add calculation type as 'SCF only'.