### PR TITLE
Fix/remove workchain output

### DIFF
--- a/src/aiidalab_qe/app/result/electronic_structure.py
+++ b/src/aiidalab_qe/app/result/electronic_structure.py
@@ -18,13 +18,15 @@ def export_data(work_chain_node, group_dos_by="atom"):
 
 
 def export_pdos_data(work_chain_node, group_dos_by="atom"):
-    if "dos" in work_chain_node.outputs:
-        _, energy_dos, _ = work_chain_node.outputs.dos.get_x()
-        tdos_values = {f"{n}": v for n, v, _ in work_chain_node.outputs.dos.get_y()}
+    if "pdos" in work_chain_node.outputs:
+        _, energy_dos, _ = work_chain_node.outputs.pdos.dos.output_dos.get_x()
+        tdos_values = {
+            f"{n}": v for n, v, _ in work_chain_node.outputs.pdos.dos.output_dos.get_y()
+        }
 
         dos = []
 
-        if "projections" in work_chain_node.outputs:
+        if "projections" in work_chain_node.outputs.pdos.projwfc:
             # The total dos parsed
             tdos = {
                 "label": "Total DOS",
@@ -38,7 +40,7 @@ def export_pdos_data(work_chain_node, group_dos_by="atom"):
             dos.append(tdos)
 
             dos += _projections_curated(
-                work_chain_node.outputs.projections,
+                work_chain_node.outputs.pdos.projwfc.projections,
                 group_dos_by=group_dos_by,
                 spin_type="none",
             )
@@ -67,21 +69,23 @@ def export_pdos_data(work_chain_node, group_dos_by="atom"):
 
             # spin-up (↑)
             dos += _projections_curated(
-                work_chain_node.outputs.projections_up,
+                work_chain_node.outputs.pdos.projwfc.projections_up,
                 group_dos_by=group_dos_by,
                 spin_type="up",
             )
 
             # spin-dn (↓)
             dos += _projections_curated(
-                work_chain_node.outputs.projections_down,
+                work_chain_node.outputs.pdos.projwfc.projections_down,
                 group_dos_by=group_dos_by,
                 spin_type="down",
                 line_style="dash",
             )
 
         data_dict = {
-            "fermi_energy": work_chain_node.outputs.nscf_parameters["fermi_energy"],
+            "fermi_energy": work_chain_node.outputs.pdos.nscf.output_parameters[
+                "fermi_energy"
+            ],
             "dos": dos,
         }
 
@@ -92,15 +96,16 @@ def export_pdos_data(work_chain_node, group_dos_by="atom"):
 
 
 def export_bands_data(work_chain_node, fermi_energy=None):
-    if "band_structure" in work_chain_node.outputs:
+    if "bands" in work_chain_node.outputs:
         data = json.loads(
-            work_chain_node.outputs.band_structure._exportcontent(
+            work_chain_node.outputs.bands.band_structure._exportcontent(
                 "json", comments=False
             )[0]
         )
         # The fermi energy from band calculation is not robust.
         data["fermi_level"] = (
-            fermi_energy or work_chain_node.outputs.band_parameters["fermi_energy"]
+            fermi_energy
+            or work_chain_node.outputs.bands.band_parameters["fermi_energy"]
         )
         return [
             jsanitize(data),

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -129,7 +129,7 @@ class WorkChainViewer(ipw.VBox):
                 self._results_shown.add("structure")
 
             if "electronic_structure" not in self._results_shown and (
-                "band_structure" in self.node.outputs or "dos" in self.node.outputs
+                "bands" in self.node.outputs or "pdos" in self.node.outputs
             ):
                 self._show_electronic_structure()
                 self._results_shown.add("electronic_structure")

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -90,20 +90,12 @@ class QeAppWorkChain(WorkChain):
             ),
             cls.run_plugin,
             cls.inspect_plugin,
-            cls.results
         )
         spec.exit_code(401, 'ERROR_SUB_PROCESS_FAILED_RELAX',
                        message='The PwRelaxWorkChain sub process failed')
         spec.exit_code(402, 'ERROR_SUB_PROCESS_FAILED_PDOS',
                        message='The PdosWorkChain sub process failed')
         spec.output('structure', valid_type=StructureData, required=False)
-        spec.output('band_parameters', valid_type=orm.Dict, required=False)
-        spec.output('band_structure', valid_type=BandsData, required=False)
-        spec.output('nscf_parameters', valid_type=orm.Dict, required=False)
-        spec.output('dos', valid_type=XyData, required=False)
-        spec.output('projections', valid_type=Orbital, required=False)
-        spec.output('projections_up', valid_type=Orbital, required=False)
-        spec.output('projections_down', valid_type=Orbital, required=False)
         # yapf: enable
 
     @classmethod
@@ -254,30 +246,6 @@ class QeAppWorkChain(WorkChain):
                     workchain, entry_point["workchain"], namespace=name
                 )
             )
-
-    def results(self):
-        """Add the results to the outputs."""
-        if "bands" in self.ctx:
-            self.out("band_parameters", self.ctx.bands.outputs.band_parameters)
-            self.out("band_structure", self.ctx.bands.outputs.band_structure)
-
-        if "pdos" in self.ctx:
-            self.out(
-                "nscf_parameters",
-                self.ctx.pdos.outputs.nscf.output_parameters,
-            )
-            self.out("dos", self.ctx.pdos.outputs.dos.output_dos)
-            if "projections_up" in self.ctx.pdos.outputs.projwfc:
-                self.out(
-                    "projections_up",
-                    self.ctx.pdos.outputs.projwfc.projections_up,
-                )
-                self.out(
-                    "projections_down",
-                    self.ctx.pdos.outputs.projwfc.projections_down,
-                )
-            else:
-                self.out("projections", self.ctx.pdos.outputs.projwfc.projections)
 
     def on_terminated(self):
         """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -630,19 +630,6 @@ def generate_qeapp_workchain(
             wkchain.out_many(
                 wkchain.exposed_outputs(pdos.node, PdosWorkChain, namespace="pdos")
             )
-            wkchain.out("nscf_parameters", pdos.node.outputs.nscf.output_parameters)
-            wkchain.out("dos", pdos.node.outputs.dos.output_dos)
-            if "projections_up" in pdos.node.outputs.projwfc:
-                wkchain.out(
-                    "projections_up",
-                    pdos.node.outputs.projwfc.projections_up,
-                )
-                wkchain.out(
-                    "projections_down",
-                    pdos.node.outputs.projwfc.projections_down,
-                )
-            else:
-                wkchain.out("projections", pdos.node.outputs.projwfc.projections)
         if run_bands:
             from aiida_quantumespresso.workflows.pw.bands import PwBandsWorkChain
 
@@ -650,8 +637,6 @@ def generate_qeapp_workchain(
             wkchain.out_many(
                 wkchain.exposed_outputs(bands.node, PwBandsWorkChain, namespace="bands")
             )
-            wkchain.out("band_structure", bands.node.outputs.band_structure)
-            wkchain.out("band_parameters", bands.node.outputs.band_parameters)
         wkchain.update_outputs()
         # set ui_parameters
         qeapp_node = wkchain.node


### PR DESCRIPTION
Fix #390 

The electronic structure panel is still hardcoded because it needs the results from both bands and pdos plugins. When we find a good solution to support results from multiple plugin, we can remove both the code in the electronic structure result and the code in the workchain.

For the moment, we remove the code in the workchain, but still hardcoded the electronic structure result panel.