### PR TITLE
Show result panel immediately when available. 

### DIFF
--- a/docs/source/development/plugin.rst
+++ b/docs/source/development/plugin.rst
@@ -119,8 +119,8 @@ In this widget, you need to:
 - specify the `workchain_labels` to tell the app which workchains the panel is intended for.
 - implement the ``_update_view`` method to tell the app how to show the results of the workchain.
 
-The output of the workchain will be stored in ``self.outputs.plugin_name``.
-For example, you can access the ``output_parameters`` output of the ``EOSWorkChain`` by ``self.outputs.eos.output_parameters``.
+The workchains specified in the `workchain_labels` will be stored in ``self.workchain_nodes`` attribute.
+For example, you can access the ``output_parameters`` output of the ``EOSWorkChain`` by ``self.workchain_nodes['eos'].outputs.output_parameters``.
 
 .. code-block:: python
 
@@ -147,7 +147,7 @@ For example, you can access the ``output_parameters`` output of the ``EOSWorkCha
             g.layout.xaxis.title = "Volume (A^3)"
             g.layout.yaxis.title = "Energy (eV)"
             # get the output parameters
-            eos = self.outputs.eos.output_parameters.get_dict()
+            eos = self.workchain_nodes['eos'].outputs.output_parameters.get_dict()
             volumes = eos["volumes"]
             energies = eos["energies"]
             eos = EquationOfState(volumes, energies, eos="birchmurnaghan")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_qe
-version = 23.10.0b2
+version = 23.11.0rc0
 description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -71,7 +71,7 @@ ignore =
     E203
 
 [bumpver]
-current_version = "v23.10.0b2"
+current_version = "v23.11.0rc0"
 version_pattern = "v0Y.0M.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -117,10 +117,20 @@ class WorkChainViewer(ipw.VBox):
             for result in self.results.values():
                 # check if the result is already shown
                 if result.identifier not in self._results_shown:
-                    # check if the all required results are in the outputs
-                    results_ready = [
-                        label in self.node.outputs for label in result.workchain_labels
+                    # get all required workchain nodes
+                    plugin_workchain_nodes = [
+                        link.node
+                        for link in self.node.base.links.get_outgoing().all()
+                        if link.link_label in result.workchain_labels
                     ]
+                    # if any of the workchains required has not started yet
+                    if len(plugin_workchain_nodes) < len(result.workchain_labels):
+                        continue
+                    results_ready = [
+                        node.process_state.value == "finished"
+                        for node in plugin_workchain_nodes
+                    ]
+                    # if all the workchains required have finished
                     if all(results_ready):
                         result._update_view()
                         self._results_shown.add(result.identifier)

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -120,6 +120,19 @@ class ResultPanel(Panel):
 
         return self.node.outputs
 
+    @property
+    def workchain_nodes(self):
+        """Workchain nodes of the calculation."""
+        workchain_nodes = {}
+        links = self.node.base.links.get_outgoing()
+        all_link_labels = links.all_link_labels()
+        for label in self.workchain_labels:
+            if label in all_link_labels:
+                workchain_nodes[label] = links.get_node_by_label(label)
+            else:
+                workchain_nodes[label] = None
+        return workchain_nodes
+
     def _update_view(self):
         """Update the result in the panel.
 

--- a/src/aiidalab_qe/plugins/bands/result.py
+++ b/src/aiidalab_qe/plugins/bands/result.py
@@ -37,7 +37,9 @@ class Result(ResultPanel):
     def _update_view(self):
         from widget_bandsplot import BandsPlotWidget
 
-        bands_data = export_bands_data(self.outputs.bands)
+        if self.workchain_nodes["bands"] is None:
+            return
+        bands_data = export_bands_data(self.workchain_nodes["bands"].outputs)
         _bands_plot_view = BandsPlotWidget(
             bands=bands_data,
         )

--- a/src/aiidalab_qe/plugins/pdos/result.py
+++ b/src/aiidalab_qe/plugins/pdos/result.py
@@ -167,6 +167,8 @@ class Result(ResultPanel):
         """Update the view of the widget."""
         from widget_bandsplot import BandsPlotWidget
 
+        if self.workchain_nodes["pdos"] is None:
+            return
         group_dos_by = ipw.ToggleButtons(
             options=[
                 ("Atom", "atom"),
@@ -191,14 +193,16 @@ class Result(ResultPanel):
             layout={"margin": "0 0 30px 30px"},
         )
         #
-        dos_data = export_pdos_data(self.outputs.pdos, group_dos_by=group_dos_by.value)
+        dos_data = export_pdos_data(
+            self.workchain_nodes["pdos"].outputs, group_dos_by=group_dos_by.value
+        )
         _bands_plot_view = BandsPlotWidget(
             dos=dos_data,
         )
 
         def response(change):
             dos_data = export_pdos_data(
-                self.outputs.pdos, group_dos_by=group_dos_by.value
+                self.workchain_nodes["pdos"].outputs, group_dos_by=group_dos_by.value
             )
             _bands_plot_view = BandsPlotWidget(
                 dos=dos_data,

--- a/src/aiidalab_qe/version.py
+++ b/src/aiidalab_qe/version.py
@@ -3,4 +3,4 @@
 
 """This module contains project version information for both the app and the workflow."""
 
-__version__ = "v23.10.0b2"
+__version__ = "v23.11.0rc0"


### PR DESCRIPTION
This PR supports showing the result panel immediately when the plugin's result is available.  The plugin result panel reads the result from the plugin's workchain process directly.

Still need to fix the failed workchain test.