### PR TITLE
check code exist in the DEFAULT_PARAMETERS or not

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -198,6 +198,8 @@ class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
     def _auto_select_code(self, change):
         if change["new"] and not change["old"]:
             for name, code_widget in self.codes.items():
+                if not DEFAULT_PARAMETERS["codes"].get(name):
+                    continue
                 try:
                     code_widget.refresh()
                     code_widget.value = orm.load_code(


### PR DESCRIPTION
fix #659 .
Skip setting the code if the code does not exist in the `DEFAULT_PARAMETERS`.