### PR TITLE
Remove the load_profile warning by move it to front

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,8 @@ repos:
           - id: nbqa-isort
             args: [--profile=black]
           - id: nbqa-ruff
+            # suppress E402
+            args: [--ignore=E402]
 
     - repo: https://github.com/kynan/nbstripout
       rev: 0.6.1

--- a/qe.ipynb
+++ b/qe.ipynb
@@ -19,6 +19,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile(); # noqa: E402"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Fix pybel import path\n",
     "try:\n",
     "    import sys\n",
@@ -37,24 +48,6 @@
     "\n",
     "from aiidalab_qe.app import App, static\n",
     "from aiidalab_qe.version import __version__"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from aiida import load_profile\n",
-    "\n",
-    "load_profile();"
    ]
   },
   {


### PR DESCRIPTION
The problem is introduced by https://github.com/aiidalab/aiidalab-qe/pull/593, where I move the load_profile to after the import of AWB.