### PR TITLE
fix plugin.yaml file url

### DIFF
--- a/plugin_list.ipynb
+++ b/plugin_list.ipynb
@@ -26,7 +26,7 @@
     "import yaml\n",
     "\n",
     "# URL of the YAML file\n",
-    "filepath = 'https://raw.githubusercontent.com/aiidalab/aiidalab-qe-plugin-registry/main/plugins.yaml'\n",
+    "filepath = 'https://raw.githubusercontent.com/aiidalab/aiidalab-qe/main/plugins.yaml'\n",
     "\n",
     "# Fetch the contents of the URL\n",
     "response = requests.get(filepath)\n",


### PR DESCRIPTION
fix #696 . Now it shows the correct author list.

![Screenshot from 2024-04-29 15-40-41](https://github.com/aiidalab/aiidalab-qe/assets/11457659/f1470c14-7ad4-4c69-84e7-2d8146e1c17b)
