### PR TITLE
Backward compatibility for report widget

### DIFF
--- a/aiidalab_qe/app/node_view.py
+++ b/aiidalab_qe/app/node_view.py
@@ -28,7 +28,6 @@ from traitlets import Instance, Int, List, Unicode, Union, default, observe, val
 from widget_bandsplot import BandsPlotWidget
 
 from aiidalab_qe.app import static
-from aiidalab_qe.app.report import generate_report_html
 
 
 class MinimalStructureViewer(ipw.VBox):
@@ -286,6 +285,15 @@ class VBoxWithCaption(ipw.VBox):
 
 class SummaryView(ipw.VBox):
     def __init__(self, wc_node, **kwargs):
+        from packaging import version
+
+        # To backward compatibility < 23.10.0 use the legacy report generator
+        plugin_version = wc_node.base.attributes.all['version']['plugin']
+        if version.parse(plugin_version) < version.parse("23.10.0a0"):
+            from aiidalab_qe.app.report_legacy import generate_report_html
+        else:
+            from aiidalab_qe.app.report import generate_report_html
+            
         report_html = generate_report_html(wc_node)
 
         self.summary_view = ipw.HTML(report_html)

--- a/aiidalab_qe/app/node_view.py
+++ b/aiidalab_qe/app/node_view.py
@@ -288,12 +288,12 @@ class SummaryView(ipw.VBox):
         from packaging import version
 
         # To backward compatibility < 23.10.0 use the legacy report generator
-        plugin_version = wc_node.base.attributes.all['version']['plugin']
+        plugin_version = wc_node.base.attributes.all["version"]["plugin"]
         if version.parse(plugin_version) < version.parse("23.10.0a0"):
             from aiidalab_qe.app.report_legacy import generate_report_html
         else:
             from aiidalab_qe.app.report import generate_report_html
-            
+
         report_html = generate_report_html(wc_node)
 
         self.summary_view = ipw.HTML(report_html)

--- a/aiidalab_qe/app/report.py
+++ b/aiidalab_qe/app/report.py
@@ -1,3 +1,5 @@
+from aiida.orm import WorkChainNode
+
 FUNCTIONAL_LINK_MAP = {
     "PBE": "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.77.3865",
     "PBEsol": "https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.100.136406",
@@ -94,7 +96,7 @@ def _generate_report_html(report):
     return env.from_string(template).render(style=style, **report)
 
 
-def generate_report_html(qeapp_wc):
+def generate_report_html(qeapp_wc: WorkChainNode):
     """Generate a html for reporting the inputs for the `QeAppWorkChain`"""
     builder_parameters = qeapp_wc.base.extras.get("builder_parameters", {})
     report = dict(_generate_report_dict(builder_parameters))

--- a/aiidalab_qe/app/report_legacy.py
+++ b/aiidalab_qe/app/report_legacy.py
@@ -1,9 +1,15 @@
 from aiida.orm import WorkChainNode
 from aiida.plugins import WorkflowFactory
 
-from .report import PROTOCOL_PSEUDO_MAP, PSEUDO_LINK_MAP, FUNCTIONAL_LINK_MAP, _generate_report_html
+from .report import (
+    FUNCTIONAL_LINK_MAP,
+    PROTOCOL_PSEUDO_MAP,
+    PSEUDO_LINK_MAP,
+    _generate_report_html,
+)
 
 PwBaseWorkChain = WorkflowFactory("quantumespresso.pw.base")
+
 
 def _generate_report_dict(qeapp_wc: WorkChainNode):
     builder_parameters = qeapp_wc.base.extras.get("builder_parameters", {})

--- a/aiidalab_qe/app/report_legacy.py
+++ b/aiidalab_qe/app/report_legacy.py
@@ -1,0 +1,120 @@
+from aiida.orm import WorkChainNode
+from aiida.plugins import WorkflowFactory
+
+from .report import PROTOCOL_PSEUDO_MAP, PSEUDO_LINK_MAP, FUNCTIONAL_LINK_MAP, _generate_report_html
+
+PwBaseWorkChain = WorkflowFactory("quantumespresso.pw.base")
+
+def _generate_report_dict(qeapp_wc: WorkChainNode):
+    builder_parameters = qeapp_wc.base.extras.get("builder_parameters", {})
+
+    # Properties
+    run_relax = builder_parameters.get("relax_type") != "none"
+    run_bands = builder_parameters.get("run_bands")
+    run_pdos = builder_parameters.get("run_pdos")
+
+    yield "relaxed", run_relax
+    yield "relax_method", builder_parameters["relax_type"]
+    yield "bands_computed", run_bands
+    yield "pdos_computed", run_pdos
+
+    # Material settings
+    yield "material_magnetic", builder_parameters["spin_type"]
+    yield "electronic_type", builder_parameters["electronic_type"]
+
+    # Calculation settings
+    yield "protocol", builder_parameters["protocol"]
+
+    try:
+        pseudo_family = builder_parameters.get("pseudo_family", None)
+        if pseudo_family is None:
+            protocol = builder_parameters.get("pseudo_family", "moderate")
+            pseudo_family = PROTOCOL_PSEUDO_MAP[protocol]
+
+        yield "pseudo_family", pseudo_family
+
+        pseudo_family_list = pseudo_family.split("/")
+        pseudo_library = pseudo_family_list[0]
+        yield "pseudo_library", pseudo_library
+
+        if pseudo_library == "SSSP":
+            yield "pseudo_version", pseudo_family_list[1]
+            functional = pseudo_family_list[2]
+            yield "functional", functional
+            yield "pseudo_protocol", pseudo_family_list[3]
+        else:
+            raise NotImplementedError
+    except (KeyError, AttributeError):
+        pass
+    yield "pseudo_link", PSEUDO_LINK_MAP[pseudo_library]
+    yield "functional_link", FUNCTIONAL_LINK_MAP[functional]
+
+    pw_parameters = None
+    energy_cutoff_wfc = None
+    energy_cutoff_rho = None
+    degauss = None
+    smearing = None
+    scf_kpoints_distance = None
+    bands_kpoints_distance = None
+
+    try:
+        scf_kpoints_distance = qeapp_wc.inputs.kpoints_distance_override.value
+    except AttributeError:
+        scf_kpoints_distance = None
+    nscf_kpoints_distance = None
+
+    default_params = PwBaseWorkChain.get_protocol_inputs(
+        builder_parameters["protocol"]
+    )["pw"]["parameters"]["SYSTEM"]
+    try:
+        degauss = qeapp_wc.inputs.degauss_override.value
+    except AttributeError:
+        # read default from protocol
+        degauss = default_params["degauss"]
+
+    try:
+        smearing = qeapp_wc.inputs.smearing_override.value
+    except AttributeError:
+        # read default from protocol
+        smearing = default_params["smearing"]
+
+    # The run_relax variable is not same as if statement below.
+    # the "relax" port is poped out to skip the real relaxiation
+    # which is not the case of SCF, we use the relax workchain but with
+    # relax_type set to none as SCF calculation.
+    if "relax" in qeapp_wc.inputs:
+        pw_parameters = qeapp_wc.inputs.relax.base.pw.parameters.get_dict()
+        if scf_kpoints_distance is None:
+            scf_kpoints_distance = qeapp_wc.inputs.relax.base.kpoints_distance.value
+
+    if run_bands:
+        pw_parameters = qeapp_wc.inputs.bands.scf.pw.parameters.get_dict()
+        if scf_kpoints_distance is None:
+            scf_kpoints_distance = qeapp_wc.inputs.bands.scf.kpoints_distance.value
+        bands_kpoints_distance = qeapp_wc.inputs.bands.bands_kpoints_distance.value
+    if run_pdos:
+        scf_kpoints_distance = (
+            scf_kpoints_distance or qeapp_wc.inputs.pdos.scf.kpoints_distance.value
+        )
+        pw_parameters = (
+            pw_parameters or qeapp_wc.inputs.pdos.scf.pw.parameters.get_dict()
+        )
+        nscf_kpoints_distance = qeapp_wc.inputs.pdos.nscf.kpoints_distance.value
+
+    energy_cutoff_wfc = round(pw_parameters["SYSTEM"]["ecutwfc"])
+    energy_cutoff_rho = round(pw_parameters["SYSTEM"]["ecutrho"])
+
+    yield "energy_cutoff_wfc", energy_cutoff_wfc
+    yield "energy_cutoff_rho", energy_cutoff_rho
+    yield "degauss", degauss
+    yield "smearing", smearing
+    yield "scf_kpoints_distance", scf_kpoints_distance
+    yield "bands_kpoints_distance", bands_kpoints_distance
+    yield "nscf_kpoints_distance", nscf_kpoints_distance
+
+
+def generate_report_html(qeapp_wc: WorkChainNode):
+    """Generate a html for reporting the inputs for the `QeAppWorkChain`"""
+    report = dict(_generate_report_dict(qeapp_wc))
+
+    return _generate_report_html(report)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     aiidalab-widgets-base~=2.0
     filelock~=3.8
     importlib-resources~=5.2
+    packaging~=21.3
     widget-bandsplot~=0.5.1
     pybtex==0.24.0
     pymatgen==2022.9.21


### PR DESCRIPTION
I insist to bring this back, since now we are planning to announce to QE community version `23.4.3` which I hard code the version used in Quantum Mobile and in the documentation. 
This means there are potential users who will run calculations with this version and still want to check this workflow after they update the app to `23.10.0`. 