### PR TITLE
Reload GUI parameters

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced.py
@@ -257,7 +257,9 @@ class AdvancedSettings(Panel):
                 "tot_charge", 0
             )
         if parameters.get("initial_magnetic_moments"):
-            self.magnetization._set_magnetization_values(**parameters)
+            self.magnetization._set_magnetization_values(
+                parameters.get("initial_magnetic_moments")
+            )
 
     def reset(self):
         """Reset the widget and the traitlets"""
@@ -378,13 +380,17 @@ class MagnetizationSettings(ipw.VBox):
             magnetization[self.input_structure_labels[i]] = self.kinds.children[i].value
         return magnetization
 
-    def _set_magnetization_values(self, **kwargs):
-        """Update used for conftest setting all magnetization to a value"""
+    def _set_magnetization_values(self, magnetic_moments):
+        """Set magnetization"""
         # self.override.value = True
         with self.hold_trait_notifications():
-            if "initial_magnetic_moments" in kwargs:
-                for i in range(len(self.kinds.children)):
-                    self.kinds.children[i].value = kwargs["initial_magnetic_moments"]
+            for i in range(len(self.kinds.children)):
+                if isinstance(magnetic_moments, dict):
+                    self.kinds.children[i].value = magnetic_moments.get(
+                        self.kinds.children[i].description, 0.0
+                    )
+                else:
+                    self.kinds.children[i].value = magnetic_moments
 
 
 class SmearingSettings(ipw.VBox):

--- a/src/aiidalab_qe/app/configuration/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced.py
@@ -234,26 +234,30 @@ class AdvancedSettings(Panel):
         """Set the panel value from the given parameters."""
 
         if "pseudo_family" in parameters:
-            self.pseudo_family_selector.value = parameters.get("pseudo_family")
+            self.pseudo_family_selector.set_from_pseudo_family(
+                parameters.get("pseudo_family")
+            )
         if "pseudos" in parameters["pw"]:
-            cutoffs = {
-                "ecutwfc": parameters["pw"]["parameters"]["SYSTEM"]["ecutwfc"],
-                "ecutrho": parameters["pw"]["parameters"]["SYSTEM"]["ecutrho"],
-            }
-            self.pseudo_setter.set_pseudos(parameters["pw"]["pseudos"], cutoffs)
+            self.pseudo_setter.set_pseudos(parameters["pw"]["pseudos"], {})
+            self.pseudo_setter.ecutwfc_setter.value = parameters["pw"]["parameters"][
+                "SYSTEM"
+            ]["ecutwfc"]
+            self.pseudo_setter.ecutrho_setter.value = parameters["pw"]["parameters"][
+                "SYSTEM"
+            ]["ecutrho"]
         #
         self.kpoints_distance.value = parameters.get("kpoints_distance", 0.15)
         if parameters.get("pw") is not None:
-            self.smearing.degauss_value = parameters["pw"]["parameters"]["SYSTEM"][
-                "degauss"
-            ]
-            self.smearing.smearing_value = parameters["pw"]["parameters"]["SYSTEM"][
-                "smearing"
-            ]
+            system = parameters["pw"]["parameters"]["SYSTEM"]
+            if "degauss" in system:
+                self.smearing.degauss_value = system["degauss"]
+            if "smearing" in system:
+                self.smearing.smearing_value = system["smearing"]
             self.total_charge.value = parameters["pw"]["parameters"]["SYSTEM"].get(
                 "tot_charge", 0
             )
-        self.magnetization._set_magnetization_values(**parameters)
+        if parameters.get("initial_magnetic_moments"):
+            self.magnetization._set_magnetization_values(**parameters)
 
     def reset(self):
         """Reset the widget and the traitlets"""

--- a/src/aiidalab_qe/app/configuration/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced.py
@@ -250,9 +250,9 @@ class AdvancedSettings(Panel):
         if parameters.get("pw") is not None:
             system = parameters["pw"]["parameters"]["SYSTEM"]
             if "degauss" in system:
-                self.smearing.degauss_value = system["degauss"]
+                self.smearing.degauss.value = system["degauss"]
             if "smearing" in system:
-                self.smearing.smearing_value = system["smearing"]
+                self.smearing.smearing.value = system["smearing"]
             self.total_charge.value = parameters["pw"]["parameters"]["SYSTEM"].get(
                 "tot_charge", 0
             )

--- a/src/aiidalab_qe/app/configuration/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/pseudos.py
@@ -192,10 +192,13 @@ class PseudoFamilySelector(ipw.VBox):
 
         with self.hold_trait_notifications():
             # This changes will trigger callbacks
-            family, _, functional, accuracy = pseudo_family.split("/")
-            protocol_selection = f"{family} {accuracy}"
-            self.protocol_selection.value = protocol_selection
-            self.dft_functional.value = functional
+            self.set_from_pseudo_family(pseudo_family)
+
+    def set_from_pseudo_family(self, pseudo_family):
+        family, _, functional, accuracy = pseudo_family.split("/")
+        protocol_selection = f"{family} {accuracy}"
+        self.protocol_selection.value = protocol_selection
+        self.dft_functional.value = functional
 
 
 class PseudoSetter(ipw.VBox):

--- a/src/aiidalab_qe/app/configuration/workflow.py
+++ b/src/aiidalab_qe/app/configuration/workflow.py
@@ -167,10 +167,11 @@ class WorkChainSettings(Panel):
             "relax_type",
             "spin_type",
             "electronic_type",
-            "workchain_protocol",
         ]:
             if key in parameters:
                 getattr(self, key).value = parameters[key]
+        if "protocol" in parameters:
+            self.workchain_protocol.value = parameters["protocol"]
         properties = parameters.get("properties", [])
         for name in self.properties:
             if name in properties:

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -149,10 +149,11 @@ class App(ipw.VBox):
                     self.configure_step.state = WizardAppWidgetStep.State.SUCCESS
                     self.submit_step.process = process
             # set ui_parameters
-            ui_parameters = deserialize_unsafe(
-                process.base.extras.get("ui_parameters", "")
-            )
-            self.configure_step.set_configuration_parameters(ui_parameters)
-            self.configure_step.state = self.configure_step.State.SUCCESS
-            self.submit_step.set_submission_parameters(ui_parameters)
-            self.submit_step.state = self.submit_step.State.SUCCESS
+            # print out error message if yaml format ui_parameters is not reachable
+            ui_parameters = process.base.extras.get("ui_parameters", {})
+            if ui_parameters and isinstance(ui_parameters, str):
+                ui_parameters = deserialize_unsafe(ui_parameters)
+                self.configure_step.set_configuration_parameters(ui_parameters)
+                self.configure_step.state = self.configure_step.State.SUCCESS
+                self.submit_step.set_submission_parameters(ui_parameters)
+                self.submit_step.state = self.submit_step.State.SUCCESS

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -98,18 +98,20 @@ class App(ipw.VBox):
         )
 
         # Add process selection header
-        work_chain_selector = QeAppWorkChainSelector(layout=ipw.Layout(width="auto"))
-        work_chain_selector.observe(self._observe_process_selection, "value")
+        self.work_chain_selector = QeAppWorkChainSelector(
+            layout=ipw.Layout(width="auto")
+        )
+        self.work_chain_selector.observe(self._observe_process_selection, "value")
 
         ipw.dlink(
             (self.submit_step, "process"),
-            (work_chain_selector, "value"),
+            (self.work_chain_selector, "value"),
             transform=lambda node: None if node is None else node.pk,
         )
 
         super().__init__(
             children=[
-                work_chain_selector,
+                self.work_chain_selector,
                 self._wizard_app_widget,
             ]
         )

--- a/src/aiidalab_qe/app/result/summary_viewer.py
+++ b/src/aiidalab_qe/app/result/summary_viewer.py
@@ -41,7 +41,9 @@ def generate_report_parameters(qeapp_wc):
 
     Return a dictionary of the parameters.
     """
-    ui_parameters = qeapp_wc.base.extras.get("ui_parameters", {})
+    from aiida.orm.utils.serialize import deserialize_unsafe
+
+    ui_parameters = deserialize_unsafe(qeapp_wc.base.extras.get("ui_parameters", ""))
     # Construct the report parameters needed for the report
     report = {
         "relaxed": ui_parameters["workchain"]["relax_type"],

--- a/src/aiidalab_qe/app/result/summary_viewer.py
+++ b/src/aiidalab_qe/app/result/summary_viewer.py
@@ -47,6 +47,9 @@ def generate_report_parameters(qeapp_wc):
     if isinstance(ui_parameters, str):
         ui_parameters = deserialize_unsafe(ui_parameters)
     # Construct the report parameters needed for the report
+    # drop support for old ui parameters
+    if "workchain" not in ui_parameters:
+        return {}
     report = {
         "relaxed": ui_parameters["workchain"]["relax_type"],
         "relax_method": ui_parameters["workchain"]["relax_type"],

--- a/src/aiidalab_qe/app/result/summary_viewer.py
+++ b/src/aiidalab_qe/app/result/summary_viewer.py
@@ -43,7 +43,9 @@ def generate_report_parameters(qeapp_wc):
     """
     from aiida.orm.utils.serialize import deserialize_unsafe
 
-    ui_parameters = deserialize_unsafe(qeapp_wc.base.extras.get("ui_parameters", ""))
+    ui_parameters = qeapp_wc.base.extras.get("ui_parameters", {})
+    if isinstance(ui_parameters, str):
+        ui_parameters = deserialize_unsafe(ui_parameters)
     # Construct the report parameters needed for the report
     report = {
         "relaxed": ui_parameters["workchain"]["relax_type"],

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -73,7 +73,10 @@ class WorkChainViewer(ipw.VBox):
         for identifier, entry_point in entries.items():
             # only show the result tab if the property is selected to be run
             # this will be repalced by the ui_parameters in the future PR
-            if identifier not in ui_parameters["workchain"]["properties"]:
+            # if this is the old version without plugin specific ui_parameters, just skip
+            if identifier not in ui_parameters.get("workchain", {}).get(
+                "properties", []
+            ):
                 continue
             result = entry_point(self.node)
             self.results[identifier] = result

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -9,6 +9,7 @@ import traitlets as tl
 from aiida import orm
 from aiida.cmdline.utils.common import get_workchain_report
 from aiida.common import LinkType
+from aiida.orm.utils.serialize import deserialize_unsafe
 from aiidalab_widgets_base import ProcessMonitor, register_viewer_widget
 from aiidalab_widgets_base.viewers import StructureDataViewer
 from filelock import FileLock, Timeout
@@ -34,7 +35,7 @@ class WorkChainViewer(ipw.VBox):
 
         self.node = node
         # this will be replaced by "ui_parameters" in the future PR
-        ui_parameters = node.base.extras.get("ui_parameters", {})
+        ui_parameters = deserialize_unsafe(node.base.extras.get("ui_parameters", ""))
 
         self.title = ipw.HTML(
             f"""

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -34,8 +34,11 @@ class WorkChainViewer(ipw.VBox):
             return
 
         self.node = node
-        # this will be replaced by "ui_parameters" in the future PR
-        ui_parameters = deserialize_unsafe(node.base.extras.get("ui_parameters", ""))
+        # In the new version of the plugin, the ui_parameters are stored as a yaml string
+        # which is then converted to a dictionary
+        ui_parameters = node.base.extras.get("ui_parameters", {})
+        if isinstance(ui_parameters, str):
+            ui_parameters = deserialize_unsafe(ui_parameters)
 
         self.title = ipw.HTML(
             f"""

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -346,18 +346,10 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
 
     @tl.observe("process")
     def _observe_process(self, change):
-        from aiida.orm.utils.serialize import deserialize_unsafe
-
         with self.hold_trait_notifications():
             process_node = change["new"]
             if process_node is not None:
                 self.input_structure = process_node.inputs.structure
-                ui_parameters = deserialize_unsafe(
-                    process_node.base.extras.get("ui_parameters", None)
-                )
-                if ui_parameters is not None:
-                    self.set_selected_codes(ui_parameters["codes"])
-                    self.set_resources(ui_parameters["resources"])
             self._update_state()
 
     def _on_submit_button_clicked(self, _):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,21 +280,6 @@ def workchain_settings_generator():
 
 
 @pytest.fixture()
-def initial_magnetic_moments_generator(generate_structure_data):
-    """Retturn a function that generatates a initial_magnetic_moments dictionary"""
-    from aiidalab_qe.app.configuration.advanced import MagnetizationSettings
-
-    def _initial_moments_generator(**kwargs):
-        initial_magnetic_moments = MagnetizationSettings()
-        initial_magnetic_moments.input_structure = generate_structure_data()
-        initial_magnetic_moments.update_kinds_widget()
-        initial_magnetic_moments._set_magnetization_values(**kwargs)
-        return initial_magnetic_moments
-
-    return _initial_moments_generator
-
-
-@pytest.fixture()
 def smearing_settings_generator():
     """Return a function that generates a smearing settings dictionary."""
     from aiidalab_qe.app.configuration.advanced import SmearingSettings
@@ -338,7 +323,6 @@ def submit_app_generator(
     generate_structure_data,
     workchain_settings_generator,
     smearing_settings_generator,
-    initial_magnetic_moments_generator,
 ):
     """Return a function that generates a submit step widget."""
 
@@ -371,10 +355,8 @@ def submit_app_generator(
         configure_step.advanced_settings.override.value = True
         configure_step.advanced_settings.total_charge.value = tot_charge
         configure_step.advanced_settings.kpoints_distance.value = kpoints_distance
-        configure_step.advanced_settings.magnetization = (
-            initial_magnetic_moments_generator(
-                initial_magnetic_moments=initial_magnetic_moments
-            )
+        configure_step.advanced_settings.magnetization._set_magnetization_values(
+            initial_magnetic_moments
         )
         # mimic the behavior of the smearing widget set up
         configure_step.advanced_settings.smearing.smearing.value = smearing
@@ -624,7 +606,7 @@ def generate_qeapp_workchain(
         s2.workchain_settings.workchain_protocol.value = "fast"
         s2.workchain_settings.spin_type.value = spin_type
         s2.advanced_settings.magnetization._set_magnetization_values(
-            **{"initial_magnetic_moments": initial_magnetic_moments}
+            initial_magnetic_moments
         )
         s2.confirm()
         # step 3 setup code and resources

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -593,6 +593,8 @@ def generate_qeapp_workchain(
     ):
         from copy import deepcopy
 
+        from aiida.orm.utils.serialize import serialize
+
         from aiidalab_qe.workflows import QeAppWorkChain
 
         # Step 1: select structure from example
@@ -670,9 +672,9 @@ def generate_qeapp_workchain(
             wkchain.out("band_structure", bands.node.outputs.band_structure)
             wkchain.out("band_parameters", bands.node.outputs.band_parameters)
         wkchain.update_outputs()
-        # set
+        # set ui_parameters
         qeapp_node = wkchain.node
-        qeapp_node.base.extras.set("ui_parameters", s3.ui_parameters)
+        qeapp_node.base.extras.set("ui_parameters", serialize(s3.ui_parameters))
         return wkchain
 
     return _generate_qeapp_workchain

--- a/tests/test_app_reload.py
+++ b/tests/test_app_reload.py
@@ -1,0 +1,13 @@
+def test_reload(submit_app_generator, generate_qeapp_workchain):
+    """Test if the GUI paramters can be reload properly"""
+    wkchain = generate_qeapp_workchain(
+        relax_type="positions", run_bands=True, run_pdos=False, spin_type="collinear"
+    )
+    app = submit_app_generator()
+    # select the pk
+    app.work_chain_selector.value = wkchain.node.pk
+    # check if the value are reload correctly
+    assert app.configure_step.workchain_settings.relax_type.value == "positions"
+    assert app.configure_step.workchain_settings.spin_type.value == "collinear"
+    assert app.configure_step.workchain_settings.properties["bands"].run.value is True
+    assert app.configure_step.workchain_settings.properties["pdos"].run.value is False

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -16,11 +16,24 @@ def test_get_configuration_parameters():
 
     wg = ConfigureQeAppWorkChainStep()
     parameters = wg.get_configuration_parameters()
+    print("parameters:", parameters)
     parameters_ref = {
         "workchain": wg.workchain_settings.get_panel_value(),
         "advanced": wg.advanced_settings.get_panel_value(),
     }
     assert parameters == parameters_ref
+
+
+def test_set_configuration_parameters(submit_app_generator):
+    from aiidalab_qe.app.configuration import ConfigureQeAppWorkChainStep
+
+    wg = ConfigureQeAppWorkChainStep()
+    parameters = wg.get_configuration_parameters()
+    parameters["workchain"]["relax_type"] = "positions"
+    parameters["advanced"]["pseudo_family"] = "SSSP/1.2/PBE/efficiency"
+    wg.set_configuration_parameters(parameters)
+    new_parameters = wg.get_configuration_parameters()
+    assert parameters == new_parameters
 
 
 def test_panel():

--- a/tests/test_submit_qe_workchain.py
+++ b/tests/test_submit_qe_workchain.py
@@ -8,7 +8,7 @@ def test_reload_selected_code(submit_app_generator):
     submit_step._create_builder()
 
     new_submit_step = SubmitQeAppWorkChainStep(qe_auto_setup=False)
-    new_submit_step.set_selected_codes(parameters=submit_step.ui_parameters)
+    new_submit_step.set_selected_codes(submit_step.ui_parameters["codes"])
 
     assert new_submit_step.pw_code.value == submit_step.pw_code.value
     assert new_submit_step.dos_code.value == submit_step.dos_code.value


### PR DESCRIPTION
This PR allows the QeApp to reload GUI parameters when the user selects a process.

- use `aiida.orm.utils.serialize.serialize` to serialize the GUI parameters as yaml, then save it as an extra of the process node. Then load it using the `deserialize_unsafe` method.
- fix set_panel_value for the `advanced_settings`.
- add unit test for reloading the app.