### PR TITLE
adding a widget to control DeltaE in PDOS plugin

### DIFF
--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -21,6 +21,7 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
     mesh_grid = tl.Unicode("")
     use_pdos_degauss = tl.Bool(False)
     pdos_degauss = tl.Float(0.005)
+    energy_grid_step = tl.Float(0.01)
 
     def update(self, specific=""):
         with self.hold_trait_notifications():
@@ -35,6 +36,7 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
             "nscf_kpoints_distance": self.kpoints_distance,
             "use_pdos_degauss": self.use_pdos_degauss,
             "pdos_degauss": self.pdos_degauss,
+            "energy_grid_step": self.energy_grid_step,
         }
 
     def set_model_state(self, parameters: dict):
@@ -44,12 +46,14 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
         )
         self.use_pdos_degauss = parameters.get("use_pdos_degauss", False)
         self.pdos_degauss = parameters.get("pdos_degauss", 0.005)
+        self.energy_grid_step = parameters.get("energy_grid_step", 0.01)
 
     def reset(self):
         with self.hold_trait_notifications():
             self.kpoints_distance = self._get_default("kpoints_distance")
             self.use_pdos_degauss = self._get_default("use_pdos_degauss")
             self.pdos_degauss = self._get_default("pdos_degauss")
+            self.energy_grid_step = self._get_default("energy_grid_step")
 
     def _get_default(self, trait):
         return self._defaults.get(trait, self.traits()[trait].default_value)

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -95,6 +95,17 @@ class PdosConfigurationSettingPanel(
             lambda degauss: f"({degauss * RYDBERG_TO_EV:.4f} eV)",
         )
 
+        self.energy_grid_step = ipw.BoundedFloatText(
+            min=0.001,
+            step=0.001,
+            description="Energy grid step (eV):",
+            style={"description_width": "initial"},
+        )
+        ipw.link(
+            (self._model, "energy_grid_step"),
+            (self.energy_grid_step, "value"),
+        )
+
         self.children = [
             ipw.HTML("""
                 <div style="padding-top: 0px; padding-bottom: 0px">
@@ -103,12 +114,14 @@ class PdosConfigurationSettingPanel(
             """),
             ipw.HTML("""
                 <div style="line-height: 140%; padding-top: 0px; padding-bottom: 5px">
-                    By default, the tetrahedron method is used for PDOS calculation.
-                    If required you can apply Gaussian broadening with a custom degauss
-                    value.
+                    By default, the <b>tetrahedron method</b> is used for partial density of states (PDOS) calculation.
+                    However, if you need more control over the broadening, you can apply <b>Gaussian broadening</b>
+                    by specifying a custom <b>degauss</b> value.
                     <br>
-                    For molecules and systems with localized orbitals, it is
-                    recommended to use a custom degauss value.
+                    <b>Recommendation for Molecules and Localized Orbitals:</b><br>
+                    For systems involving molecules or localized orbitals, it is recommended to use a
+                    <b>custom degauss value</b>. This will provide a more accurate representation of the PDOS,
+                    especially when the electronic states are localized.
                 </div>
             """),
             ipw.HBox(
@@ -117,6 +130,7 @@ class PdosConfigurationSettingPanel(
                     self.mesh_grid,
                 ]
             ),
+            self.energy_grid_step,
             self.use_pdos_degauss,
             ipw.HBox(
                 children=[

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -118,7 +118,8 @@ class PdosConfigurationSettingPanel(
                     However, if you need more control over the broadening, you can apply <b>Gaussian broadening</b>
                     by specifying a custom <b>degauss</b> value.
                     <br>
-                    <b>Recommendation for Molecules and Localized Orbitals:</b><br>
+                    <b>Recommendation for Molecules and Localized Orbitals:</b>
+                    <br>
                     For systems involving molecules or localized orbitals, it is recommended to use a
                     <b>custom degauss value</b>. This will provide a more accurate representation of the PDOS,
                     especially when the electronic states are localized.

--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -53,8 +53,20 @@ def get_builder(codes, structure, parameters, **kwargs):
     nscf_overrides = deepcopy(parameters["advanced"])
 
     # Dos Projwfc overrides
-    dos_overrides = {"parameters": {"DOS": {}}}
-    projwfc_overrides = {"parameters": {"PROJWFC": {}}}
+    dos_overrides = {
+        "parameters": {
+            "DOS": {
+                "DeltaE": parameters["pdos"]["energy_grid_step"],
+            }
+        }
+    }
+    projwfc_overrides = {
+        "parameters": {
+            "PROJWFC": {
+                "DeltaE": parameters["pdos"]["energy_grid_step"],
+            }
+        }
+    }
 
     if parameters["pdos"]["use_pdos_degauss"]:
         dos_overrides["parameters"]["DOS"] = {

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -89,6 +89,7 @@ codes:
         parallelization: {}
     override: false
 pdos:
+  energy_grid_step: 0.01
   nscf_kpoints_distance: 0.1
   pdos_degauss: 0.005
   use_pdos_degauss: false


### PR DESCRIPTION
This PR solves the problem with #959 
The solution is to set DeltaE[https://www.quantum-espresso.org/Doc/INPUT_PROJWFC.html#idm30]  (energy grid step eV) from dos.x and projwfc.x. 

![image](https://github.com/user-attachments/assets/53106ea1-8713-4aa1-8fe8-8c4bee77937e)
Here, we also modified a bit the description of the PDOS plugin tab, plus the addition of the new widget. 


By enforcing the DeltaE to be 0.01 eV we get to see the core level pdos peaks 

![newplot (2)](https://github.com/user-attachments/assets/be749029-7e94-4109-ac96-230ba3ac1b83)
