### PR TITLE
assgin clean_workdir to plugin's builder

### DIFF
--- a/src/aiidalab_qe/plugins/bands/workchain.py
+++ b/src/aiidalab_qe/plugins/bands/workchain.py
@@ -227,6 +227,6 @@ def get_builder(codes, structure, parameters, **kwargs):
 
 workchain_and_builder = {
     "workchain": PwBandsWorkChain,
-    "exclude": ("clean_workdir", "structure", "relax"),
+    "exclude": ("structure", "relax"),
     "get_builder": get_builder,
 }

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -80,6 +80,6 @@ def get_builder(codes, structure, parameters, **kwargs):
 
 workchain_and_builder = {
     "workchain": PdosWorkChain,
-    "exclude": ("clean_workdir", "structure", "relax"),
+    "exclude": ("structure", "relax"),
     "get_builder": get_builder,
 }

--- a/src/aiidalab_qe/plugins/xas/workchain.py
+++ b/src/aiidalab_qe/plugins/xas/workchain.py
@@ -106,6 +106,6 @@ def get_builder(codes, structure, parameters, **kwargs):
 
 workchain_and_builder = {
     "workchain": XspectraCrystalWorkChain,
-    "exclude": ("clean_workdir", "structure", "relax"),
+    "exclude": ("structure", "relax"),
     "get_builder": get_builder,
 }

--- a/src/aiidalab_qe/plugins/xps/workchain.py
+++ b/src/aiidalab_qe/plugins/xps/workchain.py
@@ -100,6 +100,6 @@ def get_builder(codes, structure, parameters, **kwargs):
 
 workchain_and_builder = {
     "workchain": XpsWorkChain,
-    "exclude": ("clean_workdir", "structure", "relax"),
+    "exclude": ("structure", "relax"),
     "get_builder": get_builder,
 }

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -158,20 +158,20 @@ class QeAppWorkChain(WorkChain):
         if properties is None:
             properties = []
         builder.properties = orm.List(list=properties)
+        # clean workdir
+        clean_workdir = orm.Bool(parameters["advanced"]["clean_workdir"])
+        builder.clean_workdir = clean_workdir
         # add plugin workchain
         for name, entry_point in plugin_entries.items():
             if name in properties:
                 plugin_builder = entry_point["get_builder"](
                     codes, structure, copy.deepcopy(parameters), **kwargs
                 )
+                # assume all builder has a input "clean_workdir"
+                plugin_builder.clean_workdir = clean_workdir
                 setattr(builder, name, plugin_builder)
             else:
                 builder.pop(name, None)
-
-        # XXX (unkcpz) I smell not proper design here since I have to look at
-        # configuration step to know what show be set here.
-        clean_workdir = parameters["advanced"]["clean_workdir"]
-        builder.clean_workdir = orm.Bool(clean_workdir)
 
         return builder
 

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -167,8 +167,10 @@ class QeAppWorkChain(WorkChain):
                 plugin_builder = entry_point["get_builder"](
                     codes, structure, copy.deepcopy(parameters), **kwargs
                 )
-                # assume all builder has a input "clean_workdir"
-                plugin_builder.clean_workdir = clean_workdir
+                # check if the plugin has a clean_workdir input
+                plugin_workchain = entry_point["workchain"]
+                if plugin_workchain.spec().has_input("clean_workdir"):
+                    plugin_builder.clean_workdir = clean_workdir
                 setattr(builder, name, plugin_builder)
             else:
                 builder.pop(name, None)


### PR DESCRIPTION
fix #666 

If a plugin has `clean_workdir` default to True, even if the user didn't select the `clean_workdir` box, the plugin still cleans the workdir. This PR assigns the `clean_workdir` to the plugin's builder to make sure the `clean_workdir` is consistent.