### PR TITLE
add get and set for advanced settings

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -391,12 +391,16 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
 
     def _create_builder(self) -> ProcessBuilderNamespace:
         """Create the builder for the `QeAppWorkChain` submit."""
+        from copy import deepcopy
+
         pw_code = self.pw_code.value
         dos_code = self.dos_code.value
         projwfc_code = self.projwfc_code.value
 
-        parameters = self.input_parameters
-
+        parameters = deepcopy(self.input_parameters)
+        initial_magnetic_moments = parameters["advanced_settings"].pop(
+            "initial_magnetic_moments", None
+        )
         builder = QeAppWorkChain.get_builder_from_protocol(
             structure=self.input_structure,
             pw_code=orm.load_code(pw_code),
@@ -409,8 +413,8 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             electronic_type=ElectronicType(
                 parameters["workchain_settings"]["electronic_type"]
             ),
-            overrides=parameters["overrides"],
-            initial_magnetic_moments=parameters["initial_magnetic_moments"],
+            overrides=parameters["advanced_settings"],
+            initial_magnetic_moments=initial_magnetic_moments,
         )
 
         resources = {
@@ -462,11 +466,13 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             ],
             "spin_type": input_parameters["workchain_settings"]["spin_type"],
             "protocol": input_parameters["workchain_settings"]["protocol"],
-            "initial_magnetic_moments": input_parameters["initial_magnetic_moments"],
+            "initial_magnetic_moments": input_parameters["advanced_settings"][
+                "initial_magnetic_moments"
+            ],
         }
 
         # update pseudo family information to extra_report_parameters
-        pseudo_family = input_parameters["overrides"]["relax"]["base"]["pseudo_family"]
+        pseudo_family = input_parameters["advanced_settings"]["pseudo_family"]
         pseudo_family = PROTOCOL_PSEUDO_MAP[
             input_parameters["workchain_settings"]["protocol"]
         ]

--- a/src/aiidalab_qe/plugins/bands/workchain.py
+++ b/src/aiidalab_qe/plugins/bands/workchain.py
@@ -4,13 +4,23 @@ PwBandsWorkChain = WorkflowFactory("quantumespresso.pw.bands")
 
 
 def get_builder(codes, structure, overrides, protocol, **kwargs):
+    from copy import deepcopy
+
     pw_code = codes.get("pw_code", {})
-    bands_overrides = overrides.get("bands", {})
+    scf_overrides = deepcopy(overrides)
+    bands_overrides = deepcopy(overrides)
+    bands_overrides.pop("kpoints_distance", None)
+    bands_overrides["pw"]["parameters"]["SYSTEM"].pop("smearing", None)
+    bands_overrides["pw"]["parameters"]["SYSTEM"].pop("degauss", None)
+    overrides = {
+        "scf": scf_overrides,
+        "bands": bands_overrides,
+    }
     bands = PwBandsWorkChain.get_builder_from_protocol(
         code=pw_code,
         structure=structure,
         protocol=protocol,
-        overrides=bands_overrides,
+        overrides=overrides,
         **kwargs,
     )
     # pop the inputs that are excluded from the expose_inputs

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -7,15 +7,26 @@ def get_builder(codes, structure, overrides, protocol, **kwargs):
     pw_code = codes.get("pw_code", None)
     dos_code = codes.get("dos_code", None)
     projwfc_code = codes.get("projwfc_code", None)
+    from copy import deepcopy
+
+    pw_code = codes.get("pw_code", {})
+    scf_overrides = deepcopy(overrides)
+    nscf_overrides = deepcopy(overrides)
+    nscf_overrides.pop("kpoints_distance", None)
+    nscf_overrides["pw"]["parameters"]["SYSTEM"].pop("smearing", None)
+    nscf_overrides["pw"]["parameters"]["SYSTEM"].pop("degauss", None)
+    overrides = {
+        "scf": scf_overrides,
+        "nscf": nscf_overrides,
+    }
     if dos_code is not None and projwfc_code is not None:
-        pdos_overrides = overrides.get("pdos", {})
         pdos = PdosWorkChain.get_builder_from_protocol(
             pw_code=pw_code,
             dos_code=dos_code,
             projwfc_code=projwfc_code,
             structure=structure,
             protocol=protocol,
-            overrides=pdos_overrides,
+            overrides=overrides,
             **kwargs,
         )
         # pop the inputs that are exclueded from the expose_inputs

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -136,7 +136,7 @@ class QeAppWorkChain(WorkChain):
         builder.structure = structure
 
         # relax workchain settings
-        relax_overrides = overrides.get("relax", {})
+        relax_overrides = {"base": overrides}
 
         relax = PwRelaxWorkChain.get_builder_from_protocol(
             code=pw_code,


### PR DESCRIPTION
Follow #464 

- add get and set_setting_parameters for `advaced settings`.
- move the logic of getting overrides of `base`, `scf`, `bands` and `scf` to the individual plugin.
- link the `spin_type` and `electronic_type` to the `advanced setting`. Generally, we should only link the `protocol` of the `workchain_settings` to the plugin's setting. However, in the advanced setting, we also need the `spin_type` and `electronice_type`, which we hard-coded. If other plugins also need these values, they should directly access the `self.parent.workchain_settings.spin_type.value`.

