### PR TITLE
Move spin orbit to basic settings

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -253,25 +253,6 @@ class AdvancedConfigurationSettingsPanel(
             lambda override: not override,
         )
 
-        # Spin-Orbit calculation
-        self.spin_orbit = ipw.ToggleButtons(
-            description="Spin-Orbit:",
-            style={"description_width": "initial"},
-        )
-        ipw.dlink(
-            (self._model, "spin_orbit_options"),
-            (self.spin_orbit, "options"),
-        )
-        ipw.link(
-            (self._model, "spin_orbit"),
-            (self.spin_orbit, "value"),
-        )
-        ipw.dlink(
-            (self._model, "override"),
-            (self.spin_orbit, "disabled"),
-            lambda override: not override,
-        )
-
         self.pseudos.render()
 
         self.children = [
@@ -335,7 +316,6 @@ class AdvancedConfigurationSettingsPanel(
                 ]
             ),
             self.hubbard,
-            self.spin_orbit,
             self.pseudos,
         ]
 

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -37,11 +37,13 @@ class AdvancedConfigurationSettingsModel(
         "workchain.protocol",
         "workchain.spin_type",
         "workchain.electronic_type",
+        "workchain.spin_orbit",
     ]
 
     protocol = tl.Unicode()
     spin_type = tl.Unicode()
     electronic_type = tl.Unicode()
+    spin_orbit = tl.Unicode()
 
     clean_workdir = tl.Bool(False)
     override = tl.Bool(False)
@@ -58,14 +60,6 @@ class AdvancedConfigurationSettingsModel(
         ],
     )
     van_der_waals = tl.Unicode(DEFAULT["advanced"]["vdw_corr"])
-    spin_orbit_options = tl.List(
-        trait=tl.List(tl.Unicode()),
-        default_value=[
-            ["Off", "wo_soc"],
-            ["On", "soc"],
-        ],
-    )
-    spin_orbit = tl.Unicode("wo_soc")
     forc_conv_thr = tl.Float(0.0)
     forc_conv_thr_step = tl.Float(1e-4)
     etot_conv_thr = tl.Float(0.0)

--- a/src/aiidalab_qe/app/configuration/basic/model.py
+++ b/src/aiidalab_qe/app/configuration/basic/model.py
@@ -39,6 +39,14 @@ class BasicConfigurationSettingsModel(ConfigurationSettingsModel):
         ],
     )
     electronic_type = tl.Unicode(DEFAULT["workchain"]["electronic_type"])
+    spin_orbit_options = tl.List(
+        trait=tl.List(tl.Unicode()),
+        default_value=[
+            ["Off", "wo_soc"],
+            ["On", "soc"],
+        ],
+    )
+    spin_orbit = tl.Unicode("wo_soc")
 
     include = True
 

--- a/src/aiidalab_qe/app/configuration/basic/workflow.py
+++ b/src/aiidalab_qe/app/configuration/basic/workflow.py
@@ -49,6 +49,17 @@ class BasicConfigurationSettingsPanel(
             (self.electronic_type, "value"),
         )
 
+        # Spin-Orbit calculation
+        self.spin_orbit = ipw.ToggleButtons(style={"description_width": "initial"})
+        ipw.dlink(
+            (self._model, "spin_orbit_options"),
+            (self.spin_orbit, "options"),
+        )
+        ipw.link(
+            (self._model, "spin_orbit"),
+            (self.spin_orbit, "value"),
+        )
+
         # Work chain protocol
         self.protocol = ipw.ToggleButtons()
         ipw.dlink(
@@ -64,10 +75,20 @@ class BasicConfigurationSettingsPanel(
             InAppGuide(identifier="basic-settings"),
             ipw.HTML("""
                 <div style="line-height: 140%; padding-top: 10px; padding-bottom: 10px">
-                    Below you can indicate both if the material should be treated as an
-                    insulator or a metal (if in doubt, choose "Metal"), and if it
-                    should be studied with magnetization/spin polarization, switch
-                    magnetism On or Off (On is at least twice more costly).
+                    Below you can indicate the following:
+                    <ol>
+                        <li>
+                            If the material should be treated as an insulator or a metal
+                            (if in doubt, choose "Metal")
+                        </li>
+                        <li>
+                            If the material should be studied with magnetization/spin
+                            polarization (at least twice as costly if activated)
+                        </li>
+                        <li>
+                            If the material should be studied with spin-orbit coupling
+                        </li>
+                    </ol>
                 </div>
             """),
             ipw.HBox(
@@ -86,6 +107,15 @@ class BasicConfigurationSettingsPanel(
                         layout=ipw.Layout(justify_content="flex-start", width="120px"),
                     ),
                     self.spin_type,
+                ]
+            ),
+            ipw.HBox(
+                children=[
+                    ipw.Label(
+                        "Spin-orbit coupling:",
+                        layout=ipw.Layout(justify_content="flex-start", width="120px"),
+                    ),
+                    self.spin_orbit,
                 ]
             ),
             ipw.HTML("""

--- a/src/aiidalab_qe/app/configuration/basic/workflow.py
+++ b/src/aiidalab_qe/app/configuration/basic/workflow.py
@@ -88,6 +88,10 @@ class BasicConfigurationSettingsPanel(
                         <li>
                             If the material should be studied with spin-orbit coupling
                         </li>
+                        <li>
+                            The protocol to use for the calculation, which sets default
+                            values balancing the accuracy and speed of the calculation
+                        </li>
                     </ol>
                 </div>
             """),
@@ -118,13 +122,15 @@ class BasicConfigurationSettingsPanel(
                     self.spin_orbit,
                 ]
             ),
-            ipw.HTML("""
-                <div style="padding-top: 0px; padding-bottom: 0px">
-                    <h4>Protocol</h4>
-                </div>
-            """),
-            ipw.HTML("Select the protocol:", layout=ipw.Layout(flex="1 1 auto")),
-            self.protocol,
+            ipw.HBox(
+                children=[
+                    ipw.Label(
+                        "Protocol:",
+                        layout=ipw.Layout(justify_content="flex-start", width="120px"),
+                    ),
+                    self.protocol,
+                ]
+            ),
             ipw.HTML("""
                 <div style="line-height: 140%; padding-top: 6px; padding-bottom: 0px">
                     The "moderate" protocol represents a trade-off between accuracy and

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -115,7 +115,6 @@ class App(ipw.VBox):
                 self._process_loading_message,
                 self._wizard_app_widget,
                 InAppGuide(identifier="post-guide", classes=["post-guide"]),
-                InAppGuide(children=[ipw.HTML("hello")], guide_id="general/basic"),
             ]
         )
 


### PR DESCRIPTION
This PR moves the spin orbit control from advanced to basic settings. It also simplifies/uniforms the basic settings UI.

Handles #981