### PR TITLE
Bump bumpver to 2023.1124

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ python_requires = >=3.8
 
 [options.extras_require]
 dev =
-    bumpver~=2023.1121
+    bumpver~=2023.1124
     pre-commit~=2.20
     pytest~=6.2
     pytest-regressions~=2.2


### PR DESCRIPTION
In order to use https://github.com/mbarkhau/bumpver/pull/207 for backport compatibility support for branch `support-23.04.x`.