### PR TITLE
Remove # symbol in requirements which break the deps check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     aiidalab-widgets-base==2.0.0a1
     filelock~=3.8
     importlib-resources~=5.2.2
-    numpy~=1.23 # pined for pymatgen
+    numpy~=1.23
     widget-bandsplot~=0.2.8
 python_requires = >=3.8
 


### PR DESCRIPTION
The issue https://github.com/aiidalab/aiidalab/issues/326 is caused from the `#` symbol is requirements list of `setup.cfg`.