### PR TITLE
No untar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,9 @@ COPY --from=qe_conda_env ${QE_DIR} ${QE_DIR}
 
 USER root
 COPY ./before-notebook.d/* /usr/local/bin/before-notebook.d/
-RUN fix-permissions "${CONDA_DIR}"
+RUN mkdir -p /opt/store/ && \
+    fix-permissions /opt/store/
+
 # Remove content of $HOME
 # '-mindepth=1' ensures that we do not remove the home directory itself.
 RUN find /home/${NB_USER}/ -mindepth 1 -delete
@@ -96,7 +98,7 @@ COPY --chown=${NB_UID}:${NB_GID} . ${QE_APP_FOLDER}
 # Remove all untracked files and directories.
 RUN git clean -dffx || true
 
-ENV HOME_TAR="/opt/home.tar"
+ENV HOME_TAR="/opt/store/home.tar"
 COPY --from=home_build /opt/conda/home.tar "$HOME_TAR"
 
 USER ${NB_USER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,6 @@ COPY --from=qe_conda_env ${QE_DIR} ${QE_DIR}
 
 USER root
 COPY ./before-notebook.d/* /usr/local/bin/before-notebook.d/
-RUN mkdir -p /opt/store/ && \
-    fix-permissions /opt/store/
 
 # Remove content of $HOME
 # '-mindepth=1' ensures that we do not remove the home directory itself.
@@ -98,7 +96,7 @@ COPY --chown=${NB_UID}:${NB_GID} . ${QE_APP_FOLDER}
 # Remove all untracked files and directories.
 RUN git clean -dffx || true
 
-ENV HOME_TAR="/opt/store/home.tar"
+ENV HOME_TAR="/opt/home.tar"
 COPY --from=home_build /opt/conda/home.tar "$HOME_TAR"
 
 USER ${NB_USER}

--- a/before-notebook.d/00_untar_home.sh
+++ b/before-notebook.d/00_untar_home.sh
@@ -5,8 +5,8 @@ home="/home/${NB_USER}"
 
 # Untar home archive file to restore home directory if it is empty
 if [[ $(ls -A ${home} | wc -l) = "0" ]]; then
-  if [[ ! -f $HOME_TAR ]]; then
-    echo "File $HOME_TAR does not exist!"
+  if [[ ! -d $TMP_HOME ]]; then
+    echo "Folder $TMP_HOME does not exist!"
     exit 1
   fi
   if [[ ! -d ${QE_APP_FOLDER} ]]; then
@@ -14,8 +14,8 @@ if [[ $(ls -A ${home} | wc -l) = "0" ]]; then
     exit 1
   fi
 
-  echo "Extracting $HOME_TAR to $home"
-  tar -xf $HOME_TAR -C "$home"
+  echo "Moving $TMP_HOME to $home"
+  mv $TMP_HOME/* "$home"
 
   echo "Copying directory '$QE_APP_FOLDER' to '$AIIDALAB_APPS'"
   cp -r "$QE_APP_FOLDER" "$AIIDALAB_APPS"


### PR DESCRIPTION
fixes #791 

- Not using tar/untar which is already take care by container runtime.
- Move the home leave thus leave no duplicated data in `/opt/` which occupied disk space.