### PR TITLE
Register plugin node viewer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_qe
-version = 23.10.0b2
+version = 23.11.0rc0
 description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -71,7 +71,7 @@ ignore =
     E203
 
 [bumpver]
-current_version = "v23.10.0b2"
+current_version = "v23.11.0rc0"
 version_pattern = "v0Y.0M.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -22,7 +22,7 @@ from aiidalab_qe.app.utils import get_entry_items
 from .summary_viewer import SummaryView
 
 
-@register_viewer_widget("process.workflow.workchain.WorkChainNode.")
+@register_viewer_widget("aiidalab_qe.workflows.QeAppWorkChain")
 class WorkChainViewer(ipw.VBox):
     _results_shown = tl.Set()
 

--- a/src/aiidalab_qe/plugins/bands/result.py
+++ b/src/aiidalab_qe/plugins/bands/result.py
@@ -2,22 +2,27 @@
 
 """
 
+from aiidalab_widgets_base import register_viewer_widget
 
 from aiidalab_qe.common.panel import ResultPanel
 
 
-def export_bands_data(outputs, fermi_energy=None):
+def export_bands_data(work_chain_node, fermi_energy=None):
     """Export the bands data from the outputs of the calculation."""
     import json
 
     from monty.json import jsanitize
 
-    if "band_structure" in outputs:
+    if "band_structure" in work_chain_node.outputs:
         data = json.loads(
-            outputs.band_structure._exportcontent("json", comments=False)[0]
+            work_chain_node.outputs.band_structure._exportcontent(
+                "json", comments=False
+            )[0]
         )
         # The fermi energy from band calculation is not robust.
-        data["fermi_level"] = fermi_energy or outputs.band_parameters["fermi_energy"]
+        data["fermi_level"] = (
+            fermi_energy or work_chain_node.outputs.band_parameters["fermi_energy"]
+        )
         return [
             jsanitize(data),
         ]
@@ -25,6 +30,7 @@ def export_bands_data(outputs, fermi_energy=None):
         return None
 
 
+@register_viewer_widget("aiida.workflows:quantumespresso.pw.bands")
 class Result(ResultPanel):
     """Result panel for the bands calculation."""
 
@@ -33,11 +39,24 @@ class Result(ResultPanel):
 
     def __init__(self, node=None, **kwargs):
         super().__init__(node=node, **kwargs)
+        self.workchain_nodes = {}
+        if node.process_type == "aiida.workflows:quantumespresso.pw.bands":
+            self.workchain_nodes["bands"] = node
+        elif node.process_type == "aiidalab_qe.workflows.QeAppWorkChain":
+            if "bands" in node.base.links.get_outgoing().all_link_labels():
+                self.workchain_nodes[
+                    "bands"
+                ] = node.base.links.get_outgoing().get_node_by_label("bands")
+            else:
+                self.workchain_nodes["bands"] = None
+        self._update_view()
 
     def _update_view(self):
         from widget_bandsplot import BandsPlotWidget
 
-        bands_data = export_bands_data(self.outputs.bands)
+        if self.workchain_nodes["bands"] is None:
+            return
+        bands_data = export_bands_data(self.workchain_nodes["bands"])
         _bands_plot_view = BandsPlotWidget(
             bands=bands_data,
         )

--- a/src/aiidalab_qe/version.py
+++ b/src/aiidalab_qe/version.py
@@ -3,4 +3,4 @@
 
 """This module contains project version information for both the app and the workflow."""
 
-__version__ = "v23.10.0b2"
+__version__ = "v23.11.0rc0"


### PR DESCRIPTION
This PR allows the result panel (as an AiiDA node viewer) for the plugin to show when the user selects the plugin's workchain process in the node tree. 

Blocked by [aiidalab/aiidalab-widgets-base/issues/540](https://github.com/aiidalab/aiidalab-widgets-base/issues/540)

Here is an example: I selected the `Pdos` plugin process, which will trigger the plugin's result panel.

![Screenshot from 2023-11-20 14-47-00](https://github.com/aiidalab/aiidalab-qe/assets/11457659/06cba99e-85bb-4ffa-a848-a7fd950d4dd0)
