### PR TITLE
Bump artifact action to v4

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -52,7 +52,7 @@ runs:
 
         - name: Upload screenshots as artifacts
           if : ${{ inputs.architecture == 'amd64' }}
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
               name: Screenshots-CI-${{ inputs.architecture }}
               path: screenshots/

--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -16,7 +16,7 @@ runs:
     using: composite
     steps:
         - name: Download built image 📥
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
               name: ${{ inputs.image }}-${{ inputs.architecture }}
               path: /tmp/aiidalab/

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -27,7 +27,7 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
@@ -69,7 +69,7 @@ jobs:
               if: always()
 
             - name: Upload image as artifact 💾
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.image }}-${{ inputs.architecture }}
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}.tar

--- a/.github/workflows/docker-merge-tags.yml
+++ b/.github/workflows/docker-merge-tags.yml
@@ -25,19 +25,19 @@ jobs:
 
         steps:
             - name: Checkout Repo ⚡️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Create dev environment 📦
               uses: ./.github/actions/create-dev-env
               with:
                   architecture: amd64
 
             - name: Download amd64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-amd64-tags
                   path: /tmp/aiidalab
             - name: Download arm64 tags file 📥
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-arm64-tags
                   path: /tmp/aiidalab

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -86,7 +86,7 @@ jobs:
               shell: bash
 
             - name: Upload tags file 📤
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.registry }}-${{ inputs.image }}-${{ inputs.architecture }}-tags
                   path: /tmp/aiidalab/${{ inputs.image }}-${{ inputs.architecture }}-tags.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
                   --outdir dist/
 
             - name: Upload distribution artifact
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: release
                   path: dist/
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/download-artifact@v2
+            - uses: actions/download-artifact@v4
               name: Download distribution artifact
               with:
                   name: release


### PR DESCRIPTION
The changes should significantly speed up artifact upload, see https://github.com/actions/upload-artifact#v4---whats-new