### PR TITLE
Plugin band

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,10 @@ dev =
 aiidalab_qe.app.parameters = qeapp.yaml
 aiidalab_qe.app.static = *
 
+[options.entry_points]
+aiidalab_qe.property =
+    bands = aiidalab_qe.app.plugins.bands:property
+
 [aiidalab]
 title = Quantum ESPRESSO
 description = Perform Quantum ESPRESSO calculations

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ aiidalab_qe.app.static = *
 
 [options.entry_points]
 aiidalab_qe.properties =
-    bands = aiidalab_qe.app.plugins.bands:property
+    bands = aiidalab_qe.app.plugins.bands:bands
 
 [aiidalab]
 title = Quantum ESPRESSO

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ aiidalab_qe.app.parameters = qeapp.yaml
 aiidalab_qe.app.static = *
 
 [options.entry_points]
-aiidalab_qe.property =
+aiidalab_qe.properties =
     bands = aiidalab_qe.app.plugins.bands:property
 
 [aiidalab]

--- a/src/aiidalab_qe/app/common/panel.py
+++ b/src/aiidalab_qe/app/common/panel.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Class to .
+
+Authors:
+
+    AiiDAlab Team
+"""
+import ipywidgets as ipw
+
+DEFAULT_PARAMETERS = {}
+
+
+class Panel(ipw.VBox):
+    """Base class for all the panels.
+
+    The base class has a method to return the value of all the widgets in
+    the panel as a dictionary. The dictionary is used to construct the
+    input file for the calculation. The class also has a method to load a dictionary to set the value of the widgets in the panel.
+
+    title: the title to be shown in the GUI
+    identifier: which plugin this panel belong to.
+
+    """
+
+    title = "Panel"
+
+    def __init__(self, parent=None, identifier="panel", **kwargs):
+        """Initialize the panel.
+
+        :param kwargs: keyword arguments to pass to the ipw.VBox constructor.
+        """
+        self.parent = parent
+        if identifier:
+            self.identifier = identifier
+        super().__init__(
+            children=self.children,
+            **kwargs,
+        )
+
+    def get_panel_value(self):
+        """Return the value of all the widgets in the panel as a dictionary.
+
+        :return: a dictionary of the values of all the widgets in the panel.
+        """
+        return {}
+
+    def set_panel_value(self, parameters):
+        """Set the value of the widgets in the panel.
+
+        :param parameters: a dictionary of the values of all the widgets in the panel.
+        """
+        for key, value in parameters.items():
+            if key in self.__dict__:
+                setattr(self, key, value)
+
+    def reset(self):
+        """Reset the panel to the default value."""
+        self.set_panel_value(DEFAULT_PARAMETERS)
+
+    def _update_state(self):
+        """Update the state of the panel."""
+        pass
+
+
+class OutlinePanel(Panel):
+    title = "Outline"
+    description = ""
+
+    def __init__(self, **kwargs):
+        # Checkbox to see if the property should be calculated
+        self.run = ipw.Checkbox(
+            description=self.title,
+            indent=False,
+            value=False,
+            layout=ipw.Layout(max_width="50%"),
+        )
+        self.description_html = ipw.HTML(
+            f"""<div style="line-height: 140%; padding-top: 0px; padding-bottom: 5px">
+            {self.description}</div>"""
+        )
+        self.accordion = ipw.Accordion(children=[self.description_html])
+        self.accordion.selected_index = None
+        # self.children = [self.run, self.accordion]
+        self.children = [self.run, self.description_html]
+        super().__init__(**kwargs)
+
+    def get_panel_value(self):
+        return {f"{self.identifier}_run": self.run.value}
+
+    def set_panel_value(self, input_dict):
+        self.run.value = input_dict.get(f"{self.identifier}_run", False)
+
+
+class ResultPanel(Panel):
+    """Base class for all the result panels.
+
+    The base class has a method to load the result of the calculation.
+    And a show method to display it in the panel.
+    It has a update method to update the result in the panel.
+    """
+
+    title = "Result"
+
+    def __init__(self, node=None, **kwargs):
+        self.node = node
+        self.children = [
+            ipw.VBox(
+                [ipw.Label(f"{self.title} not available.")],
+                layout=ipw.Layout(min_height="380px"),
+            )
+        ]
+        super().__init__(**kwargs)
+
+    @property
+    def outputs(self):
+        """Outputs of the calculation."""
+        if self.node is None:
+            return None
+
+        return getattr(self.node.outputs, self.identifier)
+
+    def _update_view(self):
+        """Update the result in the panel.
+
+        :param result: the result of the calculation.
+        """
+        pass

--- a/src/aiidalab_qe/app/common/panel.py
+++ b/src/aiidalab_qe/app/common/panel.py
@@ -124,4 +124,3 @@ class ResultPanel(Panel):
 
         :param result: the result of the calculation.
         """
-        pass

--- a/src/aiidalab_qe/app/common/panel.py
+++ b/src/aiidalab_qe/app/common/panel.py
@@ -32,9 +32,8 @@ class Panel(ipw.VBox):
         self.parent = parent
         if identifier:
             self.identifier = identifier
-        self.widgets = []
         super().__init__(
-            children=self.widgets,
+            children=self.children,
             **kwargs,
         )
 
@@ -81,8 +80,8 @@ class OutlinePanel(Panel):
         )
         self.accordion = ipw.Accordion(children=[self.description_html])
         self.accordion.selected_index = None
-        # self.widgets = [self.run, self.accordion]
-        self.widgets = [self.run, self.description_html]
+        # self.children = [self.run, self.accordion]
+        self.children = [self.run, self.description_html]
         super().__init__(**kwargs)
 
     def get_panel_value(self):
@@ -104,7 +103,7 @@ class ResultPanel(Panel):
 
     def __init__(self, node=None, **kwargs):
         self.node = node
-        self.widgets = [
+        self.children = [
             ipw.VBox(
                 [ipw.Label(f"{self.title} not available.")],
                 layout=ipw.Layout(min_height="380px"),

--- a/src/aiidalab_qe/app/common/panel.py
+++ b/src/aiidalab_qe/app/common/panel.py
@@ -59,7 +59,6 @@ class Panel(ipw.VBox):
 
     def _update_state(self):
         """Update the state of the panel."""
-        pass
 
 
 class OutlinePanel(Panel):

--- a/src/aiidalab_qe/app/common/panel.py
+++ b/src/aiidalab_qe/app/common/panel.py
@@ -32,8 +32,9 @@ class Panel(ipw.VBox):
         self.parent = parent
         if identifier:
             self.identifier = identifier
+        self.widgets = []
         super().__init__(
-            children=self.children,
+            children=self.widgets,
             **kwargs,
         )
 
@@ -80,8 +81,8 @@ class OutlinePanel(Panel):
         )
         self.accordion = ipw.Accordion(children=[self.description_html])
         self.accordion.selected_index = None
-        # self.children = [self.run, self.accordion]
-        self.children = [self.run, self.description_html]
+        # self.widgets = [self.run, self.accordion]
+        self.widgets = [self.run, self.description_html]
         super().__init__(**kwargs)
 
     def get_panel_value(self):
@@ -103,7 +104,7 @@ class ResultPanel(Panel):
 
     def __init__(self, node=None, **kwargs):
         self.node = node
-        self.children = [
+        self.widgets = [
             ipw.VBox(
                 [ipw.Label(f"{self.title} not available.")],
                 layout=ipw.Layout(min_height="380px"),

--- a/src/aiidalab_qe/app/configuration/__init__.py
+++ b/src/aiidalab_qe/app/configuration/__init__.py
@@ -51,18 +51,19 @@ class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             (self.workchain_settings.workchain_protocol, "value"),
             (self.advanced_settings.smearing, "protocol"),
         )
-
+        #
+        self.built_in_settings = [
+            self.workchain_settings,
+            ipw.VBox(
+                children=[
+                    self.advanced_settings,
+                    self.pseudo_family_selector,
+                    self.pseudo_setter,
+                ]
+            ),
+        ]
         self.tab = ipw.Tab(
-            children=[
-                self.workchain_settings,
-                ipw.VBox(
-                    children=[
-                        self.advanced_settings,
-                        self.pseudo_family_selector,
-                        self.pseudo_setter,
-                    ]
-                ),
-            ],
+            children=self.built_in_settings,
             layout=ipw.Layout(min_height="250px"),
         )
 
@@ -181,7 +182,7 @@ class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
     def _update_panel(self, _=None):
         """Dynamic add/remove the panel based on the selected properties."""
         # only keep basic and advanced settings
-        self.tab.children = self.tab.children[:2]
+        self.tab.children = self.built_in_settings
         # add plugin specific settings
         for name in self.workchain_settings.properties:
             if (

--- a/src/aiidalab_qe/app/configuration/__init__.py
+++ b/src/aiidalab_qe/app/configuration/__init__.py
@@ -11,11 +11,11 @@ from aiida import orm
 from aiidalab_widgets_base import WizardAppWidgetStep
 
 from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
+from aiidalab_qe.app.utils import get_entry_items
 
 from .advanced import AdvancedSettings
 from .pseudos import PseudoFamilySelector, PseudoSetter
 from .workflow import WorkChainSettings
-from aiidalab_qe.app.utils import get_entry_items
 
 
 class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):

--- a/src/aiidalab_qe/app/configuration/__init__.py
+++ b/src/aiidalab_qe/app/configuration/__init__.py
@@ -72,7 +72,7 @@ class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         # add plugin specific settings
         self.settings = {}
         # add plugin specific settings
-        entries = get_entry_items("aiidalab_qe.property", "setting")
+        entries = get_entry_items("aiidalab_qe.properties", "setting")
         for name, entry_point in entries.items():
             self.settings[name] = entry_point(parent=self)
             self.settings[name].identifier = name

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -102,7 +102,7 @@ class WorkChainSettings(ipw.VBox):
                 ]
             ),
         ]
-        entries = get_entry_items("aiidalab_qe.property", "outline")
+        entries = get_entry_items("aiidalab_qe.properties", "outline")
         for name, entry_point in entries.items():
             self.properties[name] = entry_point()
             property_children.append(self.properties[name])

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -6,6 +6,8 @@ Authors: AiiDAlab team
 import ipywidgets as ipw
 
 from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
+from aiidalab_qe.app.common.panel import Panel
+from aiidalab_qe.app.utils import get_entry_items
 
 
 class WorkChainSettings(ipw.VBox):
@@ -77,14 +79,6 @@ class WorkChainSettings(ipw.VBox):
             style={"description_width": "initial"},
         )
 
-        # Checkbox to see if the band structure should be calculated
-        self.bands_run = ipw.Checkbox(
-            description="",
-            indent=False,
-            value=True,
-            layout=ipw.Layout(max_width="10%"),
-        )
-
         # Checkbox to see if the PDOS should be calculated
         self.pdos_run = ipw.Checkbox(
             description="",
@@ -98,6 +92,22 @@ class WorkChainSettings(ipw.VBox):
             options=["fast", "moderate", "precise"],
             value="moderate",
         )
+        self.properties = {}
+        property_children = [
+            self.properties_title,
+            ipw.HTML("Select which properties to calculate:"),
+            ipw.HBox(
+                children=[
+                    ipw.HTML("<b>Projected density of states</b>"),
+                    self.pdos_run,
+                ]
+            ),
+        ]
+        entries = get_entry_items("aiidalab_qe.property", "outline")
+        for name, entry_point in entries.items():
+            self.properties[name] = entry_point()
+            property_children.append(self.properties[name])
+        property_children.append(self.properties_help)
         super().__init__(
             children=[
                 self.structure_title,
@@ -126,16 +136,7 @@ class WorkChainSettings(ipw.VBox):
                         self.spin_type,
                     ]
                 ),
-                self.properties_title,
-                ipw.HTML("Select which properties to calculate:"),
-                ipw.HBox(children=[ipw.HTML("<b>Band structure</b>"), self.bands_run]),
-                ipw.HBox(
-                    children=[
-                        ipw.HTML("<b>Projected density of states</b>"),
-                        self.pdos_run,
-                    ]
-                ),
-                self.properties_help,
+                *property_children,
                 self.protocol_title,
                 ipw.HTML("Select the protocol:", layout=ipw.Layout(flex="1 1 auto")),
                 self.workchain_protocol,
@@ -150,7 +151,6 @@ class WorkChainSettings(ipw.VBox):
             "relax_type",
             "spin_type",
             "electronic_type",
-            "bands_run",
             "pdos_run",
             "workchain_protocol",
         ]:

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -92,7 +92,7 @@ class WorkChainSettings(ipw.VBox):
             value="moderate",
         )
         self.properties = {}
-        property_children = [
+        self.property_children = [
             self.properties_title,
             ipw.HTML("Select which properties to calculate:"),
             ipw.HBox(
@@ -105,8 +105,8 @@ class WorkChainSettings(ipw.VBox):
         entries = get_entry_items("aiidalab_qe.properties", "outline")
         for name, entry_point in entries.items():
             self.properties[name] = entry_point()
-            property_children.append(self.properties[name])
-        property_children.append(self.properties_help)
+            self.property_children.append(self.properties[name])
+        self.property_children.append(self.properties_help)
         super().__init__(
             children=[
                 self.structure_title,
@@ -135,7 +135,7 @@ class WorkChainSettings(ipw.VBox):
                         self.spin_type,
                     ]
                 ),
-                *property_children,
+                *self.property_children,
                 self.protocol_title,
                 ipw.HTML("Select the protocol:", layout=ipw.Layout(flex="1 1 auto")),
                 self.workchain_protocol,

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -150,8 +150,13 @@ class WorkChainSettings(ipw.VBox):
             "relax_type",
             "spin_type",
             "electronic_type",
+            "bands_run",
             "pdos_run",
             "workchain_protocol",
         ]:
             if key in kwargs:
-                getattr(self, key).value = kwargs[key]
+                # a temporary solution for the bands_run property
+                if key == "bands_run":
+                    self.properties["bands"].run.value = kwargs[key]
+                else:
+                    getattr(self, key).value = kwargs[key]

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -5,7 +5,6 @@ Authors: AiiDAlab team
 """
 import ipywidgets as ipw
 
-from aiidalab_qe.app.common.panel import Panel
 from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.app.utils import get_entry_items
 

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -5,8 +5,8 @@ Authors: AiiDAlab team
 """
 import ipywidgets as ipw
 
-from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.app.common.panel import Panel
+from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.app.utils import get_entry_items
 
 

--- a/src/aiidalab_qe/app/plugins/bands/__init__.py
+++ b/src/aiidalab_qe/app/plugins/bands/__init__.py
@@ -16,7 +16,7 @@ SeeK-path tool</a>.
 """
 
 
-property = {
+bands = {
     "outline": BandsOutline,
     "setting": Setting,
     "result": Result,

--- a/src/aiidalab_qe/app/plugins/bands/__init__.py
+++ b/src/aiidalab_qe/app/plugins/bands/__init__.py
@@ -1,0 +1,23 @@
+# from aiidalab_qe.bands.result import Result
+from aiidalab_qe.app.common.panel import OutlinePanel
+
+from .result import Result
+from .setting import Setting
+from .workchain import workchain_and_builder
+
+
+class BandsOutline(OutlinePanel):
+    title = "Electronic band structure"
+    help = """The band structure workflow will
+automatically detect the default path in reciprocal space using the
+<a href="https://www.materialscloud.org/work/tools/seekpath" target="_blank">
+SeeK-path tool</a>.
+"""
+
+
+property = {
+    "outline": BandsOutline,
+    "setting": Setting,
+    "result": Result,
+    "workchain": workchain_and_builder,
+}

--- a/src/aiidalab_qe/app/plugins/bands/__init__.py
+++ b/src/aiidalab_qe/app/plugins/bands/__init__.py
@@ -3,7 +3,8 @@ from aiidalab_qe.app.common.panel import OutlinePanel
 
 from .result import Result
 from .setting import Setting
-from .workchain import workchain_and_builder
+
+# from .workchain import workchain_and_builder
 
 
 class BandsOutline(OutlinePanel):
@@ -19,5 +20,5 @@ property = {
     "outline": BandsOutline,
     "setting": Setting,
     "result": Result,
-    "workchain": workchain_and_builder,
+    # "workchain": workchain_and_builder,
 }

--- a/src/aiidalab_qe/app/plugins/bands/result.py
+++ b/src/aiidalab_qe/app/plugins/bands/result.py
@@ -1,0 +1,45 @@
+"""Bands results view widgets
+
+"""
+
+
+from aiidalab_qe.app.common.panel import ResultPanel
+
+
+def export_bands_data(outputs, fermi_energy=None):
+    """Export the bands data from the outputs of the calculation."""
+    import json
+
+    from monty.json import jsanitize
+
+    if "band_structure" in outputs:
+        data = json.loads(
+            outputs.band_structure._exportcontent("json", comments=False)[0]
+        )
+        # The fermi energy from band calculation is not robust.
+        data["fermi_level"] = fermi_energy or outputs.band_parameters["fermi_energy"]
+        return [
+            jsanitize(data),
+        ]
+    else:
+        return None
+
+
+class Result(ResultPanel):
+    """Result panel for the bands calculation."""
+
+    title = "Bands"
+
+    def __init__(self, node=None, **kwargs):
+        super().__init__(node=node, identifier="bands", **kwargs)
+
+    def _update_view(self):
+        from widget_bandsplot import BandsPlotWidget
+
+        bands_data = export_bands_data(self.outputs)
+        _bands_plot_view = BandsPlotWidget(
+            bands=bands_data,
+        )
+        self.children = [
+            _bands_plot_view,
+        ]

--- a/src/aiidalab_qe/app/plugins/bands/setting.py
+++ b/src/aiidalab_qe/app/plugins/bands/setting.py
@@ -37,7 +37,7 @@ class Setting(Panel):
             style={"description_width": "initial"},
         )
 
-        self.children = [
+        self.widgets = [
             self.settings_title,
             self.settings_help,
             self.path,
@@ -52,7 +52,7 @@ class Setting(Panel):
             "npoint": Int(self.npoint.value),
         }
 
-    def load_panel_value(self, input_dict):
+    def set_panel_value(self, input_dict):
         """Load a dictionary with the input parameters for the plugin."""
         self.path.value = input_dict.get("path", 1)
         self.npoint.value = input_dict.get("npoint", 2)

--- a/src/aiidalab_qe/app/plugins/bands/setting.py
+++ b/src/aiidalab_qe/app/plugins/bands/setting.py
@@ -37,7 +37,7 @@ class Setting(Panel):
             style={"description_width": "initial"},
         )
 
-        self.widgets = [
+        self.children = [
             self.settings_title,
             self.settings_help,
             self.path,

--- a/src/aiidalab_qe/app/plugins/bands/setting.py
+++ b/src/aiidalab_qe/app/plugins/bands/setting.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""Panel for Bands plugin."""
+import ipywidgets as ipw
+from aiida.orm import Int, Str
+
+from aiidalab_qe.app.common.panel import Panel
+
+
+class Setting(Panel):
+    title = "Bands Structure Settings"
+    identifier = "bands"
+
+    def __init__(self, **kwargs):
+        self.settings_title = ipw.HTML(
+            """<div style="padding-top: 0px; padding-bottom: 0px">
+            <h4>Settings</h4></div>"""
+        )
+        self.settings_help = ipw.HTML(
+            """<div style="line-height: 140%; padding-top: 0px; padding-bottom: 5px">
+            Please set the value of path and number of points.
+            </div>"""
+        )
+        self.workchain_protocol = ipw.ToggleButtons(
+            options=["fast", "moderate", "precise"],
+            value="moderate",
+        )
+        self.path = ipw.Text(
+            value="G",
+            description="Bands path:",
+            disabled=False,
+            style={"description_width": "initial"},
+        )
+        self.npoint = ipw.IntText(
+            value=50,
+            description="Number of point:",
+            disabled=False,
+            style={"description_width": "initial"},
+        )
+
+        self.children = [
+            self.settings_title,
+            self.settings_help,
+            self.path,
+            self.npoint,
+        ]
+        super().__init__(**kwargs)
+
+    def get_panel_value(self):
+        """Return a dictionary with the input parameters for the plugin."""
+        return {
+            "path": Str(self.path.value),
+            "npoint": Int(self.npoint.value),
+        }
+
+    def load_panel_value(self, input_dict):
+        """Load a dictionary with the input parameters for the plugin."""
+        self.path.value = input_dict.get("path", 1)
+        self.npoint.value = input_dict.get("npoint", 2)

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -64,7 +64,7 @@ class WorkChainViewer(ipw.VBox):
         self.result_tabs.set_title(2, "Electronic Structure (n/a)")
 
         # add plugin specific settings
-        entries = get_entry_items("aiidalab_qe.property", "result")
+        entries = get_entry_items("aiidalab_qe.properties", "result")
         self.results = {}
         for name, entry_point in entries.items():
             # only show the result tab if the property is selected to be run

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -17,10 +17,10 @@ from jinja2 import Environment
 from widget_bandsplot import BandsPlotWidget
 
 from aiidalab_qe.app import static
+from aiidalab_qe.app.utils import get_entry_items
 
 from .electronic_structure import export_data
 from .summary_viewer import SummaryView
-from aiidalab_qe.app.utils import get_entry_items
 
 
 @register_viewer_widget("process.workflow.workchain.WorkChainNode.")
@@ -69,7 +69,7 @@ class WorkChainViewer(ipw.VBox):
         for name, entry_point in entries.items():
             # only show the result tab if the property is selected to be run
             # this will be repalced by the ui_parameters in the future PR
-            if not builder_parameters.get(f'run_{name}', False):
+            if not builder_parameters.get(f"run_{name}", False):
                 continue
             result = entry_point(self.node)
             self.results[name] = result

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -20,6 +20,7 @@ from aiidalab_qe.app import static
 
 from .electronic_structure import export_data
 from .summary_viewer import SummaryView
+from aiidalab_qe.app.utils import get_entry_items
 
 
 @register_viewer_widget("process.workflow.workchain.WorkChainNode.")
@@ -32,6 +33,8 @@ class WorkChainViewer(ipw.VBox):
             return
 
         self.node = node
+        # this will be replaced by "ui_parameters" in the future PR
+        builder_parameters = node.base.extras.get("builder_parameters", {})
 
         self.title = ipw.HTML(
             f"""
@@ -59,6 +62,19 @@ class WorkChainViewer(ipw.VBox):
         self.result_tabs.set_title(0, "Workflow Summary")
         self.result_tabs.set_title(1, "Final Geometry (n/a)")
         self.result_tabs.set_title(2, "Electronic Structure (n/a)")
+
+        # add plugin specific settings
+        entries = get_entry_items("aiidalab_qe.property", "result")
+        self.results = {}
+        for name, entry_point in entries.items():
+            # only show the result tab if the property is selected to be run
+            # this will be repalced by the ui_parameters in the future PR
+            if not builder_parameters.get(f'run_{name}', False):
+                continue
+            result = entry_point(self.node)
+            self.results[name] = result
+            self.result_tabs.children += (result,)
+            self.result_tabs.set_title(len(self.result_tabs.children) - 1, result.title)
 
         # An ugly fix to the structure appearance problem
         # https://github.com/aiidalab/aiidalab-qe/issues/69
@@ -109,6 +125,16 @@ class WorkChainViewer(ipw.VBox):
             ):
                 self._show_electronic_structure()
                 self._results_shown.add("electronic_structure")
+            # update the plugin specific results
+            for result in self.result_tabs.children[3:]:
+                # check if the result is already shown
+                # check if the plugin workchain result is in the outputs
+                if (
+                    result.identifier not in self._results_shown
+                    and result.identifier in self.node.outputs
+                ):
+                    result._update_view()
+                    self._results_shown.add(result.identifier)
 
     def _show_structure(self):
         self._structure_view = StructureDataViewer(

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -487,7 +487,6 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
 
         run_pdos = self.workchain_settings.pdos_run.value
 
-        
         protocol = self.workchain_settings.workchain_protocol.value
 
         properties = []

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -485,16 +485,22 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         electronic_type = self.workchain_settings.electronic_type.value
         spin_type = self.workchain_settings.spin_type.value
 
-        run_bands = self.workchain_settings.bands_run.value
         run_pdos = self.workchain_settings.pdos_run.value
+
+        
         protocol = self.workchain_settings.workchain_protocol.value
 
         properties = []
 
-        if run_bands:
-            properties.append("bands")
         if run_pdos:
             properties.append("pdos")
+        # add plugin specific settings
+        run_bands = False
+        for name in self.workchain_settings.properties:
+            if self.workchain_settings.properties[name].run.value:
+                properties.append(name)
+            if name == "bands":
+                run_bands = True
 
         if RelaxType(relax_type) is not RelaxType.NONE or not (run_bands or run_pdos):
             properties.append("relax")

--- a/src/aiidalab_qe/app/utils/__init__.py
+++ b/src/aiidalab_qe/app/utils/__init__.py
@@ -1,5 +1,5 @@
 # load entry points
-def get_entries(entry_point_name="aiidalab_qe.property"):
+def get_entries(entry_point_name="aiidalab_qe.properties"):
     from importlib.metadata import entry_points
 
     entries = {}

--- a/src/aiidalab_qe/app/utils/__init__.py
+++ b/src/aiidalab_qe/app/utils/__init__.py
@@ -1,0 +1,18 @@
+# load entry points
+def get_entries(entry_point_name="aiidalab_qe.property"):
+    from importlib.metadata import entry_points
+
+    entries = {}
+    for entry_point in entry_points().get(entry_point_name, []):
+        entries[entry_point.name] = entry_point.load()
+
+    return entries
+
+
+def get_entry_items(entry_point_name, item_name="outline"):
+    entries = get_entries(entry_point_name)
+    return {
+        name: entry_point.get(item_name)
+        for name, entry_point in entries.items()
+        if entry_point.get(item_name, False)
+    }

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -254,7 +254,9 @@ class QeAppWorkChain(WorkChain):
         # Attach the output nodes directly as outputs of the workchain.
         self.out_many(
             self.exposed_outputs(
-                workchain, PwBandsWorkChain, namespace="bands",
+                workchain,
+                PwBandsWorkChain,
+                namespace="bands",
             )
         )
         self.ctx.scf_parent_folder = scf.outputs.remote_folder

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -52,6 +52,8 @@ class QeAppWorkChain(WorkChain):
                            exclude=('clean_workdir', 'structure'),
                            namespace_options={'required': False, 'populate_defaults': False,
                                               'help': 'Inputs for the `PdosWorkChain`.'})
+        spec.expose_outputs(PwBandsWorkChain, namespace='bands',
+                            namespace_options={"required": False})
         spec.outline(
             cls.setup,
             if_(cls.should_run_relax)(
@@ -248,6 +250,12 @@ class QeAppWorkChain(WorkChain):
             workchain.get_outgoing(orm.WorkChainNode, link_label_filter="scf")
             .one()
             .node
+        )
+        # Attach the output nodes directly as outputs of the workchain.
+        self.out_many(
+            self.exposed_outputs(
+                workchain, PwBandsWorkChain, namespace="bands",
+            )
         )
         self.ctx.scf_parent_folder = scf.outputs.remote_folder
         self.ctx.current_structure = workchain.outputs.primitive_structure

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -1,0 +1,6 @@
+def test_entry_point():
+    from aiidalab_qe.app.utils import get_entries
+
+    entries = get_entries()
+    print(entries)
+    assert "bands" in entries

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -2,5 +2,4 @@ def test_entry_point():
     from aiidalab_qe.app.utils import get_entries
 
     entries = get_entries()
-    print(entries)
     assert "bands" in entries

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -1,0 +1,11 @@
+def test_outline_panel():
+    """Test OutlinePanel class."""
+    from aiidalab_qe.app.common.panel import OutlinePanel
+
+    panel = OutlinePanel(identifier="test")
+    assert panel.identifier == "test"
+    parameters = panel.get_panel_value()
+    assert parameters == {"test_run": False}
+    parameters = {"test_run": True}
+    panel.set_panel_value(parameters)
+    assert panel.run.value is True

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -126,8 +126,8 @@ pdos:
       pseudos:
         Si: Si.upf
 properties:
-- bands
 - pdos
+- bands
 - relax
 relax:
   base:


### PR DESCRIPTION
This PR uses the plugin design to implement a basic version of `bands`. It only adds the `UI` part:
- setting panel, It is only used to illustrate that the setting panel appears when the user selects the bands property. No parameters from this panel are used in the workchain.
- result panel. This is a panel only to show the bands. The code for `electronic_structure` tab is still kept.

