### PR TITLE
Use label in WorkChainSelector

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -383,10 +383,30 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             builder_parameters = self._extract_report_parameters(
                 builder, extra_parameters
             )
+            process.label = self._generate_label()
             process.base.extras.set("builder_parameters", builder_parameters)
             self.process = process
 
         self._update_state()
+
+    def _generate_label(self) -> dict:
+        """Generate a label for the work chain based on the input parameters."""
+        formula = self.input_structure.get_formula()
+        properties = [
+            p for p in self.input_parameters["workchain"]["properties"] if p != "realx"
+        ]
+        relax_type = self.input_parameters["workchain"].get("relax_type")
+        if relax_type != "none":
+            relax_info = "structure is relaxed"
+        else:
+            relax_info = "structure is not relaxed"
+        if not properties:
+            properties_info = ""
+        else:
+            properties_info = f"properties on {', '.join(properties)}"
+
+        label = "{} {} {}".format(formula, relax_info, properties_info)
+        return label
 
     def _create_builder(self) -> ProcessBuilderNamespace:
         """Create the builder for the `QeAppWorkChain` submit."""

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -3,7 +3,6 @@ from dataclasses import make_dataclass
 
 import ipywidgets as ipw
 import traitlets as tl
-from aiida import orm
 from aiida.tools.query.calculation import CalculationQueryBuilder
 
 
@@ -29,9 +28,10 @@ class WorkChainSelector(ipw.HBox):
     # use `None` as setting the widget's value to None will lead to "no selection".
     _NO_PROCESS = object()
 
-    BASE_FMT_WORKCHAIN = "{wc.pk:6}{wc.ctime:>10}\t{wc.state:<16}"
+    BASE_FMT_WORKCHAIN = "{wc.pk:6}{wc.ctime:>10}\t{wc.state:<16}\t{wc.label:<16}"
 
-    BASE_FIELDS = [("pk", int), ("ctime", str), ("state", str)]
+    projections = ["pk", "ctime", "state", "label"]
+    BASE_FIELDS = [("pk", int), ("ctime", str), ("state", str), ("label", str)]
     extra_fields = None
 
     def __init__(self, process_label, **kwargs):
@@ -82,14 +82,13 @@ class WorkChainSelector(ipw.HBox):
             filters=filters,
             order_by={"ctime": "desc"},
         )
-        projections = ["pk", "ctime", "state"]
         projected = builder.get_projected(
             query_set,
-            projections=projections,
+            projections=self.projections,
         )
 
         for result in projected[1:]:
-            process_info = dict(zip(projections, result))
+            process_info = dict(zip(self.projections, result))
 
             if self.extra_fields is not None:
                 pk = process_info["pk"]
@@ -145,43 +144,7 @@ class WorkChainSelector(ipw.HBox):
 
 
 class QeAppWorkChainSelector(WorkChainSelector):
-    extra_fields = [("formula", str), ("relax_info", str), ("properties_info", str)]
+    # extra_fields = [("formula", str), ("relax_info", str), ("properties_info", str)]
 
     def __init__(self, **kwargs):
         super().__init__(process_label="QeAppWorkChain", **kwargs)
-
-    def parse_extra_info(self, pk: int) -> dict:
-        """Parse extra information about the work chain.
-
-        :param pk: the UUID of the work chain to parse
-        :return: the parsed extra information"""
-        workchain = orm.load_node(pk)
-        formula = workchain.inputs.structure.get_formula()
-
-        properties = []
-        if "pdos" in workchain.inputs:
-            properties.append("pdos")
-        if "bands" in workchain.inputs:
-            properties.append("bands")
-
-        if "relax" in workchain.inputs:
-            builder_parameters = workchain.get_extra("builder_parameters", {})
-            relax_type = builder_parameters.get("relax_type")
-
-            if relax_type != "none":
-                relax_info = "structure is relaxed"
-            else:
-                relax_info = "static SCF calculation on structure"
-        else:
-            relax_info = "structure is not relaxed"
-
-        if not properties:
-            properties_info = ""
-        else:
-            properties_info = f"properties on {', '.join(properties)}"
-
-        return {
-            "formula": formula,
-            "relax_info": relax_info,
-            "properties_info": properties_info,
-        }


### PR DESCRIPTION
Related to #455 .

This PR avoids loading nodes in the `WorkChainSelecter`.

On my computer, there are 81 `QeAppWorkChain` processes. 

### Time to refresh the WorkChainSelecter

|   Old   |   This PR   |
|:-------:|:-------:|
|  19 s   |  0.15 s |

### Time to load QeApp

|   Old   |   This PR   |
|:-------:|:-------:|
|  22 s   |  7 s |
