### PR TITLE
Store already added node viewer and load it when needed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_qe
-version = 23.10.0b2
+version = 23.11.0rc0
 description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -71,7 +71,7 @@ ignore =
     E203
 
 [bumpver]
-current_version = "v23.10.0b2"
+current_version = "v23.11.0rc0"
 version_pattern = "v0Y.0M.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/src/aiidalab_qe/app/result/__init__.py
+++ b/src/aiidalab_qe/app/result/__init__.py
@@ -4,7 +4,6 @@ from aiida import orm
 from aiida.engine import ProcessState
 from aiida.engine.processes import control
 from aiidalab_widgets_base import (
-    AiidaNodeViewWidget,
     ProcessMonitor,
     ProcessNodesTreeWidget,
     WizardAppWidgetStep,
@@ -23,14 +22,10 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
             (self, "process"),
             (self.process_tree, "value"),
         )
-
-        self.node_view = AiidaNodeViewWidget(layout={"width": "auto", "height": "auto"})
-        ipw.dlink(
-            (self.process_tree, "selected_nodes"),
-            (self.node_view, "node"),
-            transform=lambda nodes: nodes[0] if nodes else None,
-        )
-        self.process_status = ipw.VBox(children=[self.process_tree, self.node_view])
+        self.process_tree.observe(self._update_node_view, names="selected_nodes")
+        # keep track of the node views
+        self.node_views = {}
+        self.process_status = ipw.VBox(children=[self.process_tree])
 
         # Setup process monitor
         self.process_monitor = ProcessMonitor(
@@ -115,3 +110,20 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
         # as the self.state is updated in the _update_state method.
         self._update_state()
         self._update_kill_button_layout()
+
+    def _update_node_view(self, change):
+        """Callback for when the a new node is selected."""
+        from aiidalab_widgets_base.viewers import viewer
+
+        nodes = change["new"]
+        if not nodes:
+            return
+        # only show the first selected node
+        node = nodes[0]
+        # check if the viewer is already added
+        if node.uuid in self.node_views:
+            node_view = self.node_views[node.uuid]
+        else:
+            node_view = viewer(node)
+            self.node_views[node.uuid] = node_view
+        self.process_status.children = [self.process_tree, node_view]

--- a/src/aiidalab_qe/version.py
+++ b/src/aiidalab_qe/version.py
@@ -3,4 +3,4 @@
 
 """This module contains project version information for both the app and the workflow."""
 
-__version__ = "v23.10.0b2"
+__version__ = "v23.11.0rc0"


### PR DESCRIPTION
In aiidalab-widgets-base/viewer.py, it creates a new `viewer` every time we select a new AiiDA node, and the viewer is not saved in the app, so we can not reuse it later. This has two drawbacks:
- The performance is back. user needs to wait every time when selecting a new node.
- One can not call the viewer later, e.g., for `reset`.

This PR stores the already added viewer and reuses it later.