### PR TITLE
pinning more specific aiida-core and aiida-qe

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,16 +22,14 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    aiida-core~=2.2,<3
+    aiida-core~=2.3.0,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.2
+    aiida-quantumespresso~=4.2.0
     aiidalab-qe-workchain@https://github.com/aiidalab/aiidalab-qe/releases/download/v23.04.4/aiidalab_qe_workchain-23.4.4-py3-none-any.whl
     aiidalab-widgets-base~=2.0
     filelock~=3.8
     importlib-resources~=5.2
     widget-bandsplot~=0.5.1
-    pybtex==0.24.0
-    pymatgen==2022.9.21
 python_requires = >=3.8
 
 [options.extras_require]


### PR DESCRIPTION
The installation broke by `pymatgen`, again. 😞 
For the "stable" `23.04.x` support, I think the only way is to keep on bump the patch version with the fix which means endlessly pining/unpinning the pymatgen with specific versions.
For `23.10.0`, I'll try to introduce the `pip-compile` and `pip-sync` to solve this once for all if we really can not get rid of `pymatgen` (we should try at least @mbercx).  