### PR TITLE
bump AWB to released 2.0 (#394)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,14 +22,15 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    Jinja2~=3.0
     aiida-core~=2.2,<3
+    Jinja2~=3.0
     aiida-quantumespresso~=4.2
     aiidalab-qe-workchain@https://github.com/aiidalab/aiidalab-qe/releases/download/v23.04.1/aiidalab_qe_workchain-23.4.1-py3-none-any.whl
-    aiidalab-widgets-base==2.0.0b6
+    aiidalab-widgets-base~=2.0
     filelock~=3.8
-    importlib-resources~=5.2.2
+    importlib-resources~=5.2
     widget-bandsplot~=0.5.1
+    pybtex==0.24.0
     pymatgen==2022.9.21
 python_requires = >=3.8
 


### PR DESCRIPTION
`aiidalab-widgets-base` 2.0 is released, the version is bump here. Jinja2 and importlib are from aiida-quantumespresso, therefore the version is loosely pinned. The pybtex has to be added to work around the installation issue.