### PR TITLE
increasing the range of the magnetization floattext

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced.py
@@ -183,8 +183,8 @@ class MagnetizationSettings(ipw.VBox):
             for kind_label in self.input_structure_labels:
                 kind_widget = ipw.BoundedFloatText(
                     description=kind_label,
-                    min=-1,
-                    max=1,
+                    min=-4,
+                    max=4,
                     step=0.1,
                     value=0.0,
                     disabled=True,


### PR DESCRIPTION
This PR increases the value of the magnetization widget, the values -1, 1 were too limited leading to low starting_magnetization values in the pw.x calculation