### PR TITLE
fix override in get_panel_value for advanced

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced.py
@@ -203,25 +203,23 @@ class AdvancedSettings(Panel):
             parameters["pw"]["parameters"]["SYSTEM"][
                 "ecutrho"
             ] = self.pseudo_setter.ecutrho
-        if self.override.value:
+        # if override is not ticked, use the default value
+        parameters["pw"]["parameters"]["SYSTEM"]["tot_charge"] = self.total_charge.value
+        # there are two choose, use link or parent
+        if self.spin_type == "collinear":
+            parameters[
+                "initial_magnetic_moments"
+            ] = self.magnetization.get_magnetization()
+        parameters["kpoints_distance"] = self.value.get("kpoints_distance")
+        if self.electronic_type == "metal":
+            # smearing type setting
             parameters["pw"]["parameters"]["SYSTEM"][
-                "tot_charge"
-            ] = self.total_charge.value
-            # there are two choose, use link or parent
-            if self.spin_type == "collinear":
-                parameters[
-                    "initial_magnetic_moments"
-                ] = self.magnetization.get_magnetization()
-            parameters["kpoints_distance"] = self.value.get("kpoints_distance")
-            if self.electronic_type == "metal":
-                # smearing type setting
-                parameters["pw"]["parameters"]["SYSTEM"][
-                    "smearing"
-                ] = self.smearing.smearing_value
-                # smearing degauss setting
-                parameters["pw"]["parameters"]["SYSTEM"][
-                    "degauss"
-                ] = self.smearing.degauss_value
+                "smearing"
+            ] = self.smearing.smearing_value
+            # smearing degauss setting
+            parameters["pw"]["parameters"]["SYSTEM"][
+                "degauss"
+            ] = self.smearing.degauss_value
 
         return parameters
 


### PR DESCRIPTION
#477 
We should output the values even if the `override` is not selected. In this case, the default values are used. Since the default values are also with `protocol`, so it safe to use them.