### PR TITLE
fix result tab

### DIFF
--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -73,6 +73,7 @@ class WorkChainViewer(ipw.VBox):
                 continue
             result = entry_point(self.node)
             self.results[identifier] = result
+            self.results[identifier].identifier = identifier
             self.result_tabs.children += (result,)
             self.result_tabs.set_title(len(self.result_tabs.children) - 1, result.title)
 

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -66,13 +66,13 @@ class WorkChainViewer(ipw.VBox):
         # add plugin specific settings
         entries = get_entry_items("aiidalab_qe.properties", "result")
         self.results = {}
-        for name, entry_point in entries.items():
+        for identifier, entry_point in entries.items():
             # only show the result tab if the property is selected to be run
             # this will be repalced by the ui_parameters in the future PR
-            if not builder_parameters.get(f"run_{name}", False):
+            if identifier not in builder_parameters["properties"]:
                 continue
             result = entry_point(self.node)
-            self.results[name] = result
+            self.results[identifier] = result
             self.result_tabs.children += (result,)
             self.result_tabs.set_title(len(self.result_tabs.children) - 1, result.title)
 

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -455,6 +455,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             "initial_magnetic_moments": input_parameters["advanced"][
                 "initial_magnetic_moments"
             ],
+            "properties": input_parameters["workchain"]["properties"],
         }
 
         # update pseudo family information to extra_report_parameters


### PR DESCRIPTION
Check the plugin design by installing a plugin from another repository: https://github.com/superstar54/aiidalab-qe-eos. 
One issue is found: the result panel of eos does not show. This PR fixes it.

Now, we have the first `working` version of the plugin design. Cheers!

## Following work
### mush have
- add more tests, in the old `plugin_ui` PR, the test coverage is around 80%
- rewrite `set_panel_value` for `advanced_settings`, so we can load data from the process. This needs some improvement from sub-widgets.
- add a clear doc for the plugin.

### Nice to have improvement
- add entry_point for step 3, allowing the user to set computer resources for their plugin.
- update the result panel, so that it can combine results from different plugins, e.g. bands and pdos.