### PR TITLE
update nscf kpoints distance

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -447,7 +447,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
                         self.advanced_settings.magnetization.get_magnetization()
                     )
 
-                if key in ["base", "scf"]:
+                if key in ["base", "scf" , "nscf"]:
                     if self.advanced_settings.kpoints.override.value:
                         pw_overrides[key][
                             "kpoints_distance"


### PR DESCRIPTION
When doing an override of the kpoints distance, the nscf calculation of PdosWorkChain is not updated. This PR fix that behaviour