### PR TITLE
Pre-install app by aiidalab install

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ on:
             - .github/actions/load-image/action.yml
 
             - src/**
+            - docker/**
             - qe.ipynb
             - setup.cfg
             - pyproject.toml
@@ -40,6 +41,7 @@ on:
             - .github/actions/load-image/action.yml
 
             - src/**
+            - docker/**
             - qe.ipynb
             - setup.cfg
             - pyproject.toml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM base-image
 
-
 # Copy whole repo and pre-install the dependencies and app to the tmp folder.
 # In the before notebook scripts the app will be re-installed by moving it to the app folder.
 ENV PREINSTALL_APP_FOLDER ${CONDA_DIR}/aiidalab-qe
@@ -12,7 +11,8 @@ USER ${NB_USER}
 RUN cd ${PREINSTALL_APP_FOLDER} && \
      # Remove all untracked files and directories. For example the setup lock flag file.
      git clean -fx && \
-     pip install . --no-cache-dir && \
+     # It is important to install from `aiidalab install` to mimic the same installation operation from the app store.
+     aiidalab install --yes --python "/opt/conda/bin/python" "quantum-espresso@file://${PREINSTALL_APP_FOLDER}" && \
      fix-permissions "${CONDA_DIR}" && \
      fix-permissions "/home/${NB_USER}"
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+import setuptools
+
+setuptools.setup()


### PR DESCRIPTION
The pre-installation of the app is through run `aiidalab install` from local folder, instead of using `pip install`, this mimics the installation operation from AppStore and prevents issue such as after removing `setup.py` the dependencies are not found.
I'll keep this as draft without adding `setup.py` back and after the new docker stack release with new `aiidalab/aiidalab`, the test should pass.

- The first commit should success because I add the `setup.py` back.
- The second commit is again remove `setup.py`.