### PR TITLE
removing force_parity from create_kpoints_from_distance

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced.py
@@ -328,7 +328,7 @@ class AdvancedSettings(Panel):
             mesh = create_kpoints_from_distance.process_class._func(
                 self.input_structure,
                 orm.Float(self.kpoints_distance.value),
-                orm.Bool(True),
+                orm.Bool(False),
             )
             self.mesh_grid.value = "Mesh " + str(mesh.get_kpoints_mesh()[0])
         else:

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -57,7 +57,7 @@ class Setting(Panel):
         mesh = create_kpoints_from_distance.process_class._func(
             self.input_structure,
             orm.Float(self.nscf_kpoints_distance.value),
-            orm.Bool(True),
+            orm.Bool(False),
         )
         self.mesh_grid.value = "Mesh " + str(mesh.get_kpoints_mesh()[0])
 

--- a/tests/configuration/test_advanced.py
+++ b/tests/configuration/test_advanced.py
@@ -150,4 +150,4 @@ def test_advanced_kpoints_mesh():
 
     # change protocol
     w.protocol = "fast"
-    assert w.mesh_grid.value == "Mesh [6, 6, 6]"
+    assert w.mesh_grid.value == "Mesh [5, 5, 5]"


### PR DESCRIPTION
This allows the app to follow the same logic of aiida-quantumespresso plugin, therefore displaying the final kpoint mesh as in the calculation