### PR TITLE
add version when installing pseudo

### DIFF
--- a/aiidalab_qe/app/sssp.py
+++ b/aiidalab_qe/app/sssp.py
@@ -63,6 +63,8 @@ def install_pseudos(pseudo_set):
                 p_func,
                 "-p",
                 p_type,
+                "-v",
+                "1.2",
             ]
         elif pseudo.startswith("PseudoDojo"):
             p_family, p_version, p_func, p_rel, p_type, p_format = pseudo.split("/")
@@ -78,6 +80,8 @@ def install_pseudos(pseudo_set):
                 p_type,
                 "-f",
                 p_format,
+                "-v",
+                "0.4",
             ]
         run_(cmds)
 


### PR DESCRIPTION
QeApp failed when installing SSSP pseudo, because the new SSSP version (1.3) is released, and we hard-coded version 1.2 in QeApp, so we need to add the version when installing pseudo.