### PR TITLE
Final screenshot fixture

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
                 - flake8-bugbear==22.7.1
 
     - repo: https://github.com/pycqa/isort
-      rev: 5.11.4
+      rev: 5.12.0
       hooks:
           - id: isort
             args: [--profile, black, --filter-files]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,14 @@ def selenium_driver(selenium, notebook_service):
         url, token = notebook_service
         url_with_token = urljoin(url, f"apps/apps/aiidalab-qe/{nb_path}?token={token}")
         selenium.get(f"{url_with_token}")
-        selenium.implicitly_wait(wait_time)  # must wait until the app loaded
+        # By default, let's allow selenium functions to retry for 10s
+        # till a given element is loaded, see:
+        # https://selenium-python.readthedocs.io/waits.html#implicit-waits
+        selenium.implicitly_wait(wait_time)
+        window_width = 800
+        window_height = 600
+        selenium.set_window_size(window_width, window_height)
+
 
         selenium.find_element(By.ID, "ipython-main-app")
         selenium.find_element(By.ID, "notebook-container")
@@ -83,6 +90,16 @@ def selenium_driver(selenium, notebook_service):
 
     return _selenium_driver
 
+@pytest.fixture
+def final_screenshot(request, screenshot_dir, selenium):
+    """Take screenshot at the end of the test.
+    Screenshot name is generated from the test function name
+    by stripping the 'test_' prefix
+    """
+    screenshot_name = f"{request.function.__name__[5:]}.png"
+    screenshot_path = Path.joinpath(screenshot_dir, screenshot_name)
+    yield
+    selenium.get_screenshot_as_file(screenshot_path)
 
 @pytest.fixture(scope="session")
 def screenshot_dir():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,13 +82,13 @@ def selenium_driver(selenium, notebook_service):
         window_height = 600
         selenium.set_window_size(window_width, window_height)
 
-
         selenium.find_element(By.ID, "ipython-main-app")
         selenium.find_element(By.ID, "notebook-container")
 
         return selenium
 
     return _selenium_driver
+
 
 @pytest.fixture
 def final_screenshot(request, screenshot_dir, selenium):
@@ -100,6 +100,7 @@ def final_screenshot(request, screenshot_dir, selenium):
     screenshot_path = Path.joinpath(screenshot_dir, screenshot_name)
     yield
     selenium.get_screenshot_as_file(screenshot_path)
+
 
 @pytest.fixture(scope="session")
 def screenshot_dir():

--- a/tests/test_qe_app.py
+++ b/tests/test_qe_app.py
@@ -26,16 +26,13 @@ def test_qe_app_select_silicon_and_confirm(
 ):
     driver = selenium_driver("qe.ipynb", wait_time=30.0)
     driver.set_window_size(1920, 1485)
-    time.sleep(15)
-
-    driver.find_element(
-        By.XPATH, "//*[text()='From Examples']"
-    ).click()  # click `From Examples` tab for input structure
 
     element = WebDriverWait(driver, 60).until(
-        EC.element_to_be_clickable((By.XPATH, "//option[@value='Diamond']"))
+        EC.presence_of_element_located((By.XPATH, "//*[text()='From Examples']"))
     )
     element.click()
+
+    driver.find_element(By.XPATH, "//option[@value='Diamond']").click()
 
     driver.get_screenshot_as_file(
         str(Path.joinpath(screenshot_dir, "qe-app-select-diamond-selected.png"))

--- a/tests/test_qe_app.py
+++ b/tests/test_qe_app.py
@@ -27,12 +27,13 @@ def test_qe_app_select_silicon_and_confirm(
     driver = selenium_driver("qe.ipynb", wait_time=30.0)
     driver.set_window_size(1920, 1485)
 
-    element = WebDriverWait(driver, 60).until(
+    element = WebDriverWait(driver, 10).until(
         EC.presence_of_element_located((By.XPATH, "//*[text()='From Examples']"))
     )
     element.click()
 
     driver.find_element(By.XPATH, "//option[@value='Diamond']").click()
+    time.sleep(10)
 
     driver.get_screenshot_as_file(
         str(Path.joinpath(screenshot_dir, "qe-app-select-diamond-selected.png"))

--- a/tests/test_qe_app.py
+++ b/tests/test_qe_app.py
@@ -2,7 +2,9 @@ import time
 from pathlib import Path
 
 import requests
+import selenium.webdriver.support.expected_conditions as EC
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
 
 
 def test_notebook_service_available(notebook_service):
@@ -18,21 +20,31 @@ def test_qe_app_take_screenshot(selenium_driver, final_screenshot):
 
 
 def test_qe_app_select_silicon_and_confirm(
-    selenium_driver, screenshot_dir, final_screenshot
+    selenium_driver,
+    screenshot_dir,
+    final_screenshot,
 ):
     driver = selenium_driver("qe.ipynb", wait_time=30.0)
     driver.set_window_size(1920, 1485)
+    time.sleep(15)
+
     driver.find_element(
         By.XPATH, "//*[text()='From Examples']"
     ).click()  # click `From Examples` tab for input structure
-    time.sleep(10)
-    driver.find_element(By.XPATH, "//option[@value='Diamond']").click()
-    time.sleep(10)
+
+    element = WebDriverWait(driver, 60).until(
+        EC.element_to_be_clickable((By.XPATH, "//option[@value='Diamond']"))
+    )
+    element.click()
+
     driver.get_screenshot_as_file(
         str(Path.joinpath(screenshot_dir, "qe-app-select-diamond-selected.png"))
     )
-    confirm_button = driver.find_element(By.XPATH, "//button[text()='Confirm']")
-    confirm_button.location_once_scrolled_into_view  # scroll into view
-    confirm_button.click()
+
+    element = WebDriverWait(driver, 60).until(
+        EC.element_to_be_clickable((By.XPATH, "//button[text()='Confirm']"))
+    )
+    element.click()
+
     # Test that we have indeed proceeded to the next step
     driver.find_element(By.XPATH, "//span[contains(.,'✓ Step 1')]")

--- a/tests/test_qe_app.py
+++ b/tests/test_qe_app.py
@@ -16,12 +16,16 @@ def test_qe_app_take_screenshot(selenium_driver, final_screenshot):
     driver.set_window_size(1920, 1485)
     time.sleep(15)
 
-def test_qe_app_select_silicon_and_confirm(selenium_driver, screenshot_dir, final_screenshot):
+
+def test_qe_app_select_silicon_and_confirm(
+    selenium_driver, screenshot_dir, final_screenshot
+):
     driver = selenium_driver("qe.ipynb", wait_time=30.0)
     driver.set_window_size(1920, 1485)
     driver.find_element(
         By.XPATH, "//*[text()='From Examples']"
     ).click()  # click `From Examples` tab for input structure
+    time.sleep(10)
     driver.find_element(By.XPATH, "//option[@value='Diamond']").click()
     time.sleep(10)
     driver.get_screenshot_as_file(

--- a/tests/test_qe_app.py
+++ b/tests/test_qe_app.py
@@ -11,14 +11,12 @@ def test_notebook_service_available(notebook_service):
     assert response.status_code == 200
 
 
-def test_qe_app_take_screenshot(selenium_driver, screenshot_dir):
+def test_qe_app_take_screenshot(selenium_driver, final_screenshot):
     driver = selenium_driver("qe.ipynb", wait_time=30.0)
     driver.set_window_size(1920, 1485)
     time.sleep(15)
-    driver.get_screenshot_as_file(str(Path.joinpath(screenshot_dir, "qe-app.png")))
 
-
-def test_qe_app_select_silicon(selenium_driver, screenshot_dir):
+def test_qe_app_select_silicon_and_confirm(selenium_driver, screenshot_dir, final_screenshot):
     driver = selenium_driver("qe.ipynb", wait_time=30.0)
     driver.set_window_size(1920, 1485)
     driver.find_element(
@@ -34,6 +32,3 @@ def test_qe_app_select_silicon(selenium_driver, screenshot_dir):
     confirm_button.click()
     # Test that we have indeed proceeded to the next step
     driver.find_element(By.XPATH, "//span[contains(.,'✓ Step 1')]")
-    driver.get_screenshot_as_file(
-        str(Path.joinpath(screenshot_dir, "qe-app-select-diamond-confirmed.png"))
-    )


### PR DESCRIPTION
fixes #343 

Using the fixture `final_screenshot` to take the screenshot for smoke tests at the end of tests. 
In this PR, I also try to use the `WebDriverWait` to load the element without explicitly waiting. 