### PR TITLE
Run one SCF calculation for all plugins

### DIFF
--- a/src/aiidalab_qe/plugins/bands/workchain.py
+++ b/src/aiidalab_qe/plugins/bands/workchain.py
@@ -215,6 +215,8 @@ def get_builder(codes, structure, parameters, **kwargs):
 
     # pop the inputs that are excluded from the expose_inputs
     bands.pop("relax")
+    # run the scf workchain from the app's workchain
+    bands.pop("scf")
     bands.pop("structure", None)
     bands.pop("clean_workdir", None)
     return bands
@@ -224,4 +226,6 @@ workchain_and_builder = {
     "workchain": PwBandsWorkChain,
     "exclude": ("clean_workdir", "structure", "relax"),
     "get_builder": get_builder,
+    "requires_scf": True,
+    "input_from_ctx": {"bands.pw.parent_folder": "scf_folder"},
 }

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -66,6 +66,8 @@ def get_builder(codes, structure, parameters, **kwargs):
         # pop the inputs that are exclueded from the expose_inputs
         pdos.pop("structure", None)
         pdos.pop("clean_workdir", None)
+        # run the scf workchain from the app's workchain
+        pdos.pop("scf")
     else:
         raise ValueError("The dos_code and projwfc_code are required.")
     return pdos
@@ -75,4 +77,6 @@ workchain_and_builder = {
     "workchain": PdosWorkChain,
     "exclude": ("clean_workdir", "structure", "relax"),
     "get_builder": get_builder,
+    "requires_scf": True,
+    "input_from_ctx": {"nscf.pw.parent_folder": "scf_folder"},
 }


### PR DESCRIPTION
Currently, plugins are independent, meaning one plugin will not know what other plugins are running. Thus, when selecting both Bands and DOS, the app will run two completely independent SCFs in parallel.

This PR adds one `SCF` step in the main workflow before running any plugins. On the plugin side, I added a `requires_scf` and `from_ctx` keys. If any plugin asks a SCF calculation, the main workchain will do that, and save the scf folder as `ctx.scf_folder`, so that the plugins can use it.

However, this PR is blocked by aiida-quantumespresso, because the `scf` namespace is required in the `PwBandsWorkChain`. In principle, one can remove this requirement so that it can use `scf` calculation from other calculations.
Hi @mbercx , am I correct on this?

