### PR TITLE
not reset steps when  select a new structure

### DIFF
--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -21,7 +21,6 @@ class App(ipw.VBox):
     def __init__(self, qe_auto_setup=True):
         # Create the application steps
         self.structure_step = StructureSelectionStep(auto_advance=True)
-        self.structure_step.observe(self._observe_structure_selection, "structure")
         self.configure_step = ConfigureQeAppWorkChainStep(auto_advance=True)
         self.submit_step = SubmitQeAppWorkChainStep(
             auto_advance=True, qe_auto_setup=qe_auto_setup
@@ -84,15 +83,6 @@ class App(ipw.VBox):
                 self._wizard_app_widget,
             ]
         )
-
-    # Reset all subsequent steps in case that a new structure is selected
-    def _observe_structure_selection(self, change):
-        with self.structure_step.hold_sync():
-            if (
-                self.structure_step.confirmed_structure is not None
-                and self.structure_step.confirmed_structure != change["new"]
-            ):
-                self._wizard_app_widget.reset()
 
     def _observe_process_selection(self, change):
         from aiida.orm.utils.serialize import deserialize_unsafe

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -71,12 +71,6 @@ class App(ipw.VBox):
         )
         self.work_chain_selector.observe(self._observe_process_selection, "value")
 
-        ipw.dlink(
-            (self.submit_step, "process"),
-            (self.work_chain_selector, "value"),
-            transform=lambda node: None if node is None else node.pk,
-        )
-
         super().__init__(
             children=[
                 self.work_chain_selector,

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -71,6 +71,12 @@ class App(ipw.VBox):
         )
         self.work_chain_selector.observe(self._observe_process_selection, "value")
 
+        ipw.dlink(
+            (self.submit_step, "process"),
+            (self.work_chain_selector, "value"),
+            transform=lambda node: None if node is None else node.pk,
+        )
+
         super().__init__(
             children=[
                 self.work_chain_selector,

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -376,7 +376,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             process.base.extras.set("ui_parameters", serialize(self.ui_parameters))
             self.process = process
 
-        self.state = self.State.SUCCESS
+        self._update_state()
 
     def _generate_label(self) -> dict:
         """Generate a label for the work chain based on the input parameters."""

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -376,7 +376,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             process.base.extras.set("ui_parameters", serialize(self.ui_parameters))
             self.process = process
 
-        self._update_state()
+        self.state = self.State.SUCCESS
 
     def _generate_label(self) -> dict:
         """Generate a label for the work chain based on the input parameters."""


### PR DESCRIPTION
Fix #527  

This bug is caused by the loop between traitlets. 
- the first loop. When selecting a new structure, it will reset all steps. This will reset the structure again.
- the second loop. When resetting the process of the submit_step, it will change the value of the workchain selector to `None`, which will reset all steps again.