### PR TITLE
Change the aiida-core version to 2.0 for qe workchain lib

### DIFF
--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -18,8 +18,8 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    aiida-core~=1.0
-    aiida-quantumespresso~=3.2
+    aiida-core~=2.0
+    aiida-quantumespresso~=4.0
 python_requires = >=3.7
 
 [flake8]


### PR DESCRIPTION
I have to push this change to the qe-workchain and make a tagged release for future use. 
It seems a bit weird but if we don't want to break the current release strategy for aiidalab-qe-workchain, this is a have to change from my perspective. 
The plan is 
1. first get this merged to the `master` and make a tagged release `22.11.2a0`, 
2. then I'll revert the change for `master` branch to make the impact limited.
3. The test is based on `pytest-docker` which implemented in https://github.com/aiidalab/aiidalab-qe/pull/271 can then continued by tagging the `aiidalab-qe-workchain` to `22.11.2a0`.