### PR TITLE
Adding dynamic visualization of codes using block layout

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -308,10 +308,10 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         with self.hold_trait_notifications():
             self.submit_button.disabled = change["new"] != self.State.CONFIGURED
 
-    @tl.observe("previous_step_state")
+    @tl.observe("previous_step_state", "input_parameters")
     def _observe_input_structure(self, _):
         self._update_state()
-        self.udpate_codes_visibility()
+        self.update_codes_display()
 
     @tl.observe("process")
     def _observe_process(self, change):
@@ -348,18 +348,18 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             for name, code in self.codes.items():
                 code.value = _get_code_uuid(codes.get(name))
 
-    def udpate_codes_visibility(self):
+    def update_codes_display(self):
         """Hide code if no related property is selected."""
         # hide all codes except pw
         for name, code in self.codes.items():
             if name == "pw":
                 continue
-            code.layout.visibility = "hidden"
+            code.layout.display = "none"
         properties = self.input_parameters.get("workchain", {}).get("properties", [])
         # show the code if the related property is selected.
         for identifer in properties:
             for code in self.code_entries.get(identifer, {}).values():
-                code.layout.visibility = "visible"
+                code.layout.display = "block"
 
     def submit(self, _=None):
         """Submit the work chain with the current inputs."""

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -20,18 +20,18 @@ def test_set_selected_codes(submit_app_generator):
     assert new_submit_step.get_selected_codes() == submit_step.get_selected_codes()
 
 
-def test_udpate_codes_visibility():
-    """Test udpate_codes_visibility method.
+def test_update_codes_display():
+    """Test update_codes_visibility method.
     If the workchain property is not selected, the related code should be hidden.
     """
     from aiidalab_qe.app.submission import SubmitQeAppWorkChainStep
 
     submit = SubmitQeAppWorkChainStep(qe_auto_setup=False)
-    submit.udpate_codes_visibility()
-    assert submit.codes["dos"].layout.visibility == "hidden"
+    submit.update_codes_display()
+    assert submit.codes["dos"].layout.display == "none"
     submit.input_parameters = {"workchain": {"properties": ["pdos"]}}
-    submit.udpate_codes_visibility()
-    assert submit.codes["dos"].layout.visibility == "visible"
+    submit.update_codes_display()
+    assert submit.codes["dos"].layout.display == "block"
 
 
 def test_identify_submission_blockers(app):


### PR DESCRIPTION
This PR enables the possibility to dynamically show codes in step 3, even if something is changed in step 2 after the confirmation. If you confirm again with a different set of properties, now the shown code is updated, at variance with before.
Moreover, codes that are not shown will not occupy blank space in the app, instead, they are now in the main branch. I achieved this using display instead of visibility.