### PR TITLE
Remove pinning pymatgen

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,6 @@ install_requires =
     filelock~=3.8
     importlib-resources~=5.2
     widget-bandsplot~=0.5.1
-    pybtex==0.24.0
-    pymatgen==2022.9.21
     pydantic~=1.10,>=1.10.8
 python_requires = >=3.8
 


### PR DESCRIPTION
`pybtex` is a dependency of `pymatgen` and was pinned to a workaround of a installation issue before. The `pymatgen` was pinned to accelerating the installation other wise the pip will take a long time to solve the dependencies. 
But the version `pymatgen==2022.9.21` now cause the error:

```
gcc -pthread -B /opt/conda/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O3 -Wall -fPIC -O3 -isystem /opt/conda/include -fPIC -O3 -isystem /opt/conda/include -fPIC -I/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/numpy/core/include -I/opt/conda/include/python3.9 -c pymatgen/optimization/linear_assignment.c -o build/temp.linux-aarch64-cpython-39/pymatgen/optimization/linear_assignment.o
      In file included from /tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/numpy/core/include/numpy/ndarraytypes.h:1822,
                       from /tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/numpy/core/include/numpy/ndarrayobject.h:12,
                       from /tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                       from pymatgen/optimization/linear_assignment.c:1097:
      /tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
         17 | #warning "Using deprecated NumPy API, disable it with " \
            |  ^~~~~~~
      pymatgen/optimization/linear_assignment.c: In function ‘__pyx_pf_8pymatgen_12optimization_17linear_assignment_16LinearAssignment___init__.constprop’:
      pymatgen/optimization/linear_assignment.c:19466:7: warning: ‘__pyx_v_last’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      19466 |   int __pyx_v_last;
            |       ^~~~~~~~~~~~
      pymatgen/optimization/linear_assignment.c:20264:19: warning: ‘__pyx_v_j2’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      20264 |         __pyx_t_5 = __pyx_v_j1;
            |         ~~~~~~~~~~^~~~~~~~~~~~
      pymatgen/optimization/linear_assignment.c:19480:7: note: ‘__pyx_v_j2’ was declared here
      19480 |   int __pyx_v_j2;
            |       ^~~~~~~~~~
      pymatgen/optimization/linear_assignment.c:20998:96: warning: ‘__pyx_v_m’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      20998 |                 (__pyx_v_v[__pyx_v_j1]) = (((__pyx_v_v[__pyx_v_j1]) + (__pyx_v_d[__pyx_v_j1])) - __pyx_v_m);
            |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
      pymatgen/optimization/linear_assignment.c:19476:26: note: ‘__pyx_v_m’ was declared here
      19476 |   __pyx_t_5numpy_float_t __pyx_v_m;
            |                          ^~~~~~~~~
      gcc -pthread -B /opt/conda/compiler_compat -shared -Wl,--allow-shlib-undefined -Wl,-rpath,/opt/conda/lib -Wl,-rpath-link,/opt/conda/lib -L/opt/conda/lib -Wl,--allow-shlib-undefined -Wl,-rpath,/opt/conda/lib -Wl,-rpath-link,/opt/conda/lib -L/opt/conda/lib build/temp.linux-aarch64-cpython-39/pymatgen/optimization/linear_assignment.o -o build/lib.linux-aarch64-cpython-39/pymatgen/optimization/linear_assignment.cpython-39-aarch64-linux-gnu.so
      warning: pymatgen/util/coord_cython.pyx:217:25: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
      warning: pymatgen/util/coord_cython.pyx:266:41: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          #ensure correct shape
          fcoords1, fcoords2 = np.atleast_2d(fcoords1, fcoords2)
      
          pbc = lattice.pbc
          cdef int n_pbc = sum(pbc)
          cdef int n_pbc_im = 3 ** n_pbc
                                ^
      ------------------------------------------------------------
      
      pymatgen/util/coord_cython.pyx:94:26: Cannot assign type 'double' to 'int'
      Compiling pymatgen/util/coord_cython.pyx because it changed.
      [1/1] Cythonizing pymatgen/util/coord_cython.pyx
      Traceback (most recent call last):
        File "/opt/conda/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/conda/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/conda/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 416, in build_wheel
          return self._build_with_temp_dir(['bdist_wheel'], '.whl',
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 401, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 74, in <module>
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 107, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 1234, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1bww2zm1/normal/lib/python3.9/site-packages/wheel/bdist_wheel.py", line 343, in run
          self.run_command("build")
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 1234, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/build.py", line 131, in run
          self.run_command(cmd_name)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 318, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 1234, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/command/build_ext.py", line 84, in run
          _build_ext.run(self)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/build_ext.py", line 345, in run
          self.build_extensions()
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/build_ext.py", line 467, in build_extensions
          self._build_extensions_serial()
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/build_ext.py", line 493, in _build_extensions_serial
          self.build_extension(ext)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/setuptools/command/build_ext.py", line 246, in build_extension
          _build_ext.build_extension(self, ext)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/Cython/Distutils/build_ext.py", line 122, in build_extension
          new_ext = cythonize(
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1134, in cythonize
          cythonize_one(*args)
        File "/tmp/pip-build-env-1bww2zm1/overlay/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1301, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: pymatgen/util/coord_cython.pyx
```