### PR TITLE
Use AiiDA Monitor

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ aiidalab_qe.properties =
     bands = aiidalab_qe.plugins.bands:bands
     pdos = aiidalab_qe.plugins.pdos:pdos
     electronic_structure = aiidalab_qe.plugins.electronic_structure:electronic_structure
+    pw_monitor = aiidalab_qe.plugins.pw_monitor:pw_monitor
 aiida.calculations.monitors =
     aiidalab_qe.relax_pw = aiidalab_qe.workflows.monitor:relax_pw
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,8 @@ aiidalab_qe.properties =
     bands = aiidalab_qe.plugins.bands:bands
     pdos = aiidalab_qe.plugins.pdos:pdos
     electronic_structure = aiidalab_qe.plugins.electronic_structure:electronic_structure
+aiida.calculations.monitors =
+    aiidalab_qe.relax_pw = aiidalab_qe.workflows.monitor:relax_pw
 
 [aiidalab]
 title = Quantum ESPRESSO

--- a/src/aiidalab_qe/app/structure/__init__.py
+++ b/src/aiidalab_qe/app/structure/__init__.py
@@ -50,7 +50,8 @@ class StructureSelectionStep(ipw.VBox, WizardAppWidgetStep):
     def __init__(self, description=None, **kwargs):
         importers = [
             StructureUploadWidget(title="Upload file"),
-            OptimadeQueryWidget(embedded=False),
+            # I disable optimade for now, because the version conflicts with aiida-core
+            # OptimadeQueryWidget(embedded=False),
             StructureBrowserWidget(title="AiiDA database"),
             StructureExamplesWidget(title="From Examples", examples=Examples),
         ]

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -407,10 +407,10 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             structure=self.input_structure,
             parameters=deepcopy(self.ui_parameters),
         )
-        # add monitor
+        # add monitor for relax workchain
         builder.relax.base.pw.monitors = {
             "energy": orm.Dict(
-                {"entry_point": "aiidalab_qe.relax_pw", "minimum_poll_interval": 20}
+                {"entry_point": "aiidalab_qe.relax_pw", "minimum_poll_interval": 2}
             ),
         }
 

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -407,6 +407,12 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
             structure=self.input_structure,
             parameters=deepcopy(self.ui_parameters),
         )
+        # add monitor
+        builder.relax.base.pw.monitors = {
+            "energy": orm.Dict(
+                {"entry_point": "aiidalab_qe.relax_pw", "minimum_poll_interval": 20}
+            ),
+        }
 
         self._update_builder(builder, self.MAX_MPI_PER_POOL)
 

--- a/src/aiidalab_qe/plugins/pw_monitor/__init__.py
+++ b/src/aiidalab_qe/plugins/pw_monitor/__init__.py
@@ -1,0 +1,5 @@
+from .result import Result
+
+pw_monitor = {
+    "result": Result,
+}

--- a/src/aiidalab_qe/plugins/pw_monitor/result.py
+++ b/src/aiidalab_qe/plugins/pw_monitor/result.py
@@ -1,0 +1,75 @@
+"""PW monitor result widget."""
+import ipywidgets as ipw
+
+from aiidalab_qe.common.panel import ResultPanel
+
+
+class Result(ResultPanel):
+    title = "PW monitor"
+    workchain_labels = []
+
+    def __init__(self, node=None, **kwargs):
+        super().__init__(node=node, **kwargs)
+
+    def _update_view(self):
+        """Update the view of the widget."""
+        import threading
+
+        update_interval = 1
+
+        self.update_view = threading.Thread(
+            target=self._draw_scf_convergence, args=(update_interval,)
+        )
+        self.update_view.start()
+
+    def _draw_scf_convergence(self, update_interval):
+        """Draw the SCF convergence plot."""
+        import time
+
+        import plotly.graph_objects as go
+
+        #
+        def get_data(relax_node):
+            energies = []
+            pw_base_nodes = [
+                link.node
+                for link in relax_node.base.links.get_outgoing().all()
+                if link.link_label.startswith("iteration")
+            ]
+            for pw_base_node in pw_base_nodes:
+                for link in pw_base_node.base.links.get_outgoing().all():
+                    if not link.link_label.startswith("iteration"):
+                        continue
+                    energies.extend(link.node.base.extras.get("monitor_energies", []))
+            return energies
+
+        #
+        if "relax" not in self.node.base.links.get_outgoing().all_link_labels():
+            self.children = ipw.HTML("<h4>There is no relax calculation!</h4>")
+            return
+        # init figure
+        relax_node = self.node.base.links.get_outgoing().get_node_by_label("relax")
+        g = go.FigureWidget(
+            layout=go.Layout(
+                title=dict(text="SCF convergence"),
+                barmode="overlay",
+            )
+        )
+        g.layout.xaxis.title = "SCF step"
+        g.layout.yaxis.title = "Energy (eV)"
+        energies = get_data(relax_node)
+        g.add_scatter(x=list(range(len(energies))), y=energies, mode="lines+markers")
+        self.children = (ipw.HTML("<h4>PW calculation running!</h4>"), g)
+        while relax_node.process_state.value not in ["finished", "excepted", "killed"]:
+            energies = get_data(relax_node)
+            with g.batch_update():
+                g.data[0].x = list(range(len(energies)))
+                g.data[0].y = energies
+            time.sleep(update_interval)
+        self.children = (ipw.HTML("<h4>PW calculation completed!</h4>"), g)
+
+    def reset(self):
+        """Reset the widget.
+        Currently, this is not possible."""
+        self.children = []
+        self.update_view.stop()

--- a/src/aiidalab_qe/plugins/pw_monitor/result.py
+++ b/src/aiidalab_qe/plugins/pw_monitor/result.py
@@ -26,10 +26,15 @@ class Result(ResultPanel):
         """Draw the SCF convergence plot."""
         import time
 
+        import nglview as nv
         import plotly.graph_objects as go
 
         #
         def get_data(relax_node):
+            """Get the data from the extras of the relax node."""
+            from ase import Atoms
+
+            images = []
             energies = []
             pw_base_nodes = [
                 link.node
@@ -41,7 +46,17 @@ class Result(ResultPanel):
                     if not link.link_label.startswith("iteration"):
                         continue
                     energies.extend(link.node.base.extras.get("monitor_energies", []))
-            return energies
+                    atoms = link.node.base.extras.get("monitor_atoms", {})
+                    trajectory = link.node.base.extras.get("monitor_trajectory", [])
+                    for i in range(len(trajectory)):
+                        atoms.update(
+                            {"positions": trajectory[i], "pbc": [True, True, True]}
+                        )
+                        images.append(Atoms(**atoms))
+            # the first image is the initial structure
+            if len(images) == 0:
+                images = [relax_node.inputs.structure.get_ase()]
+            return energies, images
 
         #
         if "relax" not in self.node.base.links.get_outgoing().all_link_labels():
@@ -51,22 +66,47 @@ class Result(ResultPanel):
         relax_node = self.node.base.links.get_outgoing().get_node_by_label("relax")
         g = go.FigureWidget(
             layout=go.Layout(
-                title=dict(text="SCF convergence"),
+                title=dict(text="SCF iteration."),
                 barmode="overlay",
             )
         )
         g.layout.xaxis.title = "SCF step"
         g.layout.yaxis.title = "Energy (eV)"
-        energies = get_data(relax_node)
+        energies, images = get_data(relax_node)
         g.add_scatter(x=list(range(len(energies))), y=energies, mode="lines+markers")
-        self.children = (ipw.HTML("<h4>PW calculation running!</h4>"), g)
+        atoms_viewer = nv.show_asetraj(images)
+        atoms_viewer.frame = len(images) - 1
+        self.children = (
+            ipw.HTML("<h4>PW calculation is running!</h4>"),
+            g,
+            ipw.HTML("<h4>Trajectory</h4>"),
+            atoms_viewer,
+        )
+        nimage = len(images)
         while relax_node.process_state.value not in ["finished", "excepted", "killed"]:
-            energies = get_data(relax_node)
+            energies, images = get_data(relax_node)
+            # udpate the atoms viewer if there are new images
+            if len(images) > nimage:
+                atoms_viewer = nv.show_asetraj(images)
+                atoms_viewer.frame = len(images) - 1
+                self.children = (
+                    ipw.HTML("<h4>PW calculation is running!</h4>"),
+                    g,
+                    ipw.HTML("<h4>Trajectory</h4>"),
+                    atoms_viewer,
+                )
+                nimage = len(images)
             with g.batch_update():
                 g.data[0].x = list(range(len(energies)))
                 g.data[0].y = energies
             time.sleep(update_interval)
-        self.children = (ipw.HTML("<h4>PW calculation completed!</h4>"), g)
+        state = relax_node.process_state.value
+        self.children = (
+            ipw.HTML(f"<h4>PW calculation is {state}!</h4>"),
+            g,
+            ipw.HTML("<h4>Trajectory</h4>"),
+            atoms_viewer,
+        )
 
     def reset(self):
         """Reset the widget.

--- a/src/aiidalab_qe/workflows/monitor.py
+++ b/src/aiidalab_qe/workflows/monitor.py
@@ -11,12 +11,29 @@ def relax_pw(node: CalcJobNode, transport: Transport) -> str:
     :param transport: The transport that can be used to retrieve files from remote working directory.
     :returns: A string if the job should be killed, `None` otherwise.
     """
+    import numpy as np
+    from ase.io import read
+
     try:
+        # read structure
+        with tempfile.NamedTemporaryFile("w+") as handle:
+            transport.getfile(node.get_option("output_filename"), handle.name)
+            handle.seek(0)
+            images = read(handle, index=":", format="espresso-out")
+            if len(images) > 0:
+                atoms = images[0].todict()
+                # type `<class 'numpy.bool_'>` is not supported as it is not json-serializable
+                atoms.pop("pbc")
+                trajectory = np.zeros((len(images), len(images[0]), 3))
+                for i in range(len(images)):
+                    trajectory[i] = images[i].positions
+                node.base.extras.set("monitor_atoms", atoms)
+                node.base.extras.set("monitor_trajectory", trajectory)
+        # read scf energy
         with tempfile.NamedTemporaryFile("w+") as handle:
             transport.getfile(node.get_option("output_filename"), handle.name)
             handle.seek(0)
             output = handle.read()
-
         energies = []
         lines = output.splitlines()
         for line in lines:

--- a/src/aiidalab_qe/workflows/monitor.py
+++ b/src/aiidalab_qe/workflows/monitor.py
@@ -1,0 +1,26 @@
+import tempfile
+
+from aiida.orm import CalcJobNode
+from aiida.transports import Transport
+
+
+def relax_pw(node: CalcJobNode, transport: Transport) -> str:
+    """Retrieve and inspect files in working directory of job to determine whether the job should be killed.
+
+    :param node: The node representing the calculation job.
+    :param transport: The transport that can be used to retrieve files from remote working directory.
+    :returns: A string if the job should be killed, `None` otherwise.
+    """
+    if "relax" not in node.base.links.get_outgoing().all_link_labels():
+        return
+    node = node.base.links.get_outgoing().get_node_by_label("relax")
+    with tempfile.NamedTemporaryFile("w+") as handle:
+        transport.getfile(node.options.output_filename, handle.name)
+        handle.seek(0)
+        output = handle.read()
+
+    energies = []
+    for line in output:
+        if "total energy              =" in line:
+            energies.append(float(line.split("=")[1]))
+    node.base.extras.set("monitor.energies", energies)

--- a/src/aiidalab_qe/workflows/monitor.py
+++ b/src/aiidalab_qe/workflows/monitor.py
@@ -5,22 +5,23 @@ from aiida.transports import Transport
 
 
 def relax_pw(node: CalcJobNode, transport: Transport) -> str:
-    """Retrieve and inspect files in working directory of job to determine whether the job should be killed.
+    """Retrieve and save the total energy from aiida.out file and save it into the node extras.
 
     :param node: The node representing the calculation job.
     :param transport: The transport that can be used to retrieve files from remote working directory.
     :returns: A string if the job should be killed, `None` otherwise.
     """
-    if "relax" not in node.base.links.get_outgoing().all_link_labels():
-        return
-    node = node.base.links.get_outgoing().get_node_by_label("relax")
-    with tempfile.NamedTemporaryFile("w+") as handle:
-        transport.getfile(node.options.output_filename, handle.name)
-        handle.seek(0)
-        output = handle.read()
+    try:
+        with tempfile.NamedTemporaryFile("w+") as handle:
+            transport.getfile(node.get_option("output_filename"), handle.name)
+            handle.seek(0)
+            output = handle.read()
 
-    energies = []
-    for line in output:
-        if "total energy              =" in line:
-            energies.append(float(line.split("=")[1]))
-    node.base.extras.set("monitor.energies", energies)
+        energies = []
+        lines = output.splitlines()
+        for line in lines:
+            if "total energy              =" in line:
+                energies.append(float(line.split("=")[1].split()[0]))
+        node.base.extras.set("monitor_energies", energies)
+    except FileExistsError:
+        return


### PR DESCRIPTION
This is an attempt to use AiiDA Monitor inside AiiDAlab. So the user can monitor the real-time job status (energy, trajectory). It's a good use case for the new AiiDA feature: Monitor.

### Technique details:
- A monitor is added to the pw calcjob of the relax workchain. It reads the SCF energies and the trajectory from the `aida.out` file, then saves the date in the `node.base.extras`.
- In the AiiDAlab-QE result panel, open a new `thread` to read data from the `node.base.extras` and update the widiget.

Here is the screencast

https://github.com/aiidalab/aiidalab-qe/assets/11457659/46d05b7f-4303-42b0-a8a1-803ac525a08d


