### PR TITLE
Print container logs if service fails to start

### DIFF
--- a/.github/workflows/docker-build-test-upload.yml
+++ b/.github/workflows/docker-build-test-upload.yml
@@ -78,7 +78,7 @@ jobs:
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
 
             - name: Run pytest for Chrome
-              run: pytest --driver Chrome tests_integration/
+              run: pytest -sv --driver Chrome tests_integration/
               env:
                   QE_IMAGE: ${{ env.IMAGE }}@${{ steps.build-upload.outputs.digest }}
 

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -50,19 +50,22 @@ def nb_user(aiidalab_exec):
 
 
 @pytest.fixture(scope="session")
-def notebook_service(docker_ip, docker_services):
+def notebook_service(docker_compose, docker_ip, docker_services):
     """Ensure that HTTP service is up and responsive."""
 
     # `port_for` takes a container port and returns the corresponding host port
     port = docker_services.port_for("aiidalab", 8888)
     url = f"http://{docker_ip}:{port}"
     token = os.environ.get("JUPYTER_TOKEN", "testtoken")
-    docker_services.wait_until_responsive(
-        # The timeout is very high for this test, because the installation of pseudo libraries.
-        timeout=180.0,
-        pause=0.1,
-        check=lambda: is_responsive(url),
-    )
+    try:
+        docker_services.wait_until_responsive(
+            timeout=180.0,
+            pause=1.0,
+            check=lambda: is_responsive(url),
+        )
+    except Exception as e:
+        print(docker_compose.execute("logs").decode().strip())
+        pytest.exit(e)
     return url, token
 
 


### PR DESCRIPTION
When a Docker container fails to start properly, the integration tests fail with a timeout error. In that case, we will print container logs for debugging. We use the same strategy in AWB and it works well.

Extracted from #781.