### PR TITLE
bump AWB to released 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,11 @@ project_urls =
 packages = find:
 install_requires =
     aiida-core~=2.2,<3
+    Jinja2~=3.0
     aiida-quantumespresso~=4.2
     aiidalab-widgets-base~=2.0
     filelock~=3.8
+    importlib-resources~=5.2
     widget-bandsplot~=0.5.1
     pybtex==0.24.0
     pymatgen==2022.9.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,13 +22,12 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    Jinja2~=3.0
     aiida-core~=2.2,<3
     aiida-quantumespresso~=4.2
-    aiidalab-widgets-base==2.0
+    aiidalab-widgets-base~=2.0
     filelock~=3.8
-    importlib-resources~=5.2.2
     widget-bandsplot~=0.5.1
+    pybtex==0.24.0
     pymatgen==2022.9.21
 python_requires = >=3.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     Jinja2~=3.0
     aiida-core~=2.2,<3
     aiida-quantumespresso~=4.2
-    aiidalab-widgets-base==2.0.0b6
+    aiidalab-widgets-base==2.0
     filelock~=3.8
     importlib-resources~=5.2.2
     widget-bandsplot~=0.5.1


### PR DESCRIPTION
Jinja2 and importlib are from aiida-quantumespresso, therefore the version is loosely pinned. The pybtex has to be added to work around the installation issue.