### PR TITLE
Feature/result multiple plugins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ aiidalab_qe.app.structure.examples = *
 aiidalab_qe.properties =
     bands = aiidalab_qe.plugins.bands:bands
     pdos = aiidalab_qe.plugins.pdos:pdos
+    electronic_structure = aiidalab_qe.plugins.electronic_structure:electronic_structure
 
 [aiidalab]
 title = Quantum ESPRESSO

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -108,9 +108,9 @@ class WorkChainViewer(ipw.VBox):
             ):
                 self._show_structure()
                 self.result_tabs.children += (self.structure_tab,)
-                self.result_tabs.set_title(
-                    len(self.result_tabs.children) - 1, "Final Geometry"
-                )
+                # index of the last tab
+                index = len(self.result_tabs.children) - 1
+                self.result_tabs.set_title(index, "Final Geometry")
                 self._results_shown.add("structure")
 
             # update the plugin specific results
@@ -121,14 +121,14 @@ class WorkChainViewer(ipw.VBox):
                     results_ready = [
                         label in self.node.outputs for label in result.workchain_labels
                     ]
-                    if False not in results_ready:
+                    if all(results_ready):
                         result._update_view()
                         self._results_shown.add(result.identifier)
                         # add this plugin result panel
                         self.result_tabs.children += (result,)
-                        self.result_tabs.set_title(
-                            len(self.result_tabs.children) - 1, result.title
-                        )
+                        # index of the last tab
+                        index = len(self.result_tabs.children) - 1
+                        self.result_tabs.set_title(index, result.title)
 
     def _show_structure(self):
         """Show the structure of the workchain."""

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -15,12 +15,10 @@ from aiidalab_widgets_base.viewers import StructureDataViewer
 from filelock import FileLock, Timeout
 from IPython.display import HTML, display
 from jinja2 import Environment
-from widget_bandsplot import BandsPlotWidget
 
 from aiidalab_qe.app import static
 from aiidalab_qe.app.utils import get_entry_items
 
-from .electronic_structure import export_data
 from .summary_viewer import SummaryView
 
 
@@ -55,34 +53,18 @@ class WorkChainViewer(ipw.VBox):
             [ipw.Label("Structure not available.")],
             layout=ipw.Layout(min_height="380px"),
         )
-        self.bands_tab = ipw.VBox(
-            [ipw.Label("Electronic Structure not available.")],
-            layout=ipw.Layout(min_height="380px"),
-        )
-        self.result_tabs = ipw.Tab(
-            children=[self.summary_tab, self.structure_tab, self.bands_tab]
-        )
+        self.result_tabs = ipw.Tab(children=[self.summary_tab])
 
         self.result_tabs.set_title(0, "Workflow Summary")
-        self.result_tabs.set_title(1, "Final Geometry (n/a)")
-        self.result_tabs.set_title(2, "Electronic Structure (n/a)")
 
         # add plugin specific settings
         entries = get_entry_items("aiidalab_qe.properties", "result")
         self.results = {}
         for identifier, entry_point in entries.items():
-            # only show the result tab if the property is selected to be run
-            # this will be repalced by the ui_parameters in the future PR
-            # if this is the old version without plugin specific ui_parameters, just skip
-            if identifier not in ui_parameters.get("workchain", {}).get(
-                "properties", []
-            ):
-                continue
+            # all the plugins result panels are added to the results dictionary
             result = entry_point(self.node)
             self.results[identifier] = result
             self.results[identifier].identifier = identifier
-            self.result_tabs.children += (result,)
-            self.result_tabs.set_title(len(self.result_tabs.children) - 1, result.title)
 
         # An ugly fix to the structure appearance problem
         # https://github.com/aiidalab/aiidalab-qe/issues/69
@@ -90,13 +72,13 @@ class WorkChainViewer(ipw.VBox):
             index = change["new"]
             # Accessing the viewer only if the corresponding tab is present.
             if self.result_tabs._titles[str(index)] == "Final Geometry":
-                self._structure_view._viewer.handle_resize()
+                self.structure_tab._viewer.handle_resize()
 
                 def toggle_camera():
                     """Toggle camera between perspective and orthographic."""
-                    self._structure_view._viewer.camera = (
+                    self.structure_tab._viewer.camera = (
                         "perspective"
-                        if self._structure_view._viewer.camera == "orthographic"
+                        if self.structure_tab._viewer.camera == "orthographic"
                         else "orthographic"
                     )
 
@@ -127,83 +109,30 @@ class WorkChainViewer(ipw.VBox):
             ):
                 self._show_structure()
                 self._results_shown.add("structure")
+                self.result_tabs.children += (self.structure_tab,)
+                self.result_tabs.set_title(
+                    len(self.result_tabs.children) - 1, "Final Geometry"
+                )
 
-            if "electronic_structure" not in self._results_shown and (
-                "bands" in self.node.outputs or "pdos" in self.node.outputs
-            ):
-                self._show_electronic_structure()
-                self._results_shown.add("electronic_structure")
             # update the plugin specific results
-            for result in self.result_tabs.children[3:]:
+            for result in self.results.values():
                 # check if the result is already shown
                 # check if the plugin workchain result is in the outputs
-                if (
-                    result.identifier not in self._results_shown
-                    and result.identifier in self.node.outputs
-                ):
-                    result._update_view()
-                    self._results_shown.add(result.identifier)
+                if result.identifier not in self._results_shown:
+                    results_ready = [
+                        label in self.node.outputs for label in result.workchain_labels
+                    ]
+                    if False not in results_ready:
+                        result._update_view()
+                        self._results_shown.add(result.identifier)
+                        # if the result is present in the workchain, the result will be added to the tab
+                        self.result_tabs.children += (result,)
+                        self.result_tabs.set_title(
+                            len(self.result_tabs.children) - 1, result.title
+                        )
 
     def _show_structure(self):
-        self._structure_view = StructureDataViewer(
-            structure=self.node.outputs.structure
-        )
-        self.result_tabs.children[1].children = [self._structure_view]
-        self.result_tabs.set_title(1, "Final Geometry")
-
-    def _show_electronic_structure(self):
-        group_dos_by = ipw.ToggleButtons(
-            options=[
-                ("Atom", "atom"),
-                ("Orbital", "angular"),
-            ],
-            value="atom",
-        )
-        settings = ipw.VBox(
-            children=[
-                ipw.HBox(
-                    children=[
-                        ipw.Label(
-                            "DOS grouped by:",
-                            layout=ipw.Layout(
-                                justify_content="flex-start", width="120px"
-                            ),
-                        ),
-                        group_dos_by,
-                    ]
-                ),
-            ],
-            layout={"margin": "0 0 30px 30px"},
-        )
-        #
-        data = export_data(self.node, group_dos_by=group_dos_by.value)
-        bands_data = data.get("bands", None)
-        dos_data = data.get("dos", None)
-        _bands_plot_view = BandsPlotWidget(
-            bands=bands_data,
-            dos=dos_data,
-        )
-
-        def response(change):
-            data = export_data(self.node, group_dos_by=group_dos_by.value)
-            bands_data = data.get("bands", None)
-            dos_data = data.get("dos", None)
-            _bands_plot_view = BandsPlotWidget(
-                bands=bands_data,
-                dos=dos_data,
-            )
-            self.result_tabs.children[2].children = [
-                settings,
-                _bands_plot_view,
-            ]
-
-        group_dos_by.observe(response, names="value")
-        # update the electronic structure tab
-        self.result_tabs.children[2].children = [
-            settings,
-            _bands_plot_view,
-        ]
-        self.result_tabs.set_title(2, "Electronic Structure")
+        self.structure_tab = StructureDataViewer(structure=self.node.outputs.structure)
 
     def _show_workflow_output(self):
         self.workflows_output = WorkChainOutputs(self.node)

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -308,7 +308,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         with self.hold_trait_notifications():
             self.submit_button.disabled = change["new"] != self.State.CONFIGURED
 
-    @tl.observe("previous_step_state","input_parameters")
+    @tl.observe("previous_step_state", "input_parameters")
     def _observe_input_structure(self, _):
         self._update_state()
         self.update_codes_display()

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -308,7 +308,7 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
         with self.hold_trait_notifications():
             self.submit_button.disabled = change["new"] != self.State.CONFIGURED
 
-    @tl.observe("previous_step_state", "input_parameters")
+    @tl.observe("previous_step_state","input_parameters")
     def _observe_input_structure(self, _):
         self._update_state()
         self.update_codes_display()

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -99,6 +99,7 @@ class ResultPanel(Panel):
     """
 
     title = "Result"
+    # to specify which plugins (outputs) are needed for this result panel.
     workchain_labels = []
 
     def __init__(self, node=None, **kwargs):

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -124,20 +124,3 @@ class ResultPanel(Panel):
 
         :param result: the result of the calculation.
         """
-
-
-class CodePanel(Panel):
-    title = "Code"
-    description = "pw.x"
-    default_calc_job_plugin = "quantumespresso.pw"
-
-    def __init__(self, **kwargs):
-        from aiidalab_widgets_base import ComputationalResourcesWidget
-
-        # Checkbox to see if the property should be calculated
-        self.code = ComputationalResourcesWidget(
-            description=self.description,
-            default_calc_job_plugin=self.default_calc_job_plugin,
-        )
-        self.children = [self.code]
-        super().__init__(**kwargs)

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -124,3 +124,20 @@ class ResultPanel(Panel):
 
         :param result: the result of the calculation.
         """
+
+
+class CodePanel(Panel):
+    title = "Code"
+    description = "pw.x"
+    default_calc_job_plugin = "quantumespresso.pw"
+
+    def __init__(self, **kwargs):
+        from aiidalab_widgets_base import ComputationalResourcesWidget
+
+        # Checkbox to see if the property should be calculated
+        self.code = ComputationalResourcesWidget(
+            description=self.description,
+            default_calc_job_plugin=self.default_calc_job_plugin,
+        )
+        self.children = [self.code]
+        super().__init__(**kwargs)

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -99,6 +99,7 @@ class ResultPanel(Panel):
     """
 
     title = "Result"
+    workchain_labels = []
 
     def __init__(self, node=None, **kwargs):
         self.node = node
@@ -116,7 +117,7 @@ class ResultPanel(Panel):
         if self.node is None:
             return None
 
-        return getattr(self.node.outputs, self.identifier)
+        return self.node.outputs
 
     def _update_view(self):
         """Update the result in the panel.

--- a/src/aiidalab_qe/plugins/bands/result.py
+++ b/src/aiidalab_qe/plugins/bands/result.py
@@ -29,14 +29,15 @@ class Result(ResultPanel):
     """Result panel for the bands calculation."""
 
     title = "Bands"
+    workchain_labels = ["bands"]
 
     def __init__(self, node=None, **kwargs):
-        super().__init__(node=node, identifier="bands", **kwargs)
+        super().__init__(node=node, **kwargs)
 
     def _update_view(self):
         from widget_bandsplot import BandsPlotWidget
 
-        bands_data = export_bands_data(self.outputs)
+        bands_data = export_bands_data(self.outputs.bands)
         _bands_plot_view = BandsPlotWidget(
             bands=bands_data,
         )

--- a/src/aiidalab_qe/plugins/electronic_structure/__init__.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/__init__.py
@@ -1,0 +1,5 @@
+from .result import Result
+
+electronic_structure = {
+    "result": Result,
+}

--- a/src/aiidalab_qe/plugins/electronic_structure/result.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/result.py
@@ -216,27 +216,16 @@ class Result(ResultPanel):
         super().__init__(node=node, **kwargs)
 
     def _observe_group_dos_by(self, change):
-        data = export_data(self.node, group_dos_by=change["new"])
-        bands_data = data.get("bands", None)
-        dos_data = data.get("dos", None)
-        _bands_plot_view = BandsPlotWidget(
-            bands=bands_data,
-            dos=dos_data,
-        )
-        self.children = [
-            self.settings,
-            _bands_plot_view,
-        ]
+        """Update the view of the widget when the group_dos_by value changes."""
+        self._update_view()
 
     def _update_view(self):
         """Update the view of the widget."""
         #
         data = export_data(self.node, group_dos_by=self.group_dos_by.value)
-        bands_data = data.get("bands", None)
-        dos_data = data.get("dos", None)
         _bands_plot_view = BandsPlotWidget(
-            bands=bands_data,
-            dos=dos_data,
+            bands=data.get("bands", None),
+            dos=data.get("dos", None),
         )
         # update the electronic structure tab
         self.children = [

--- a/src/aiidalab_qe/plugins/electronic_structure/result.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/result.py
@@ -5,6 +5,7 @@ import random
 import ipywidgets as ipw
 from aiida import orm
 from monty.json import jsanitize
+from widget_bandsplot import BandsPlotWidget
 
 from aiidalab_qe.common.panel import ResultPanel
 
@@ -193,60 +194,52 @@ class Result(ResultPanel):
     workchain_labels = ["bands", "pdos"]
 
     def __init__(self, node=None, **kwargs):
-        super().__init__(node=node, **kwargs)
-
-    def _update_view(self):
-        """Update the view of the widget."""
-        from widget_bandsplot import BandsPlotWidget
-
-        group_dos_by = ipw.ToggleButtons(
+        self.dos_group_label = ipw.Label(
+            "DOS grouped by:",
+            layout=ipw.Layout(justify_content="flex-start", width="120px"),
+        )
+        self.group_dos_by = ipw.ToggleButtons(
             options=[
                 ("Atom", "atom"),
                 ("Orbital", "angular"),
             ],
             value="atom",
         )
-        settings = ipw.VBox(
+        self.settings = ipw.HBox(
             children=[
-                ipw.HBox(
-                    children=[
-                        ipw.Label(
-                            "DOS grouped by:",
-                            layout=ipw.Layout(
-                                justify_content="flex-start", width="120px"
-                            ),
-                        ),
-                        group_dos_by,
-                    ]
-                ),
+                self.dos_group_label,
+                self.group_dos_by,
             ],
             layout={"margin": "0 0 30px 30px"},
         )
-        #
-        data = export_data(self.node, group_dos_by=group_dos_by.value)
+        self.group_dos_by.observe(self._observe_group_dos_by, names="value")
+        super().__init__(node=node, **kwargs)
+
+    def _observe_group_dos_by(self, change):
+        data = export_data(self.node, group_dos_by=change["new"])
         bands_data = data.get("bands", None)
         dos_data = data.get("dos", None)
         _bands_plot_view = BandsPlotWidget(
             bands=bands_data,
             dos=dos_data,
         )
+        self.children = [
+            self.settings,
+            _bands_plot_view,
+        ]
 
-        def response(change):
-            data = export_data(self.node, group_dos_by=group_dos_by.value)
-            bands_data = data.get("bands", None)
-            dos_data = data.get("dos", None)
-            _bands_plot_view = BandsPlotWidget(
-                bands=bands_data,
-                dos=dos_data,
-            )
-            self.children = [
-                settings,
-                _bands_plot_view,
-            ]
-
-        group_dos_by.observe(response, names="value")
+    def _update_view(self):
+        """Update the view of the widget."""
+        #
+        data = export_data(self.node, group_dos_by=self.group_dos_by.value)
+        bands_data = data.get("bands", None)
+        dos_data = data.get("dos", None)
+        _bands_plot_view = BandsPlotWidget(
+            bands=bands_data,
+            dos=dos_data,
+        )
         # update the electronic structure tab
         self.children = [
-            settings,
+            self.settings,
             _bands_plot_view,
         ]

--- a/src/aiidalab_qe/plugins/pdos/result.py
+++ b/src/aiidalab_qe/plugins/pdos/result.py
@@ -158,9 +158,10 @@ def export_pdos_data(outputs, group_dos_by="atom"):
 
 class Result(ResultPanel):
     title = "PDOS"
+    workchain_labels = ["pdos"]
 
     def __init__(self, node=None, **kwargs):
-        super().__init__(node=node, identifier="pdos", **kwargs)
+        super().__init__(node=node, **kwargs)
 
     def _update_view(self):
         """Update the view of the widget."""
@@ -190,13 +191,15 @@ class Result(ResultPanel):
             layout={"margin": "0 0 30px 30px"},
         )
         #
-        dos_data = export_pdos_data(self.outputs, group_dos_by=group_dos_by.value)
+        dos_data = export_pdos_data(self.outputs.pdos, group_dos_by=group_dos_by.value)
         _bands_plot_view = BandsPlotWidget(
             dos=dos_data,
         )
 
         def response(change):
-            dos_data = export_pdos_data(self.outputs, group_dos_by=group_dos_by.value)
+            dos_data = export_pdos_data(
+                self.outputs.pdos, group_dos_by=group_dos_by.value
+            )
             _bands_plot_view = BandsPlotWidget(
                 dos=dos_data,
             )

--- a/tests/test_plugins_bands.py
+++ b/tests/test_plugins_bands.py
@@ -8,7 +8,6 @@ def test_result(generate_qeapp_workchain):
     assert data is not None
     # generate structure for scf calculation
     result = Result(wkchain.node)
-    assert result.identifier == "bands"
     result._update_view()
     assert isinstance(result.children[0], BandsPlotWidget)
 

--- a/tests/test_plugins_electronic_structure.py
+++ b/tests/test_plugins_electronic_structure.py
@@ -1,5 +1,5 @@
 def test_electronic_structure(generate_qeapp_workchain):
-    """test the report can be properly generated from the builder without errors"""
+    """Test the electronic structure tab."""
     from aiida import engine
 
     from aiidalab_qe.app.result.workchain_viewer import WorkChainViewer
@@ -9,10 +9,12 @@ def test_electronic_structure(generate_qeapp_workchain):
     wkchain.node.set_process_state(engine.ProcessState.FINISHED)
     wcv = WorkChainViewer(wkchain.node)
     # find the tab with the identifier "electronic_structure"
+    # the built-in summary and structure tabs is not a plugin panel,
+    # thus don't have identifiers
     tab = [
         tab
         for tab in wcv.result_tabs.children
-        if tab.identifier == "electronic_structure"
+        if getattr(tab, "identifier", "") == "electronic_structure"
     ][0]
-    # check the content of the tab
-    assert "DOS grouped by:" == tab.children[0].children[0].value
+    # It should have two children: settings and the _bands_plot_view
+    assert len(tab.children) == 2

--- a/tests/test_plugins_electronic_structure.py
+++ b/tests/test_plugins_electronic_structure.py
@@ -1,0 +1,18 @@
+def test_electronic_structure(generate_qeapp_workchain):
+    """test the report can be properly generated from the builder without errors"""
+    from aiida import engine
+
+    from aiidalab_qe.app.result.workchain_viewer import WorkChainViewer
+
+    wkchain = generate_qeapp_workchain()
+    wkchain.node.set_exit_status(0)
+    wkchain.node.set_process_state(engine.ProcessState.FINISHED)
+    wcv = WorkChainViewer(wkchain.node)
+    # find the tab with the identifier "electronic_structure"
+    tab = [
+        tab
+        for tab in wcv.result_tabs.children[2:]
+        if tab.identifier == "electronic_structure"
+    ][0]
+    # check the content of the tab
+    assert "DOS grouped by:" == tab.children[0].children[0].children[0].value

--- a/tests/test_plugins_electronic_structure.py
+++ b/tests/test_plugins_electronic_structure.py
@@ -11,8 +11,8 @@ def test_electronic_structure(generate_qeapp_workchain):
     # find the tab with the identifier "electronic_structure"
     tab = [
         tab
-        for tab in wcv.result_tabs.children[2:]
+        for tab in wcv.result_tabs.children
         if tab.identifier == "electronic_structure"
     ][0]
     # check the content of the tab
-    assert "DOS grouped by:" == tab.children[0].children[0].children[0].value
+    assert "DOS grouped by:" == tab.children[0].children[0].value

--- a/tests/test_plugins_pdos.py
+++ b/tests/test_plugins_pdos.py
@@ -6,7 +6,6 @@ def test_result(generate_qeapp_workchain):
     assert data is not None
     # generate structure for scf calculation
     result = Result(node=wkchain.node)
-    assert result.identifier == "pdos"
     result._update_view()
     assert len(result.children) == 2
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -16,23 +16,6 @@ def test_workchainview(generate_qeapp_workchain):
     assert len(wcv.result_tabs.children) == 5
     assert wcv.result_tabs._titles["0"] == "Workflow Summary"
     assert wcv.result_tabs._titles["1"] == "Final Geometry"
-    assert wcv.result_tabs._titles["2"] == "Electronic Structure"
-
-
-def test_electronic_structure(generate_qeapp_workchain):
-    """test the report can be properly generated from the builder without errors"""
-    from aiida import engine
-
-    from aiidalab_qe.app.result.workchain_viewer import WorkChainViewer
-
-    wkchain = generate_qeapp_workchain()
-    wkchain.node.set_exit_status(0)
-    wkchain.node.set_process_state(engine.ProcessState.FINISHED)
-    wcv = WorkChainViewer(wkchain.node)
-    assert (
-        "DOS grouped by:"
-        == wcv.result_tabs.children[2].children[0].children[0].children[0].value
-    )
 
 
 def test_summary_report(data_regression, generate_qeapp_workchain):


### PR DESCRIPTION
Rebase PR #522 to main, supports
- showing the result from multiple plugins.
- only shows the result panel when it is available.

One can use the workchain_labels to specify which plugins (outputs) are needed for this result panel. For example, the `electronic_structure` result panel needs `pdos` and `bands`.
```python
class Result(ResultPanel):
    title = "Electronic Structure"
    workchain_labels = ["bands", "pdos"]
```

