### PR TITLE
fix pw setting for molecule in XPS calculation

### DIFF
--- a/src/aiidalab_qe/plugins/xps/workchain.py
+++ b/src/aiidalab_qe/plugins/xps/workchain.py
@@ -7,8 +7,8 @@ XpsWorkChain = WorkflowFactory("quantumespresso.xps")
 # supercell min parameter for different protocols
 supercell_min_parameter_map = {
     "fast": 4.0,
-    "moderate": 6.0,
-    "precise": 8.0,
+    "moderate": 8.0,
+    "precise": 12.0,
 }
 
 
@@ -60,12 +60,15 @@ def get_builder(codes, structure, parameters, **kwargs):
         "is_molecule_input": Bool(is_molecule_input),
     }
     pw_code = codes.get("pw", None)
+    overrides_ch_scf = deepcopy(parameters["advanced"])
+    if is_molecule_input:
+        overrides_ch_scf["pw"]["parameters"]["SYSTEM"]["assume_isolated"] = "mt"
     overrides = {
         "relax": {
             "base": deepcopy(parameters["advanced"]),
             "base_final_scf": deepcopy(parameters["advanced"]),
         },
-        "ch_scf": deepcopy(parameters["advanced"]),
+        "ch_scf": overrides_ch_scf,
     }
     builder = XpsWorkChain.get_builder_from_protocol(
         code=pw_code,
@@ -86,8 +89,9 @@ def get_builder(codes, structure, parameters, **kwargs):
     builder.pop("relax")
     builder.pop("clean_workdir", None)
     if is_molecule_input:
-        builder.ch_scf.pw.parameters.base.attributes.all['SYSTEM']['assume_isolated']='mt'
-        builder.ch_scf.pw.settings=Dict(dict={'gamma_only':True})
+        # set a large kpoints_distance value to set the kpoints to 1x1x1
+        builder.ch_scf.kpoints_distance = Float(5)
+        builder.ch_scf.pw.settings = Dict(dict={"gamma_only": True})
     return builder
 
 

--- a/src/aiidalab_qe/plugins/xps/workchain.py
+++ b/src/aiidalab_qe/plugins/xps/workchain.py
@@ -85,11 +85,9 @@ def get_builder(codes, structure, parameters, **kwargs):
     )
     builder.pop("relax")
     builder.pop("clean_workdir", None)
-    # there is a bug in aiida-quantumespresso xps, that one can not set the kpoints
-    # this is fxied in a PR, but we need to wait for the next release.
-    # we set a large kpoints_distance value to set the kpoints to 1x1x1
     if is_molecule_input:
-        builder.ch_scf.kpoints_distance = Float(5)
+        builder.ch_scf.pw.parameters.base.attributes.all['SYSTEM']['assume_isolated']='mt'
+        builder.ch_scf.pw.settings=Dict(dict={'gamma_only':True})
     return builder
 
 


### PR DESCRIPTION

For molecules, we use `gamma_only` and `assume_isolated`. This should be fixed in the aiida-quantumespresso XpsWorkchain, but we don't want to wait for the new PR and release. Thus, we fix it here directly.

I also adjust the `supercell_min_parameter_map,` so it uses the default 8.0 when the user selects the `moderate` protocol.
