### PR TITLE
Remove hard coded codes from workflow

### DIFF
--- a/src/aiidalab_qe/app/parameters/qeapp.yaml
+++ b/src/aiidalab_qe/app/parameters/qeapp.yaml
@@ -8,9 +8,10 @@ run_bands: false
 run_pdos: false
 
 ## Codes
-dos_code: dos-7.2@localhost
-projwfc_code: projwfc-7.2@localhost
-pw_code: pw-7.2@localhost
+codes:
+    dos: dos-7.2@localhost
+    projwfc: projwfc-7.2@localhost
+    pw: pw-7.2@localhost
 
 ## Material settings
 spin_type: none

--- a/src/aiidalab_qe/plugins/bands/workchain.py
+++ b/src/aiidalab_qe/plugins/bands/workchain.py
@@ -8,7 +8,7 @@ def get_builder(codes, structure, parameters, **kwargs):
     """Get a builder for the PwBandsWorkChain."""
     from copy import deepcopy
 
-    pw_code = codes.get("pw_code", {})
+    pw_code = codes.get("pw", {})
     protocol = parameters["workchain"]["protocol"]
     #
     scf_overrides = deepcopy(parameters["advanced"])

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -7,9 +7,9 @@ PdosWorkChain = WorkflowFactory("quantumespresso.pdos")
 def get_builder(codes, structure, parameters, **kwargs):
     from copy import deepcopy
 
-    pw_code = codes.get("pw_code", None)
-    dos_code = codes.get("dos_code", None)
-    projwfc_code = codes.get("projwfc_code", None)
+    pw_code = codes.get("pw", None)
+    dos_code = codes.get("dos", None)
+    projwfc_code = codes.get("projwfc", None)
     protocol = parameters["workchain"]["protocol"]
     #
     scf_overrides = deepcopy(parameters["advanced"])

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -110,9 +110,6 @@ class QeAppWorkChain(WorkChain):
     def get_builder_from_protocol(
         cls,
         structure,
-        pw_code,
-        dos_code=None,
-        projwfc_code=None,
         parameters=None,
         clean_workdir=False,
         **kwargs,
@@ -122,7 +119,8 @@ class QeAppWorkChain(WorkChain):
 
         parameters = parameters or {}
         properties = parameters["workchain"].pop("properties", [])
-        codes = {"pw_code": pw_code, "dos_code": dos_code, "projwfc_code": projwfc_code}
+        codes = parameters.pop("codes", {})
+        codes = {key: orm.load_node(value) for key, value in codes.items()}
         # update pseudos
         for kind, uuid in parameters["advanced"]["pw"]["pseudos"].items():
             parameters["advanced"]["pw"]["pseudos"][kind] = orm.load_node(uuid)
@@ -134,7 +132,7 @@ class QeAppWorkChain(WorkChain):
         relax_overrides = {"base": parameters["advanced"]}
         protocol = parameters["workchain"]["protocol"]
         relax_builder = PwRelaxWorkChain.get_builder_from_protocol(
-            code=pw_code,
+            code=codes.get("pw"),
             structure=structure,
             protocol=protocol,
             relax_type=RelaxType(parameters["workchain"]["relax_type"]),


### PR DESCRIPTION
The codes (`pw_code`, `dos_code`, `projwfc_code`) are hard coded in the builder, which is not good for the plugin design. This PR uses `get_selected_codes`. 
The `get_resources` method is also used to make the code more modularized.