### PR TITLE
bump version of aiidalab-widgets-base and widget-bandsplot

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,13 +23,14 @@ project_urls =
 packages = find:
 install_requires =
     Jinja2~=3.0
-    aiida-core>=2.1,<3
-    aiida-quantumespresso~=4.1
+    aiida-core~=2.2,<3
+    aiida-quantumespresso~=4.2
     aiidalab-qe-workchain@https://github.com/aiidalab/aiidalab-qe/releases/download/v23.02.0/aiidalab_qe_workchain-23.2.0-py3-none-any.whl
-    aiidalab-widgets-base==2.0.0b1
+    aiidalab-widgets-base==2.0.0b5
     filelock~=3.8
     importlib-resources~=5.2.2
-    widget-bandsplot~=0.5.0
+    widget-bandsplot~=0.5.1
+    pymatgen==2022.9.21
 python_requires = >=3.8
 
 [options.extras_require]

--- a/src/setup.cfg
+++ b/src/setup.cfg
@@ -18,8 +18,8 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    aiida-core>=2.1,<3
-    aiida-quantumespresso~=4.1
+    aiida-core~=2.2,<3
+    aiida-quantumespresso~=4.2
 python_requires = >=3.8
 
 [flake8]


### PR DESCRIPTION
- `aiida-core~=2.2` to align with aiida-core version in new docker stack
- `aiidalab-widget-base==2.0.0b5` for pinning the `widgetnbextension` version https://github.com/aiidalab/aiidalab-widgets-base/pull/467
- `widget-bandsplot~=0.5.1` for fixing TDOS background filling issue.