### PR TITLE
Fix issue workchain viewer not designated for workchains except QeAppWorkchain

### DIFF
--- a/aiidalab_qe/node_view.py
+++ b/aiidalab_qe/node_view.py
@@ -19,7 +19,7 @@ import traitlets
 from aiida.cmdline.utils.common import get_workchain_report
 from aiida.common import LinkType
 from aiida.orm import CalcJobNode, Node, ProjectionData, WorkChainNode
-from aiidalab_widgets_base import ProcessMonitor, register_viewer_widget
+from aiidalab_widgets_base import register_viewer_widget
 from aiidalab_widgets_base.viewers import StructureDataViewer
 from ase import Atoms
 from filelock import FileLock, Timeout
@@ -500,12 +500,16 @@ class WorkChainOutputs(ipw.VBox):
                 handle.write(retrieved.get_object_content(filename))
 
 
-@register_viewer_widget("process.workflow.workchain.WorkChainNode.", "QeAppWorkChain")
+@register_viewer_widget("process.workflow.workchain.WorkChainNode.")
 class WorkChainViewer(ipw.VBox):
 
     _results_shown = traitlets.Set()
 
     def __init__(self, node, **kwargs):
+        if node.process_label != "QeAppWorkChain":
+            super().__init__()
+            return
+
         self.node = node
 
         self.title = ipw.HTML(
@@ -560,12 +564,6 @@ class WorkChainViewer(ipw.VBox):
         super().__init__(
             children=[self.title, self.result_tabs],
             **kwargs,
-        )
-        self._process_monitor = ProcessMonitor(
-            process=self.node,
-            callbacks=[
-                self._update_view,
-            ],
         )
 
     def _update_view(self):

--- a/aiidalab_qe/node_view.py
+++ b/aiidalab_qe/node_view.py
@@ -500,15 +500,12 @@ class WorkChainOutputs(ipw.VBox):
                 handle.write(retrieved.get_object_content(filename))
 
 
-@register_viewer_widget("process.workflow.workchain.WorkChainNode.")
+@register_viewer_widget("process.workflow.workchain.WorkChainNode.", "QeAppWorkChain")
 class WorkChainViewer(ipw.VBox):
 
     _results_shown = traitlets.Set()
 
     def __init__(self, node, **kwargs):
-        if node.process_label != "QeAppWorkChain":
-            raise KeyError(str(node.node_type))
-
         self.node = node
 
         self.title = ipw.HTML(

--- a/aiidalab_qe/node_view.py
+++ b/aiidalab_qe/node_view.py
@@ -19,7 +19,7 @@ import traitlets
 from aiida.cmdline.utils.common import get_workchain_report
 from aiida.common import LinkType
 from aiida.orm import CalcJobNode, Node, ProjectionData, WorkChainNode
-from aiidalab_widgets_base import register_viewer_widget
+from aiidalab_widgets_base import ProcessMonitor, register_viewer_widget
 from aiidalab_widgets_base.viewers import StructureDataViewer
 from ase import Atoms
 from filelock import FileLock, Timeout
@@ -564,6 +564,12 @@ class WorkChainViewer(ipw.VBox):
         super().__init__(
             children=[self.title, self.result_tabs],
             **kwargs,
+        )
+        self._process_monitor = ProcessMonitor(
+            process=self.node,
+            callbacks=[
+                self._update_view,
+            ],
         )
 
     def _update_view(self):

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -16,11 +16,11 @@ from aiida.plugins import DataFactory
 from aiida_quantumespresso.common.types import ElectronicType, RelaxType, SpinType
 from aiida_quantumespresso.workflows.pw.base import PwBaseWorkChain
 from aiidalab_widgets_base import (
+    AiidaNodeViewWidget,
     ComputationalResourcesWidget,
     ProcessMonitor,
     ProcessNodesTreeWidget,
     WizardAppWidgetStep,
-    AiidaNodeViewWidget,
 )
 from IPython.display import display
 
@@ -28,10 +28,7 @@ from aiidalab_qe.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.pseudos import PseudoFamilySelector
 from aiidalab_qe.setup_codes import QESetupWidget
 from aiidalab_qe.sssp import SSSPInstallWidget
-from aiidalab_qe.widgets import (
-    ParallelizationSettings,
-    ResourceSelectionWidget,
-)
+from aiidalab_qe.widgets import ParallelizationSettings, ResourceSelectionWidget
 from aiidalab_qe_workchain import QeAppWorkChain
 
 StructureData = DataFactory("core.structure")

--- a/aiidalab_qe/steps.py
+++ b/aiidalab_qe/steps.py
@@ -20,6 +20,7 @@ from aiidalab_widgets_base import (
     ProcessMonitor,
     ProcessNodesTreeWidget,
     WizardAppWidgetStep,
+    AiidaNodeViewWidget,
 )
 from IPython.display import display
 
@@ -28,7 +29,6 @@ from aiidalab_qe.pseudos import PseudoFamilySelector
 from aiidalab_qe.setup_codes import QESetupWidget
 from aiidalab_qe.sssp import SSSPInstallWidget
 from aiidalab_qe.widgets import (
-    NodeViewWidget,
     ParallelizationSettings,
     ResourceSelectionWidget,
 )
@@ -914,7 +914,7 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
             (self.process_tree, "value"),
         )
 
-        self.node_view = NodeViewWidget(layout={"width": "auto", "height": "auto"})
+        self.node_view = AiidaNodeViewWidget(layout={"width": "auto", "height": "auto"})
         ipw.dlink(
             (self.process_tree, "selected_nodes"),
             (self.node_view, "node"),

--- a/aiidalab_qe/widgets.py
+++ b/aiidalab_qe/widgets.py
@@ -24,7 +24,6 @@ from aiidalab_qe import node_view  # noqa: F401
 __all__ = [
     "CalcJobOutputFollower",
     "LogOutputWidget",
-    "NodeViewWidget",
 ]
 
 
@@ -365,24 +364,7 @@ class CalcJobNodeViewerWidget(ipw.VBox):
         with self.hold_trait_notifications():
             self.log_output.filename = self.output_follower.filename
             self.log_output.value = "\n".join(self.output_follower.output)
-
-
-class NodeViewWidget(ipw.VBox):
-
-    node = traitlets.Instance(Node, allow_none=True)
-
-    def __init__(self, **kwargs):
-        self._output = ipw.Output()
-        super().__init__(children=[self._output], **kwargs)
-
-    @traitlets.observe("node")
-    def _observe_node(self, change):
-        if change["new"] != change["old"]:
-            with self._output:
-                clear_output()
-                if change["new"]:
-                    display(viewer(change["new"]))
-
+            
 
 class ResourceSelectionWidget(ipw.VBox):
     """Widget for the selection of compute resources."""

--- a/aiidalab_qe/widgets.py
+++ b/aiidalab_qe/widgets.py
@@ -14,9 +14,9 @@ from time import time
 
 import ipywidgets as ipw
 import traitlets
-from aiida.orm import CalcJobNode, Node, load_node
-from aiidalab_widgets_base import register_viewer_widget, viewer
-from IPython.display import HTML, Javascript, clear_output, display
+from aiida.orm import CalcJobNode, load_node
+from aiidalab_widgets_base import register_viewer_widget
+from IPython.display import HTML, Javascript, display
 
 # trigger registration of the viewer widget:
 from aiidalab_qe import node_view  # noqa: F401
@@ -364,7 +364,7 @@ class CalcJobNodeViewerWidget(ipw.VBox):
         with self.hold_trait_notifications():
             self.log_output.filename = self.output_follower.filename
             self.log_output.value = "\n".join(self.output_follower.output)
-            
+
 
 class ResourceSelectionWidget(ipw.VBox):
     """Widget for the selection of compute resources."""

--- a/qe.ipynb
+++ b/qe.ipynb
@@ -2,9 +2,25 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+       "    return false;\n",
+       "}\n",
+       "document.title='AiiDAlab QE app'\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
@@ -15,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +47,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9abd0d5d339a42c596c39680ba5735c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import ipywidgets as ipw\n",
     "from jinja2 import Environment\n",
@@ -155,7 +184,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -169,7 +198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {

--- a/qe.ipynb
+++ b/qe.ipynb
@@ -2,25 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n",
-       "document.title='AiiDAlab QE app'\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
@@ -31,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,20 +31,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9abd0d5d339a42c596c39680ba5735c4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import ipywidgets as ipw\n",
     "from jinja2 import Environment\n",


### PR DESCRIPTION
~~Combined with https://github.com/aiidalab/aiidalab-widgets-base/pull/430 should fix #344~~

fixes #344 

The `register_viewer_widget` decorator registers the viewer by class and the new viewer for QeAppWorkchain specifically also become the viewer of other WorkChain. It will raise the `KeyError` and raised which is not expected. 
Instead of raising the exception, nothing is returned. This is a workaround since ideally if there is no new specific viewer defined for a specific work chain, it needs to fall back to the native one of AWB. As tried in https://github.com/aiidalab/aiidalab-widgets-base/pull/430