### PR TITLE
Restrict pydantic to fix testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     widget-bandsplot~=0.5.1
     pybtex==0.24.0
     pymatgen==2022.9.21
+    pydantic~=1.10,>=1.10.8
 python_requires = >=3.8
 
 [options.extras_require]


### PR DESCRIPTION
The dependency is pinned by `aiida-quantumespresso==4.4.0`, which not release yet. Revert after the aiida-quantumespresso bump.