### PR TITLE
restart the daemon with --reset flag manually

### DIFF
--- a/post_install
+++ b/post_install
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# After installing or updating a plugin package, one needs to restart the daemon with the --reset flag for changes to take effect.
+# For the moment aiidalab only restart the daemon without the --reset flag, so we need to do it manually.
+verdi daemon restart --reset
+
 # This script is executed after the app installation completes
 # triggered by the post install hook implemented in https://github.com/aiidalab/aiidalab/pull/295
 # TODO: this script is not yet properly tested. The integration tests are run from the qeapp docker image, this script is executed when the app is installed by `aiidalab install`. Therefore, we need to bring original di test (which removed in https://github.com/aiidalab/aiidalab-qe/pull/449/files#diff-83993fe9ad162677c85ae244400df2469b6d666c2a28d7b8d179785e87beb7f3) back.


### PR DESCRIPTION
After installing or updating a plugin package, one needs to restart the daemon with the --reset flag for changes to take effect.
For the moment, aiidalab only restarts the daemon without the—-reset flag, so we need to do it manually.

This is needed for our next release. We can remove this after this https://github.com/aiidalab/aiidalab/pull/424