### PR TITLE
Not pop run_bands/pdos from builder parameters

### DIFF
--- a/aiidalab_qe/report.py
+++ b/aiidalab_qe/report.py
@@ -29,9 +29,9 @@ def _generate_report_dict(qeapp_wc):
     builder_parameters = qeapp_wc.get_extra("builder_parameters", {})
 
     # Properties
-    run_relax = builder_parameters["relax_type"] != "none"
-    run_bands = builder_parameters.get("run_bands", False)
-    run_pdos = builder_parameters.get("run_pdos", False)
+    run_relax = builder_parameters.get("relax_type") != "none"
+    run_bands = builder_parameters.get("run_bands")
+    run_pdos = builder_parameters.get("run_pdos")
 
     yield "relaxed", run_relax
     yield "relax_method", builder_parameters["relax_type"].title()

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -857,10 +857,10 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         if "smearing_override" in parameters:
             builder.smearing_override = Str(parameters["smearing_override"])
 
-        if not parameters.pop("run_bands"):
+        if not parameters.get("run_bands", False):
             builder.pop("bands")
 
-        if not parameters.pop("run_pdos"):
+        if not parameters.get("run_pdos", False):
             builder.pop("pdos")
 
         resources = {


### PR DESCRIPTION
fixes #275 

The `run_bands` and `run_dos` are poped out from builder_parameters which is not needed and will then not be set as extra attributes of workchain.
It cause the issue that the report of the calculation is not correctly prepared.