### PR TITLE
Pseudo setter override pseudos properly

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -423,9 +423,9 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
                 pw_overrides[key]["pseudo_family"] = self.pseudo_family_selector.value
 
             if self.pseudo_setter.pseudos:
-                pw_overrides[key].setdefault("pseudos", self.pseudo_setter.pseudos)
-
                 pw_overrides[key].setdefault("pw", {"parameters": {"SYSTEM": {}}})
+                pw_overrides[key]["pw"]["pseudos"] = self.pseudo_setter.pseudos
+
                 pw_overrides[key]["pw"]["parameters"]["SYSTEM"][
                     "ecutwfc"
                 ] = self.pseudo_setter.ecutwfc


### PR DESCRIPTION
Setting new pseudopotential is not properly work, I did some refactoring during rebase and this change is needed.

I tried to write the test for this but failed to do it, I notice @AndresOrtegaGuerrero put similar tot_charge test in `submit_step_widget_generator` fixture. I think the better way would be to verify the data pass to create `QeWorkChainParameters` dataclass.

Since I'll take over @superstar54's PR to prototype some unit tests, I'll leave this task there.  