### PR TITLE
use get and set for WorkChain settings

### DIFF
--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -4,6 +4,7 @@
 Authors: AiiDAlab team
 """
 import ipywidgets as ipw
+from aiida_quantumespresso.common.types import RelaxType
 
 from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.app.utils import get_entry_items
@@ -130,21 +131,50 @@ class WorkChainSettings(ipw.VBox):
             **kwargs,
         )
 
-    def _update_settings(self, **kwargs):
+    def get_setting_parameters(self):
+        # Work chain settings
+        relax_type = self.relax_type.value
+        electronic_type = self.electronic_type.value
+        spin_type = self.spin_type.value
+
+        protocol = self.workchain_protocol.value
+
+        properties = []
+
+        # add plugin specific settings
+        run_bands = False
+        run_pdos = False
+        for name in self.properties:
+            if self.properties[name].run.value:
+                properties.append(name)
+            if name == "bands":
+                run_bands = True
+            elif name == "pdos":
+                run_bands = True
+
+        if RelaxType(relax_type) is not RelaxType.NONE or not (run_bands or run_pdos):
+            properties.append("relax")
+        return {
+            "protocol": protocol,
+            "relax_type": relax_type,
+            "properties": properties,
+            "spin_type": spin_type,
+            "electronic_type": electronic_type,
+        }
+
+    def set_setting_parameters(self, parameters):
         """Update the settings based on the given dict."""
         for key in [
             "relax_type",
             "spin_type",
             "electronic_type",
-            "bands_run",
-            "pdos_run",
             "workchain_protocol",
         ]:
-            if key in kwargs:
-                # a temporary solution for the bands_run property
-                if key == "bands_run":
-                    self.properties["bands"].run.value = kwargs[key]
-                elif key == "pdos_run":
-                    self.properties["pdos"].run.value = kwargs[key]
-                else:
-                    getattr(self, key).value = kwargs[key]
+            if key in parameters:
+                getattr(self, key).value = parameters[key]
+        properties = parameters.get("properties", [])
+        for name in self.properties:
+            if name in properties:
+                self.properties[name].run.value = True
+            else:
+                self.properties[name].run.value = False

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -402,11 +402,13 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             pw_code=orm.load_code(pw_code),
             dos_code=orm.load_code(dos_code),
             projwfc_code=orm.load_code(projwfc_code),
-            protocol=parameters["protocol"],
-            relax_type=RelaxType(parameters["relax_type"]),
-            properties=parameters["properties"],
-            spin_type=SpinType(parameters["spin_type"]),
-            electronic_type=ElectronicType(parameters["electronic_type"]),
+            protocol=parameters["workchain_settings"]["protocol"],
+            relax_type=RelaxType(parameters["workchain_settings"]["relax_type"]),
+            properties=parameters["workchain_settings"]["properties"],
+            spin_type=SpinType(parameters["workchain_settings"]["spin_type"]),
+            electronic_type=ElectronicType(
+                parameters["workchain_settings"]["electronic_type"]
+            ),
             overrides=parameters["overrides"],
             initial_magnetic_moments=parameters["initial_magnetic_moments"],
         )
@@ -450,24 +452,24 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         readably represented in the builder, which will be used to the report.
         It is stored in the `extra_report_parameters`.
         """
-        qe_workchain_parameters = self.input_parameters
+        input_parameters = self.input_parameters
 
         # Construct the extra report parameters needed for the report
         extra_report_parameters = {
-            "relax_type": qe_workchain_parameters["relax_type"],
-            "electronic_type": qe_workchain_parameters["electronic_type"],
-            "spin_type": qe_workchain_parameters["spin_type"],
-            "protocol": qe_workchain_parameters["protocol"],
-            "initial_magnetic_moments": qe_workchain_parameters[
-                "initial_magnetic_moments"
+            "relax_type": input_parameters["workchain_settings"]["relax_type"],
+            "electronic_type": input_parameters["workchain_settings"][
+                "electronic_type"
             ],
+            "spin_type": input_parameters["workchain_settings"]["spin_type"],
+            "protocol": input_parameters["workchain_settings"]["protocol"],
+            "initial_magnetic_moments": input_parameters["initial_magnetic_moments"],
         }
 
         # update pseudo family information to extra_report_parameters
-        pseudo_family = qe_workchain_parameters["overrides"]["relax"]["base"][
-            "pseudo_family"
+        pseudo_family = input_parameters["overrides"]["relax"]["base"]["pseudo_family"]
+        pseudo_family = PROTOCOL_PSEUDO_MAP[
+            input_parameters["workchain_settings"]["protocol"]
         ]
-        pseudo_family = PROTOCOL_PSEUDO_MAP[qe_workchain_parameters["protocol"]]
 
         pseudo_family_info = pseudo_family.split("/")
         if pseudo_family_info[0] == "SSSP":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,11 +237,13 @@ def submit_step_widget_generator(
         # Settings
         configure_step.input_structure = generate_structure_data()
         parameters = {
-            "relax_type": relax_type,
-            "spin_type": spin_type,
-            "electronic_type": electronic_type,
-            "properties": ["bands", "pdos"],
-            "protocol": workchain_protocol,
+            "workchain_settings": {
+                "relax_type": relax_type,
+                "spin_type": spin_type,
+                "electronic_type": electronic_type,
+                "properties": ["bands", "pdos"],
+                "protocol": workchain_protocol,
+            }
         }
         configure_step.set_input_parameters(parameters)
         # Advanced settings


### PR DESCRIPTION
The `get_configuration_parameters` method of `ConfigureQeAppWorkChainStep` is hard coded. In principle, it should only need to call the method from sub-settings (plugin's panel). e.g
```
        workchain_settings = self.workchain_settings.get_setting_parameters()
        advanced_settings = self.advanced_settings.get_setting_parameters()
```
Same for the `setting` method.
In this PR, I make this change for the `WorkChainSettings`. Next PR will be the `AdvancedSettings`.