### PR TITLE
Using new bumpver to support backport version release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_requires = >=3.8
 
 [options.extras_require]
 dev =
-    bumpver==2022.1119
+    bumpver~=2023.1121
     pre-commit~=2.20
     pytest~=6.2
     pytest-regressions~=2.2


### PR DESCRIPTION
This fix https://github.com/mbarkhau/bumpver/pull/207 is what I did and needed to release old support (e.g. v23.04.3) after there are new released (v23.10.0a0).