### PR TITLE
CI: Use uv for installing deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 # Run basic tests for this app
 
-name: continuous-integration
+name: CI
 
 on: [push, pull_request]
 
@@ -11,10 +11,12 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
 
+env:
+    FORCE_COLOR: 1
+
 jobs:
 
     test-package:
-
 
         strategy:
             matrix:
@@ -35,26 +37,26 @@ jobs:
         steps:
 
             - name: Check out app
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
-                  cache: pip
-                  cache-dependency-path: |
-                      **/setup.cfg
-                      **/pyproject.toml
-                      **/requirements*.txt
+
+            - name: Install uv
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.2.13/uv-installer.sh | sh
+
             - name: Install package
-              run: pip install -e .[dev] aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --system -e .[dev] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
-              run: pytest -v tests --cov
+              run: pytest -v tests --cov=aiidalab_qe
               env:
                   TAG: ${{ matrix.tag }}
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v3
+              uses: codecov/codecov-action@v4
               with:
                   flags: python-${{ matrix.python-version }}
+                  token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -3,6 +3,7 @@ name: Build a new image and then upload the image, tags and manifests to GitHub 
 
 env:
     OWNER: ${{ github.repository_owner }}
+    FORCE_COLOR: 1
 
 on:
     workflow_call:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,19 +10,10 @@ build:
     os: ubuntu-22.04
     tools:
         python: '3.11'
-
-# Build documentation in the "docs/" directory with Sphinx
-sphinx:
-    configuration: docs/source/conf.py
-
-# Optionally build your docs in additional formats such as PDF and ePub
-# formats:
-#    - pdf
-#    - epub
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-    install:
-        - requirements: docs/requirements.txt
+    commands:
+        - asdf plugin add uv
+        - asdf install uv 0.2.13
+        - asdf global uv 0.2.13
+        - uv venv
+        - uv pip install -r docs/requirements.txt
+        - .venv/bin/python -m sphinx -W --keep-going -d _build/doctrees -D language=en -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/docs/source/blogs/index.rst
+++ b/docs/source/blogs/index.rst
@@ -1,4 +1,4 @@
-.. _develop-apps:
+.. _blog:
 
 ###################
 Blogs


### PR DESCRIPTION
Use `uv` installer to speed up installing dependencies for tests + some other CI tweaks brought over from AWB:

- Use FORCE_COLOR to get colored logs in Github UI
- Update actions
- Don't collect code coverage from tests/ folders