### PR TITLE
Fix/638/remove job selection

### DIFF
--- a/qe.ipynb
+++ b/qe.ipynb
@@ -95,7 +95,8 @@
     "    pk = int(query[\"pk\"][0])\n",
     "    app_with_work_chain_selector.work_chain_selector.value = pk\n",
     "\n",
-    "view.main.children = [app_with_work_chain_selector]"
+    "view.main.children = [app_with_work_chain_selector]\n",
+    "view.app = app_with_work_chain_selector"
    ]
   },
   {

--- a/qe.ipynb
+++ b/qe.ipynb
@@ -89,14 +89,14 @@
     "url = urlparse.urlsplit(jupyter_notebook_url)  # noqa F821\n",
     "query = urlparse.parse_qs(url.query)\n",
     "\n",
-    "app_with_work_chain_selector = App(qe_auto_setup=True)\n",
-    "# if a pk is provided in the query string, set it as the value of the work_chain_selector\n",
+    "app = App(qe_auto_setup=True)\n",
+    "# if a pk is provided in the query string, set it as the process of the app\n",
     "if \"pk\" in query:\n",
-    "    pk = int(query[\"pk\"][0])\n",
-    "    app_with_work_chain_selector.work_chain_selector.value = pk\n",
+    "    pk = query[\"pk\"][0]\n",
+    "    app.process = pk\n",
     "\n",
-    "view.main.children = [app_with_work_chain_selector]\n",
-    "view.app = app_with_work_chain_selector"
+    "view.main.children = [app]\n",
+    "view.app = app"
    ]
   },
   {

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -80,7 +80,7 @@ class App(ipw.VBox):
 
         super().__init__(
             children=[
-                self.work_chain_selector,
+                # self.work_chain_selector,
                 self._wizard_app_widget,
             ]
         )

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -74,10 +74,11 @@ class App(ipw.VBox):
 
         # Add a button to start a new calculation
         self.new_work_chains_button = ipw.Button(
-            description="New calculation",
-            tooltip="Start a new calculation",
+            description="Start New Calculation",
+            tooltip="Open a new page to start a separate calculation",
             button_style="success",
             icon="plus-circle",
+            layout=ipw.Layout(width="30%"),
         )
 
         def on_button_click(_):

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -4,6 +4,7 @@ Authors: AiiDAlab team
 """
 
 import ipywidgets as ipw
+import traitlets as tl
 from IPython.display import Javascript, display
 
 from aiida.orm import load_node
@@ -12,14 +13,13 @@ from aiidalab_qe.app.result import ViewQeAppWorkChainStatusAndResultsStep
 from aiidalab_qe.app.structure import StructureSelectionStep
 from aiidalab_qe.app.submission import SubmitQeAppWorkChainStep
 from aiidalab_widgets_base import WizardAppWidget, WizardAppWidgetStep
-import traitlets as tl
 
 
 class App(ipw.VBox):
     """The main widget that combines all the application steps together."""
+
     # The PK or UUID of the work chain node.
     process = tl.Union([tl.Unicode(), tl.Int()], allow_none=True)
-
 
     def __init__(self, qe_auto_setup=True):
         # Create the application steps

--- a/src/aiidalab_qe/app/utils/search_jobs.py
+++ b/src/aiidalab_qe/app/utils/search_jobs.py
@@ -1,18 +1,20 @@
-import ipywidgets as ipw
-import pandas as pd
-from IPython.display import display
-
-from aiida.orm import QueryBuilder
-from aiidalab_qe.workflows import QeAppWorkChain
-
-
 class QueryInterface:
     def __init__(self):
+        pass
+
+    def setup_table(self):
+        import ipywidgets as ipw
+
         self.df = self.load_data()
         self.table = ipw.HTML()
         self.setup_widgets()
 
     def load_data(self):
+        import pandas as pd
+
+        from aiida.orm import QueryBuilder
+        from aiidalab_qe.workflows import QeAppWorkChain
+
         projections = [
             "id",
             "extras.structure",
@@ -70,6 +72,8 @@ class QueryInterface:
         ]
 
     def setup_widgets(self):
+        import ipywidgets as ipw
+
         self.css_style = """
             <style>
                 .df { border: none; }
@@ -151,6 +155,8 @@ class QueryInterface:
         )
 
     def apply_filters(self, _):
+        import pandas as pd
+
         selected_properties = [
             cb.description for cb in self.properties_box.children if cb.value
         ]
@@ -184,5 +190,7 @@ class QueryInterface:
         self.get_table_value(filtered_df)
 
     def display(self):
+        from IPython.display import display
+
         display(self.filters_layout)
         display(self.table)

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -49,24 +49,28 @@ class AppWrapperContoller:
         self._view.guide_toggle.disabled = False
         self._view.about_toggle.disabled = False
         self._view.job_list_toggle.disabled = False
-        self._view.plugin_list_toggle.disabled = False
 
     @without_triggering("about_toggle")
     def _on_guide_toggle(self, change: dict):
         """Toggle the guide section."""
+        if change["new"]:
+            self._view.job_list_toggle.value = False
         self._view.info_container.children = [self._view.guide] if change["new"] else []
         self._view.info_container.layout.display = "flex" if change["new"] else "none"
 
     @without_triggering("guide_toggle")
     def _on_about_toggle(self, change: dict):
         """Toggle the about section."""
+        if change["new"]:
+            self._view.job_list_toggle.value = False
         self._view.info_container.children = [self._view.about] if change["new"] else []
         self._view.info_container.layout.display = "flex" if change["new"] else "none"
 
-    @without_triggering("guide_toggle")
     def _on_job_list_toggle(self, change: dict):
-        """Toggle the about section."""
+        """Toggle the job list section."""
         if change["new"]:
+            self._view.about_toggle.value = False
+            self._view.guide_toggle.value = False
             self._view.job_list.setup_table()
             self._view.main.children = [
                 self._view.job_list.filters_layout,
@@ -143,18 +147,9 @@ class AppWrapperView(ipw.VBox):
 
         self.job_list_toggle = ipw.ToggleButton(
             button_style="",
-            icon="info",
+            icon="list",
             value=False,
             description="Job List",
-            tooltip="Learn about the app",
-            disabled=True,
-        )
-
-        self.plugin_list_toggle = ipw.ToggleButton(
-            button_style="",
-            icon="info",
-            value=False,
-            description="Plugin List",
             tooltip="Learn about the app",
             disabled=True,
         )
@@ -164,7 +159,6 @@ class AppWrapperView(ipw.VBox):
                 self.guide_toggle,
                 self.about_toggle,
                 self.job_list_toggle,
-                self.plugin_list_toggle,
             ]
         )
         info_toggles.add_class("info-toggles")

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -48,6 +48,8 @@ class AppWrapperContoller:
         """Enable the toggle buttons."""
         self._view.guide_toggle.disabled = False
         self._view.about_toggle.disabled = False
+        self._view.job_list_toggle.disabled = False
+        self._view.plugin_list_toggle.disabled = False
 
     @without_triggering("about_toggle")
     def _on_guide_toggle(self, change: dict):
@@ -61,10 +63,23 @@ class AppWrapperContoller:
         self._view.info_container.children = [self._view.about] if change["new"] else []
         self._view.info_container.layout.display = "flex" if change["new"] else "none"
 
+    @without_triggering("guide_toggle")
+    def _on_job_list_toggle(self, change: dict):
+        """Toggle the about section."""
+        if change["new"]:
+            self._view.job_list.setup_table()
+            self._view.main.children = [
+                self._view.job_list.filters_layout,
+                self._view.job_list.table,
+            ]
+        else:
+            self._view.main.children = [self._view.app]
+
     def _set_event_handlers(self) -> None:
         """Set up event handlers."""
         self._view.guide_toggle.observe(self._on_guide_toggle, "value")
         self._view.about_toggle.observe(self._on_about_toggle, "value")
+        self._view.job_list_toggle.observe(self._on_job_list_toggle, "value")
 
 
 class AppWrapperModel(traitlets.HasTraits):
@@ -89,6 +104,7 @@ class AppWrapperView(ipw.VBox):
         from jinja2 import Environment
 
         from aiidalab_qe.app.static import templates
+        from aiidalab_qe.app.utils.search_jobs import QueryInterface
         from aiidalab_qe.common.infobox import InfoBox
         from aiidalab_qe.version import __version__
 
@@ -125,10 +141,30 @@ class AppWrapperView(ipw.VBox):
             disabled=True,
         )
 
+        self.job_list_toggle = ipw.ToggleButton(
+            button_style="",
+            icon="info",
+            value=False,
+            description="Job List",
+            tooltip="Learn about the app",
+            disabled=True,
+        )
+
+        self.plugin_list_toggle = ipw.ToggleButton(
+            button_style="",
+            icon="info",
+            value=False,
+            description="Plugin List",
+            tooltip="Learn about the app",
+            disabled=True,
+        )
+
         info_toggles = ipw.HBox(
             children=[
                 self.guide_toggle,
                 self.about_toggle,
+                self.job_list_toggle,
+                self.plugin_list_toggle,
             ]
         )
         info_toggles.add_class("info-toggles")
@@ -141,6 +177,7 @@ class AppWrapperView(ipw.VBox):
         self.about = ipw.HTML(env.from_string(about_template).render())
 
         self.info_container = InfoBox()
+        self.job_list = QueryInterface()
 
         header = ipw.VBox(
             children=[

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -48,13 +48,13 @@ class AppWrapperContoller:
         """Enable the toggle buttons."""
         self._view.guide_toggle.disabled = False
         self._view.about_toggle.disabled = False
-        self._view.job_list_toggle.disabled = False
+        self._view.job_history_toggle.disabled = False
 
     @without_triggering("about_toggle")
     def _on_guide_toggle(self, change: dict):
         """Toggle the guide section."""
         if change["new"]:
-            self._view.job_list_toggle.value = False
+            self._view.job_history_toggle.value = False
         self._view.info_container.children = [self._view.guide] if change["new"] else []
         self._view.info_container.layout.display = "flex" if change["new"] else "none"
 
@@ -62,19 +62,19 @@ class AppWrapperContoller:
     def _on_about_toggle(self, change: dict):
         """Toggle the about section."""
         if change["new"]:
-            self._view.job_list_toggle.value = False
+            self._view.job_history_toggle.value = False
         self._view.info_container.children = [self._view.about] if change["new"] else []
         self._view.info_container.layout.display = "flex" if change["new"] else "none"
 
-    def _on_job_list_toggle(self, change: dict):
+    def _on_job_history_toggle(self, change: dict):
         """Toggle the job list section."""
         if change["new"]:
             self._view.about_toggle.value = False
             self._view.guide_toggle.value = False
-            self._view.job_list.setup_table()
+            self._view.job_history.setup_table()
             self._view.main.children = [
-                self._view.job_list.filters_layout,
-                self._view.job_list.table,
+                self._view.job_history.filters_layout,
+                self._view.job_history.table,
             ]
         else:
             self._view.main.children = [self._view.app]
@@ -83,7 +83,7 @@ class AppWrapperContoller:
         """Set up event handlers."""
         self._view.guide_toggle.observe(self._on_guide_toggle, "value")
         self._view.about_toggle.observe(self._on_about_toggle, "value")
-        self._view.job_list_toggle.observe(self._on_job_list_toggle, "value")
+        self._view.job_history_toggle.observe(self._on_job_history_toggle, "value")
 
 
 class AppWrapperModel(traitlets.HasTraits):
@@ -145,20 +145,21 @@ class AppWrapperView(ipw.VBox):
             disabled=True,
         )
 
-        self.job_list_toggle = ipw.ToggleButton(
+        self.job_history_toggle = ipw.ToggleButton(
             button_style="",
             icon="list",
             value=False,
-            description="Job List",
-            tooltip="Learn about the app",
+            description="Job History",
+            tooltip="View all jobs run with this app",
             disabled=True,
+            layout=ipw.Layout(width="auto"),
         )
 
         info_toggles = ipw.HBox(
             children=[
                 self.guide_toggle,
                 self.about_toggle,
-                self.job_list_toggle,
+                self.job_history_toggle,
             ]
         )
         info_toggles.add_class("info-toggles")
@@ -171,7 +172,7 @@ class AppWrapperView(ipw.VBox):
         self.about = ipw.HTML(env.from_string(about_template).render())
 
         self.info_container = InfoBox()
-        self.job_list = QueryInterface()
+        self.job_history = QueryInterface()
 
         header = ipw.VBox(
             children=[

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ def test_reload_and_reset(submit_app_generator, generate_qeapp_workchain):
     )
     app = submit_app_generator()
     # select the pk
-    app.work_chain_selector.value = wkchain.node.pk
+    app.process = wkchain.node.pk
     # check if the value are reload correctly
     assert app.configure_step.workchain_settings.relax_type.value == "positions"
     assert app.configure_step.workchain_settings.spin_type.value == "collinear"
@@ -30,7 +30,7 @@ def test_reload_and_reset(submit_app_generator, generate_qeapp_workchain):
     app._wizard_app_widget.selected_index = 2
     assert app.configure_step.state == app.configure_step.State.SUCCESS
     # new workflow, this will reset the GUI
-    app.work_chain_selector.value = None
+    app.process = None
     # check if the value are reload correctly
     assert app.structure_step.manager.structure is None
     assert app.configure_step.workchain_settings.relax_type.value == "positions_cell"


### PR DESCRIPTION
This PR fixs #813 .

- Removed the workchain selector on the top
- Remove the `previous`, `next` and `reset` header.

Then, I added
- A new `Job list` button on the top
- A button to create a new calculation. It will create a new QE App page, instead of reset the current APP.

https://github.com/user-attachments/assets/ef821b62-4119-4659-9dc5-bb1c25414315

