### PR TITLE
bump aiidalab-widgets-base version to 1.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     aiida-core~=1.0
     aiida-quantumespresso~=3.5
     aiidalab-qe-workchain@https://github.com/aiidalab/aiidalab-qe/releases/download/v22.08.0/aiidalab_qe_workchain-1.0-py3-none-any.whl
-    aiidalab-widgets-base~=1.3.3
+    aiidalab-widgets-base~=1.4.0
     filelock~=3.3.0
     importlib-resources~=5.2.2
     widget-bandsplot~=0.2.8


### PR DESCRIPTION
New aiidalab-widgets-base include lots new features shown in https://github.com/aiidalab/aiidalab-widgets-base/releases/tag/v1.4.0