### PR TITLE
load_profile explicitly in qe.ipynb

### DIFF
--- a/qe.ipynb
+++ b/qe.ipynb
@@ -34,6 +34,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ipywidgets as ipw\n",
     "from aiidalab_widgets_base.bug_report import (\n",
     "    install_create_github_issue_exception_handler,\n",


### PR DESCRIPTION
It is recommended to call `load_profile` explicitly. After `aiidalab-widgets-base` if not loaded a warning will throw up.