### PR TITLE
Feature/degauss widget pdos tab

### DIFF
--- a/src/aiidalab_qe/app/structure/__init__.py
+++ b/src/aiidalab_qe/app/structure/__init__.py
@@ -88,9 +88,7 @@ class StructureSelectionStep(ipw.VBox, WizardAppWidgetStep):
             description = ipw.HTML(
                 """
                 <p>Select a structure from one of the following sources and then click
-                "Confirm" to go to the next step. </p><i class="fa fa-exclamation-circle"
-                aria-hidden="true"></i> Currently only three-dimensional structures are
-                supported.
+                "Confirm" to go to the next step. </p>
                 """
             )
         self.description = description

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -33,12 +33,17 @@ class Setting(Panel):
             disabled=False,
             style={"description_width": "initial"},
         )
+        self.use_pdos_degauss = ipw.Checkbox(
+            value=False,
+            description="Use custom PDOS degauss",
+            style={"description_width": "initial"},
+        )
         self.pdos_degauss = ipw.BoundedFloatText(
             min=0.001,
             step=0.001,
             value=0.01,
             description="PDOS degauss (Ry):",
-            disabled=False,
+            disabled=True,
             style={"description_width": "initial"},
         )
         self.pdos_degauss_eV = ipw.HTML()
@@ -46,17 +51,21 @@ class Setting(Panel):
             f"({self.pdos_degauss.value * RYDBERG_TO_EV:.4f} eV)"
         )
 
+        self.use_pdos_degauss.observe(self._disable_pdos_degauss, "value")
         self.pdos_degauss.observe(self._update_pdos_degauss_ev, "value")
-
         self.mesh_grid = ipw.HTML()
         self.nscf_kpoints_distance.observe(self._display_mesh, "value")
         self.nscf_kpoints_distance.observe(self._procotol_changed, "change")
         self.children = [
             self.settings_title,
             ipw.HBox([self.nscf_kpoints_distance, self.mesh_grid]),
+            self.use_pdos_degauss,
             ipw.HBox([self.pdos_degauss, self.pdos_degauss_eV]),
         ]
         super().__init__(**kwargs)
+
+    def _disable_pdos_degauss(self, change):
+        self.pdos_degauss.disabled = not change["new"]
 
     def _update_pdos_degauss_ev(self, change):
         new_value = change["new"] * RYDBERG_TO_EV
@@ -89,14 +98,17 @@ class Setting(Panel):
         return {
             "nscf_kpoints_distance": self.nscf_kpoints_distance.value,
             "pdos_degauss": self.pdos_degauss.value,
+            "use_pdos_degauss": self.use_pdos_degauss.value,
         }
 
     def set_panel_value(self, input_dict):
         """Load a dictionary with the input parameters for the plugin."""
         self.nscf_kpoints_distance.value = input_dict.get("nscf_kpoints_distance", 0.1)
         self.pdos_degauss.value = input_dict.get("pdos_degauss", 0.01)
+        self.use_pdos_degauss.value = input_dict.get("use_pdos_degauss", False)
 
     def reset(self):
         """Reset the panel to its default values."""
         self.nscf_kpoints_distance.value = 0.1
         self.pdos_degauss.value = 0.01
+        self.use_pdos_degauss.value = False

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -39,9 +39,9 @@ class Setting(Panel):
             style={"description_width": "initial"},
         )
         self.pdos_degauss = ipw.BoundedFloatText(
-            min=0.001,
+            min=0.00001,
             step=0.001,
-            value=0.01,
+            value=0.005,
             description="PDOS degauss (Ry):",
             disabled=True,
             style={"description_width": "initial"},
@@ -104,11 +104,11 @@ class Setting(Panel):
     def set_panel_value(self, input_dict):
         """Load a dictionary with the input parameters for the plugin."""
         self.nscf_kpoints_distance.value = input_dict.get("nscf_kpoints_distance", 0.1)
-        self.pdos_degauss.value = input_dict.get("pdos_degauss", 0.01)
+        self.pdos_degauss.value = input_dict.get("pdos_degauss", 0.005)
         self.use_pdos_degauss.value = input_dict.get("use_pdos_degauss", False)
 
     def reset(self):
         """Reset the panel to its default values."""
         self.nscf_kpoints_distance.value = 0.1
-        self.pdos_degauss.value = 0.01
+        self.pdos_degauss.value = 0.005
         self.use_pdos_degauss.value = False

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -10,6 +10,8 @@ from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance i
 from aiida_quantumespresso.workflows.pdos import PdosWorkChain
 from aiidalab_qe.common.panel import Panel
 
+RYDBERG_TO_EV = 13.605703976
+
 
 class Setting(Panel):
     title = "PDOS"
@@ -31,14 +33,35 @@ class Setting(Panel):
             disabled=False,
             style={"description_width": "initial"},
         )
+        self.pdos_degauss = ipw.BoundedFloatText(
+            min=0.001,
+            step=0.001,
+            value=0.01,
+            description="PDOS degauss (Ry):",
+            disabled=False,
+            style={"description_width": "initial"},
+        )
+        self.pdos_degauss_eV = ipw.HTML()
+        self.pdos_degauss_eV.value = (
+            f"({self.pdos_degauss.value * RYDBERG_TO_EV:.4f} eV)"
+        )
+
+        self.pdos_degauss.observe(self._update_pdos_degauss_ev, "value")
+
         self.mesh_grid = ipw.HTML()
         self.nscf_kpoints_distance.observe(self._display_mesh, "value")
         self.nscf_kpoints_distance.observe(self._procotol_changed, "change")
         self.children = [
             self.settings_title,
             ipw.HBox([self.nscf_kpoints_distance, self.mesh_grid]),
+            ipw.HBox([self.pdos_degauss, self.pdos_degauss_eV]),
         ]
         super().__init__(**kwargs)
+
+    def _update_pdos_degauss_ev(self, change):
+        new_value = change["new"] * RYDBERG_TO_EV
+        if self.pdos_degauss_eV.value != f"({new_value} eV)":
+            self.pdos_degauss_eV.value = f"({new_value:.4f} eV)"
 
     @tl.observe("protocol")
     def _procotol_changed(self, change):
@@ -65,12 +88,15 @@ class Setting(Panel):
         """Return a dictionary with the input parameters for the plugin."""
         return {
             "nscf_kpoints_distance": self.nscf_kpoints_distance.value,
+            "pdos_degauss": self.pdos_degauss.value,
         }
 
     def set_panel_value(self, input_dict):
         """Load a dictionary with the input parameters for the plugin."""
         self.nscf_kpoints_distance.value = input_dict.get("nscf_kpoints_distance", 0.1)
+        self.pdos_degauss.value = input_dict.get("pdos_degauss", 0.01)
 
     def reset(self):
         """Reset the panel to its default values."""
         self.nscf_kpoints_distance.value = 0.1
+        self.pdos_degauss.value = 0.01

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -24,6 +24,11 @@ class Setting(Panel):
             """<div style="padding-top: 0px; padding-bottom: 0px">
             <h4>Settings</h4></div>"""
         )
+        self.description = ipw.HTML(
+            """<div style="line-height: 140%; padding-top: 0px; padding-bottom: 5px">
+                By default, the tetrahedron method is used for PDOS calculation. If required you can apply Gaussian broadening with a custom degauss value.
+            </div>"""
+        )
         # nscf kpoints setting widget
         self.nscf_kpoints_distance = ipw.BoundedFloatText(
             min=0.001,
@@ -58,6 +63,7 @@ class Setting(Panel):
         self.nscf_kpoints_distance.observe(self._procotol_changed, "change")
         self.children = [
             self.settings_title,
+            self.description,
             ipw.HBox([self.nscf_kpoints_distance, self.mesh_grid]),
             self.use_pdos_degauss,
             ipw.HBox([self.pdos_degauss, self.pdos_degauss_eV]),

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -51,9 +51,8 @@ class Setting(Panel):
             disabled=True,
             style={"description_width": "initial"},
         )
-        self.pdos_degauss_eV = ipw.HTML()
-        self.pdos_degauss_eV.value = (
-            f"({self.pdos_degauss.value * RYDBERG_TO_EV:.4f} eV)"
+        self.pdos_degauss_eV = ipw.HTML(
+            value=f"({self.pdos_degauss.value * RYDBERG_TO_EV:.4f} eV)",
         )
 
         self.use_pdos_degauss.observe(self._disable_pdos_degauss, "value")

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -52,12 +52,23 @@ def get_builder(codes, structure, parameters, **kwargs):
     scf_overrides = deepcopy(parameters["advanced"])
     nscf_overrides = deepcopy(parameters["advanced"])
 
+    # Dos Projwfc overrides
+    dos_overrides = {"parameters": {"DOS": {}}}
+    projwfc_overrides = {"parameters": {"PROJWFC": {}}}
+
+    dos_overrides["parameters"]["DOS"] = {"degauss": parameters["pdos"]["pdos_degauss"]}
+    projwfc_overrides["parameters"]["PROJWFC"] = {
+        "degauss": parameters["pdos"]["pdos_degauss"]
+    }
+
     # Update the nscf kpoints distance from the setting panel
     nscf_overrides["kpoints_distance"] = parameters["pdos"]["nscf_kpoints_distance"]
 
     overrides = {
         "scf": scf_overrides,
         "nscf": nscf_overrides,
+        "dos": dos_overrides,
+        "projwfc": projwfc_overrides,
     }
     if dos_code is not None and projwfc_code is not None:
         pdos = PdosWorkChain.get_builder_from_protocol(

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -56,10 +56,11 @@ def get_builder(codes, structure, parameters, **kwargs):
     dos_overrides = {"parameters": {"DOS": {}}}
     projwfc_overrides = {"parameters": {"PROJWFC": {}}}
 
-    dos_overrides["parameters"]["DOS"] = {"degauss": parameters["pdos"]["pdos_degauss"]}
-    projwfc_overrides["parameters"]["PROJWFC"] = {
-        "degauss": parameters["pdos"]["pdos_degauss"]
-    }
+    if parameters["pdos"]["use_pdos_degauss"]:
+        dos_overrides["parameters"]["DOS"] = {"degauss": parameters["pdos"]["pdos_degauss"]}
+        projwfc_overrides["parameters"]["PROJWFC"] = {
+            "degauss": parameters["pdos"]["pdos_degauss"]
+        }
 
     # Update the nscf kpoints distance from the setting panel
     nscf_overrides["kpoints_distance"] = parameters["pdos"]["nscf_kpoints_distance"]

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -57,7 +57,9 @@ def get_builder(codes, structure, parameters, **kwargs):
     projwfc_overrides = {"parameters": {"PROJWFC": {}}}
 
     if parameters["pdos"]["use_pdos_degauss"]:
-        dos_overrides["parameters"]["DOS"] = {"degauss": parameters["pdos"]["pdos_degauss"]}
+        dos_overrides["parameters"]["DOS"] = {
+            "degauss": parameters["pdos"]["pdos_degauss"]
+        }
         projwfc_overrides["parameters"]["PROJWFC"] = {
             "degauss": parameters["pdos"]["pdos_degauss"]
         }

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -43,7 +43,7 @@ codes:
     parallelization: {}
 pdos:
   nscf_kpoints_distance: 0.1
-  pdos_degauss: 0.01
+  pdos_degauss: 0.005
   use_pdos_degauss: false
 workchain:
   electronic_type: metal

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -43,6 +43,7 @@ codes:
     parallelization: {}
 pdos:
   nscf_kpoints_distance: 0.1
+  pdos_degauss: 0.01
 workchain:
   electronic_type: metal
   properties:

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -44,6 +44,7 @@ codes:
 pdos:
   nscf_kpoints_distance: 0.1
   pdos_degauss: 0.01
+  use_pdos_degauss: false
 workchain:
   electronic_type: metal
   properties:


### PR DESCRIPTION
This tab includes a degauss widget to the pdos plugin
This useful for some case where the PDOS calculation doesnt obtain some projections (is a projwfc,x bug , that Giovanni mentioned) , this is a way around to avoid this. 

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/ff495f77-694c-4f48-8627-5e0aecf34a22">

This solves the issue of core electron density not displayed before for Au 

Now
![image](https://github.com/user-attachments/assets/695c7ff3-2dcd-4e9e-8df7-aeb941baa7e6)

Before 
![image](https://github.com/user-attachments/assets/8aac865b-0970-43a0-b246-5c73f68fc943)

This PR is quite important since it also affects states around fermi level like in this case , if you noticed there are some missing states in the pdos

![image](https://github.com/user-attachments/assets/1db29a86-79b9-4809-be8c-1ce575b0db94)


