### PR TITLE
Dockerfile: Add --no-user to pip install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN cd ${PREINSTALL_APP_FOLDER} && \
      # aiidalab install --yes --python ${CONDA_DIR}/bin/python  "quantum-espresso@file://${PREINSTALL_APP_FOLDER}" && \
      # However, have to use `pip install` explicitly because `aiidalab install` call `pip install --user` which will install the app to `/home/${NB_USER}/.local`.
      # It won't cause issue for docker but for k8s deployment the home folder is not bind mounted to the pod and the dependencies won't be found. (see issue in `jupyter/docker-stacks` https://github.com/jupyter/docker-stacks/issues/815)
-     pip install . --no-cache-dir && \
+     pip install . --no-user --no-cache-dir && \
      fix-permissions "${CONDA_DIR}" && \
      fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
This is an important fix for the Docker build since version [v2024.1017](https://github.com/aiidalab/aiidalab-docker-stack/releases/tag/v2024.1017) of the aiidalab full-stack image, which added the `--user` argument to `pip install` by default.

@superstar54 it seems that the aiidalab_qe app dependencies were being installed in `~/.local` instead of `/opt/conda`. This may have influenced your testing of your tared-home image, as it would blow up the home size.

CC @unkcpz 

NOTE: As an alternative to this PR you can merge #761 and use uv instead of pip which speeds up the docker build by 1 minute.