### PR TITLE
Examples: Add Lithium Carbonate to List of Examples

### DIFF
--- a/src/aiidalab_qe/app/structure/__init__.py
+++ b/src/aiidalab_qe/app/structure/__init__.py
@@ -32,6 +32,7 @@ Examples = [
     ("Gallium arsenide", file_path / "examples" / "GaAs.xyz"),
     ("Gold (fcc)", file_path / "examples" / "Au.cif"),
     ("Cobalt (hcp)", file_path / "examples" / "Co.cif"),
+    ("Lithium carbonate", file_path / "examples" / "Li2CO3.cif"),
 ]
 
 OptimadeQueryWidget.title = "OPTIMADE"  # monkeypatch


### PR DESCRIPTION
Fixes an oversight from https://github.com/aiidalab/aiidalab-qe/pull/614 where the lithium carbonate example was not added to `Examples` in `__init__.py` and thus couldn't be selected as a structure.