### PR TITLE
Bump aiida-quantumespresso to 4.4.0 and unpinning pydantic

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,12 @@ packages = find:
 install_requires =
     aiida-core~=2.2,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.3.0
+    aiida-quantumespresso~=4.4.0
     aiidalab-widgets-base==2.1.0rc0
     aiida-pseudo~=1.4
     filelock~=3.8
     importlib-resources~=5.2
     widget-bandsplot~=0.5.1
-    pydantic~=1.10,>=1.10.8
 python_requires = >=3.8
 
 [options.packages.find]


### PR DESCRIPTION
The pydantic is pinned in https://github.com/aiidalab/aiidalab-qe/pull/416, after the release of `aiida-quantumespresso` it is not needed, this PR bump the aiida-quantumespresso and unpin the pydantic.