### PR TITLE
Feature/kill button - adding the kill button on top of NodeTree 

### DIFF
--- a/src/aiidalab_qe/app/result/__init__.py
+++ b/src/aiidalab_qe/app/result/__init__.py
@@ -41,22 +41,22 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
             ],
         )
         ipw.dlink((self, "process"), (self.process_monitor, "value"))
-        
+
         self.kill_work_chains_button = ipw.Button(
             description="Kill workchain",
             tooltip="Kill the below workchain.",
             button_style="danger",
             icon="window-close",
             disabled=True,
-            layout=ipw.Layout(width="120px",height="40px",display="none"),
+            layout=ipw.Layout(width="120px", height="40px", display="none"),
         )
         self.kill_work_chains_button.on_click(self._on_click_kill_work_chain)
         self.kill_work_chains_box = ipw.HBox(
             children=[self.kill_work_chains_button],
-            layout=ipw.Layout(justify_content="flex-end")
-            )
+            layout=ipw.Layout(justify_content="flex-end"),
+        )
 
-        super().__init__([self.kill_work_chains_box,self.process_status], **kwargs)
+        super().__init__([self.kill_work_chains_box, self.process_status], **kwargs)
 
     def can_reset(self):
         "Do not allow reset while process is running."
@@ -89,7 +89,7 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
             elif process.is_finished_ok:
                 self.state = self.State.SUCCESS
                 self.kill_work_chains_button.disabled = True
-                
+
     def _on_click_kill_work_chain(self, _=None):
         workchain = [orm.load_node(self.process)]
         control.kill_processes(workchain)

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -86,7 +86,9 @@ class WorkChainSelector(ipw.HBox):
         ipw.dlink(
             (self, "value"),
             (self.kill_work_chains_button, "disabled"),
-            lambda workchain: orm.load_node(workchain).is_terminated if isinstance(workchain, int) else True,
+            lambda workchain: orm.load_node(workchain).is_terminated
+            if isinstance(workchain, int)
+            else True,
         )
         self.kill_work_chains_button.on_click(self._on_click_kill_work_chain)
 
@@ -144,7 +146,6 @@ class WorkChainSelector(ipw.HBox):
             child.disabled = change["new"]
 
     def refresh_work_chains(self, _=None):
-        
         try:
             self.set_trait("busy", True)  # disables the widget
 
@@ -164,9 +165,12 @@ class WorkChainSelector(ipw.HBox):
                 self.work_chains_selector.value = original_value
         finally:
             self.set_trait("busy", False)  # reenable the widget
-            
-        self.kill_work_chains_button.disabled = orm.load_node(self.value).is_terminated if isinstance(self.value, int) else True
 
+        self.kill_work_chains_button.disabled = (
+            orm.load_node(self.value).is_terminated
+            if isinstance(self.value, int)
+            else True
+        )
 
     def _on_click_new_work_chain(self, _=None):
         self.refresh_work_chains()

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -152,7 +152,6 @@ class WorkChainSelector(ipw.HBox):
         self.refresh_work_chains()
         self.work_chains_selector.value = self._NO_PROCESS
 
-
     @tl.observe("value")
     def _observe_value(self, change):
         if change["old"] == change["new"]:

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -80,15 +80,8 @@ class WorkChainSelector(ipw.HBox):
             tooltip="Kill the selected workflow",
             button_style="danger",
             icon="window-close",
-            disabled=False,
+            disabled=True,
             layout=ipw.Layout(width="auto"),
-        )
-        ipw.dlink(
-            (self, "value"),
-            (self.kill_work_chains_button, "disabled"),
-            lambda workchain: orm.load_node(workchain).is_terminated
-            if isinstance(workchain, int)
-            else True,
         )
         self.kill_work_chains_button.on_click(self._on_click_kill_work_chain)
 
@@ -104,6 +97,9 @@ class WorkChainSelector(ipw.HBox):
         )
 
         self.refresh_work_chains()
+        #the following is needed to disable the button.
+        self.kill_work_chains_button.disabled = True
+
 
     def parse_extra_info(self, pk: int) -> dict:
         """Parse extra information about the work chain."""
@@ -166,12 +162,7 @@ class WorkChainSelector(ipw.HBox):
         finally:
             self.set_trait("busy", False)  # reenable the widget
 
-        self.kill_work_chains_button.disabled = (
-            orm.load_node(self.value).is_terminated
-            if isinstance(self.value, int)
-            else True
-        )
-
+        
     def _on_click_new_work_chain(self, _=None):
         self.refresh_work_chains()
         self.work_chains_selector.value = self._NO_PROCESS
@@ -190,6 +181,14 @@ class WorkChainSelector(ipw.HBox):
 
         if new not in {pk for _, pk in self.work_chains_selector.options}:
             self.refresh_work_chains()
+            
+        if hasattr(self,"kill_work_chains_button"):
+            #when the app is loaded the first time, the button is not there so it excepts.
+            self.kill_work_chains_button.disabled = (
+            orm.load_node(self.value).is_terminated
+            if isinstance(self.value, int)
+            else True
+        )
 
         self.work_chains_selector.value = new
 

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -4,7 +4,6 @@ from dataclasses import make_dataclass
 import ipywidgets as ipw
 import traitlets as tl
 from aiida import orm
-from aiida.engine.processes import control
 from aiida.tools.query.calculation import CalculationQueryBuilder
 
 
@@ -75,30 +74,18 @@ class WorkChainSelector(ipw.HBox):
         )
         self.refresh_work_chains_button.on_click(self.refresh_work_chains)
 
-        self.kill_work_chains_button = ipw.Button(
-            description="Kill",
-            tooltip="Kill the selected workflow",
-            button_style="danger",
-            icon="window-close",
-            disabled=True,
-            layout=ipw.Layout(width="auto"),
-        )
-        self.kill_work_chains_button.on_click(self._on_click_kill_work_chain)
-
         super().__init__(
             children=[
                 self.work_chains_prompt,
                 self.work_chains_selector,
                 self.new_work_chains_button,
                 self.refresh_work_chains_button,
-                self.kill_work_chains_button,
             ],
             **kwargs,
         )
 
         self.refresh_work_chains()
         # the following is needed to disable the button.
-        self.kill_work_chains_button.disabled = True
 
     def parse_extra_info(self, pk: int) -> dict:
         """Parse extra information about the work chain."""
@@ -165,10 +152,6 @@ class WorkChainSelector(ipw.HBox):
         self.refresh_work_chains()
         self.work_chains_selector.value = self._NO_PROCESS
 
-    def _on_click_kill_work_chain(self, _=None):
-        processes = [orm.load_node(self.work_chains_selector.value)]
-        control.kill_processes(processes)
-        self.refresh_work_chains()
 
     @tl.observe("value")
     def _observe_value(self, change):
@@ -179,14 +162,6 @@ class WorkChainSelector(ipw.HBox):
 
         if new not in {pk for _, pk in self.work_chains_selector.options}:
             self.refresh_work_chains()
-
-        if hasattr(self, "kill_work_chains_button"):
-            # when the app is loaded the first time, the button is not there so it excepts.
-            self.kill_work_chains_button.disabled = (
-                orm.load_node(self.value).is_terminated
-                if isinstance(self.value, int)
-                else True
-            )
 
         self.work_chains_selector.value = new
 

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -3,7 +3,6 @@ from dataclasses import make_dataclass
 
 import ipywidgets as ipw
 import traitlets as tl
-from aiida import orm
 from aiida.tools.query.calculation import CalculationQueryBuilder
 
 

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -97,9 +97,8 @@ class WorkChainSelector(ipw.HBox):
         )
 
         self.refresh_work_chains()
-        #the following is needed to disable the button.
+        # the following is needed to disable the button.
         self.kill_work_chains_button.disabled = True
-
 
     def parse_extra_info(self, pk: int) -> dict:
         """Parse extra information about the work chain."""
@@ -162,7 +161,6 @@ class WorkChainSelector(ipw.HBox):
         finally:
             self.set_trait("busy", False)  # reenable the widget
 
-        
     def _on_click_new_work_chain(self, _=None):
         self.refresh_work_chains()
         self.work_chains_selector.value = self._NO_PROCESS
@@ -181,14 +179,14 @@ class WorkChainSelector(ipw.HBox):
 
         if new not in {pk for _, pk in self.work_chains_selector.options}:
             self.refresh_work_chains()
-            
-        if hasattr(self,"kill_work_chains_button"):
-            #when the app is loaded the first time, the button is not there so it excepts.
+
+        if hasattr(self, "kill_work_chains_button"):
+            # when the app is loaded the first time, the button is not there so it excepts.
             self.kill_work_chains_button.disabled = (
-            orm.load_node(self.value).is_terminated
-            if isinstance(self.value, int)
-            else True
-        )
+                orm.load_node(self.value).is_terminated
+                if isinstance(self.value, int)
+                else True
+            )
 
         self.work_chains_selector.value = new
 

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -72,6 +72,15 @@ class WorkChainSelector(ipw.HBox):
             layout=ipw.Layout(width="auto"),
         )
         self.refresh_work_chains_button.on_click(self.refresh_work_chains)
+        
+        self.kill_work_chains_button = ipw.Button(
+            description="Kill",
+            tooltip="Kill the selected workflow",
+            button_style="danger",
+            icon="window-close",
+            layout=ipw.Layout(width="auto"),
+        )
+        #self.refresh_work_chains_button.on_click(self.refresh_work_chains)
 
         super().__init__(
             children=[
@@ -79,6 +88,7 @@ class WorkChainSelector(ipw.HBox):
                 self.work_chains_selector,
                 self.new_work_chains_button,
                 self.refresh_work_chains_button,
+                self.kill_work_chains_button,
             ],
             **kwargs,
         )

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -3,9 +3,10 @@ from dataclasses import make_dataclass
 
 import ipywidgets as ipw
 import traitlets as tl
-from aiida.tools.query.calculation import CalculationQueryBuilder
-from aiida.engine.processes import control
 from aiida import orm
+from aiida.engine.processes import control
+from aiida.tools.query.calculation import CalculationQueryBuilder
+
 
 class WorkChainSelector(ipw.HBox):
     """A widget to select a WorkChainNode of a given process label.
@@ -73,7 +74,7 @@ class WorkChainSelector(ipw.HBox):
             layout=ipw.Layout(width="auto"),
         )
         self.refresh_work_chains_button.on_click(self.refresh_work_chains)
-        
+
         self.kill_work_chains_button = ipw.Button(
             description="Kill",
             tooltip="Kill the selected workflow",
@@ -170,7 +171,7 @@ class WorkChainSelector(ipw.HBox):
     def _on_click_new_work_chain(self, _=None):
         self.refresh_work_chains()
         self.work_chains_selector.value = self._NO_PROCESS
-        
+
     def _on_click_kill_work_chain(self, _=None):
         processes = [orm.load_node(self.work_chains_selector.value)]
         control.kill_processes(processes)

--- a/src/aiidalab_qe/common/process.py
+++ b/src/aiidalab_qe/common/process.py
@@ -4,7 +4,8 @@ from dataclasses import make_dataclass
 import ipywidgets as ipw
 import traitlets as tl
 from aiida.tools.query.calculation import CalculationQueryBuilder
-
+from aiida.engine.processes import control
+from aiida import orm
 
 class WorkChainSelector(ipw.HBox):
     """A widget to select a WorkChainNode of a given process label.
@@ -80,7 +81,7 @@ class WorkChainSelector(ipw.HBox):
             icon="window-close",
             layout=ipw.Layout(width="auto"),
         )
-        #self.refresh_work_chains_button.on_click(self.refresh_work_chains)
+        self.kill_work_chains_button.on_click(self._on_click_kill_work_chain)
 
         super().__init__(
             children=[
@@ -159,6 +160,12 @@ class WorkChainSelector(ipw.HBox):
     def _on_click_new_work_chain(self, _=None):
         self.refresh_work_chains()
         self.work_chains_selector.value = self._NO_PROCESS
+        
+    def _on_click_kill_work_chain(self, _=None):
+        if isinstance(self.work_chains_selector.value, int):
+            self.refresh_work_chains()
+            processes = [orm.load_node(self.work_chains_selector.value)]
+            control.kill_processes(processes)
 
     @tl.observe("value")
     def _observe_value(self, change):


### PR DESCRIPTION
Fixes #161 

adding the kill button to support live-killing of a workchain, just selecting it from the list and clicking on the button. 