### PR TITLE
Add button to trigger the update of the results tabs.

### DIFF
--- a/src/aiidalab_qe/app/result/__init__.py
+++ b/src/aiidalab_qe/app/result/__init__.py
@@ -51,8 +51,8 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
             description="Kill workchain",
             tooltip="Kill the below workchain.",
             button_style="danger",
-            icon="window-close",
-            layout=ipw.Layout(width="120px", height="40px", display="none"),
+            icon="stop",
+            layout=ipw.Layout(width="120px", display="none", margin="0px 20px 0px 0px"),
         )
         self.kill_button.on_click(self._on_click_kill_button)
 
@@ -60,19 +60,30 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
             description="Clean remote data",
             tooltip="Clean the remote folders of the workchain.",
             button_style="danger",
-            icon="folder",
-            layout=ipw.Layout(width="150px", height="40px", display="none"),
+            icon="trash",
+            layout=ipw.Layout(width="150px", display="none", margin="0px 20px 0px 0px"),
         )
         self.clean_scratch_button.on_click(self._on_click_clean_scratch_button)
+        self.update_result_button = ipw.Button(
+            description="Update results tabs",
+            tooltip="Trigger the update of the results tabs.",
+            button_style="success",
+            icon="refresh",
+            layout=ipw.Layout(
+                width="150px", display="block", margin="0px 20px 0px 0px"
+            ),
+        )
+        self.update_result_button.on_click(self._on_click_update_result_button)
 
         self.process_info = ipw.HTML()
 
         super().__init__(
             [
+                self.process_info,
                 ipw.HBox(
                     children=[
                         self.kill_button,
-                        self.process_info,
+                        self.update_result_button,
                         self.clean_scratch_button,
                     ]
                 ),
@@ -189,6 +200,12 @@ class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
 
         # update the kill button layout
         self._update_clean_scratch_button_layout()
+
+    def _on_click_update_result_button(self, _=None):
+        """Trigger the update of the results tabs."""
+        # change the node to trigger the update of the view.
+        self.node_view.node = None
+        self.node_view.node = orm.load_node(self.process)
 
     @tl.observe("process")
     def _observe_process(self, _):

--- a/src/aiidalab_qe/app/result/workchain_viewer.py
+++ b/src/aiidalab_qe/app/result/workchain_viewer.py
@@ -16,7 +16,7 @@ from aiida.common import LinkType
 from aiida.orm.utils.serialize import deserialize_unsafe
 from aiidalab_qe.app.static import styles, templates
 from aiidalab_qe.app.utils import get_entry_items
-from aiidalab_widgets_base import ProcessMonitor, register_viewer_widget
+from aiidalab_widgets_base import register_viewer_widget
 from aiidalab_widgets_base.viewers import StructureDataViewer
 
 from .summary_viewer import SummaryView
@@ -84,18 +84,19 @@ class WorkChainViewer(ipw.VBox):
                 toggle_camera()
 
         self.result_tabs.observe(on_selected_index_change, "selected_index")
+        self._update_view()
 
         super().__init__(
             children=[self.title, self.result_tabs],
             **kwargs,
         )
-        self.process_monitor = ProcessMonitor(
-            timeout=1.0,
-            on_sealed=[
-                self._update_view,
-            ],
-        )
-        ipw.dlink((self, "process_uuid"), (self.process_monitor, "value"))
+        # self.process_monitor = ProcessMonitor(
+        #     timeout=1.0,
+        #     on_sealed=[
+        #         self._update_view,
+        #     ],
+        # )
+        # ipw.dlink((self, "process_uuid"), (self.process_monitor, "value"))
 
     @property
     def node(self):


### PR DESCRIPTION
In PR #844 , the process monitor updates the result tabs in another thread. This leads to an issue: when the user interacts with the result, the widget runs in the thread differently from the one running in the process monitor.

Therefore, triggering the automatic updating of the result tabs is not possible.

In this PR, we don't use process monitor anymore. Instead, we add a button to let the user trigger the update manually. 

![Screenshot from 2024-10-21 13-04-52](https://github.com/user-attachments/assets/23a27259-6287-4edd-9bc6-15175ce7aaa9)

I also modified the layout of the buttons (kill, clean) to make the UI pretty.