### PR TITLE
Utilize external resource setup notebook for code management

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -19,7 +19,7 @@ from aiidalab_qe.common.panel import (
 )
 from aiidalab_qe.common.setup_codes import QESetupWidget
 from aiidalab_qe.common.setup_pseudos import PseudosInstallWidget
-from aiidalab_qe.common.widgets import QeDependentWizardStep
+from aiidalab_qe.common.widgets import LinkButton, QeDependentWizardStep
 
 from .global_settings import GlobalResourceSettingsModel, GlobalResourceSettingsPanel
 from .model import SubmissionStepModel
@@ -135,6 +135,12 @@ class SubmitQeAppWorkChainStep(QeDependentWizardStep[SubmissionStepModel]):
             (self.submission_warning_messages, "value"),
         )
 
+        self.setup_new_codes_button = LinkButton(
+            description="Setup resources",
+            link="../home/code_setup.ipynb",
+            icon="database",
+        )
+
         self.refresh_resources_button = ipw.Button(
             description="Refresh resources",
             icon="refresh",
@@ -158,15 +164,20 @@ class SubmitQeAppWorkChainStep(QeDependentWizardStep[SubmissionStepModel]):
                 <div style="line-height: 140%; padding-top: 0px; padding-bottom: 10px">
                     Select the codes to use for running the calculations. The codes on
                     the local machine (localhost) are installed by default, but you can
-                    configure new ones on potentially more powerful machines by visiting
-                    the <a href="../home/code_setup.ipynb" target="_blank">resource
-                    setup</a> page (see also <i class="fa fa-database"></i>
-                    button at the top of the app). Make sure to click the <b>Refresh
-                    resources</b> button below after making changes to AiiDA resources
-                    to update the app resources.
+                    configure new ones on potentially more powerful machines by clicking
+                    on <i class="fa fa-database"></i> <b>Setup resources</b> (also at
+                    the top of the app). Make sure to click the <b>Refresh resources</b>
+                    button below after making changes to AiiDA resources to update the
+                    app resources.
                 </div>
             """),
-            self.refresh_resources_button,
+            ipw.HBox(
+                children=[
+                    self.setup_new_codes_button,
+                    self.refresh_resources_button,
+                ],
+                layout=ipw.Layout(grid_gap="5px"),
+            ),
             self.tabs,
             self.sssp_installation,
             self.qe_setup,

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -135,6 +135,14 @@ class SubmitQeAppWorkChainStep(QeDependentWizardStep[SubmissionStepModel]):
             (self.submission_warning_messages, "value"),
         )
 
+        self.refresh_resources_button = ipw.Button(
+            description="Refresh resources",
+            icon="refresh",
+            button_style="primary",
+            layout=ipw.Layout(width="fit-content", margin="2px 2px 12px"),
+        )
+        self.refresh_resources_button.on_click(self._refresh_resources)
+
         self.tabs = ipw.Tab(
             layout=ipw.Layout(min_height="250px"),
             selected_index=None,
@@ -147,32 +155,29 @@ class SubmitQeAppWorkChainStep(QeDependentWizardStep[SubmissionStepModel]):
         self.children = [
             InAppGuide(identifier="submission-step"),
             ipw.HTML("""
-                <div style="padding-top: 0px; padding-bottom: 0px">
-                    <h4>Codes</h4>
-                </div>
-            """),
-            ipw.HTML("""
                 <div style="line-height: 140%; padding-top: 0px; padding-bottom: 10px">
-                    Select the code to use for running the calculations. The codes on
+                    Select the codes to use for running the calculations. The codes on
                     the local machine (localhost) are installed by default, but you can
-                    configure new ones on potentially more powerful machines by clicking
-                    on "Setup new code".
+                    configure new ones on potentially more powerful machines by visiting
+                    the <a href="../home/code_setup.ipynb" target="_blank">resource
+                    setup</a> page (see also <i class="fa fa-database"></i>
+                    button at the top of the app). Make sure to click the <b>Refresh
+                    resources</b> button below after making changes to AiiDA resources
+                    to update the app resources.
                 </div>
             """),
+            self.refresh_resources_button,
             self.tabs,
             self.sssp_installation,
             self.qe_setup,
             self.submission_blocker_messages,
             self.submission_warning_messages,
             ipw.HTML("""
-                <div style="padding-top: 0px; padding-bottom: 0px">
-                    <h4>Labeling your job</h4>
-                    <p style="line-height: 140%; padding-top: 0px; padding-bottom: 10px">
-                        Label your job and provide a brief description. These details
-                        help identify the job later and make the search process easier.
-                        While optional, adding a description is recommended for better
-                        clarity.
-                    </p>
+                <div style="line-height: 140%; padding-top: 0px; padding-bottom: 10px">
+                    Label your job and provide a brief description. These details
+                    help identify the job later and make the search process easier.
+                    While optional, adding a description is recommended for better
+                    clarity.
                 </div>
             """),
             self.process_label,
@@ -276,6 +281,10 @@ class SubmitQeAppWorkChainStep(QeDependentWizardStep[SubmissionStepModel]):
     def _toggle_qe_installation_widget(self):
         qe_installation_display = "none" if self._model.qe_installed else "block"
         self.qe_setup.layout.display = qe_installation_display
+
+    def _refresh_resources(self, _=None):
+        for _, model in self._model.get_models():
+            model.refresh_codes()
 
     def _update_tabs(self):
         children = []

--- a/src/aiidalab_qe/app/submission/global_settings/model.py
+++ b/src/aiidalab_qe/app/submission/global_settings/model.py
@@ -93,6 +93,7 @@ class GlobalResourceSettingsModel(
                     description=name,
                     default_calc_job_plugin=default_calc_job_plugin,
                 )
+                base_code_model.activate()
             else:
                 base_code_model = CodeModel(
                     name=name,

--- a/src/aiidalab_qe/app/submission/global_settings/setting.py
+++ b/src/aiidalab_qe/app/submission/global_settings/setting.py
@@ -56,7 +56,6 @@ class GlobalResourceSettingsPanel(ResourceSettingsPanel[GlobalResourceSettingsMo
         self.rendered = True
 
         # Render any active codes
-        self._model.get_model("quantumespresso.pw").activate()
         for _, code_model in self._model.get_models():
             if code_model.is_active:
                 self._toggle_code(code_model)

--- a/src/aiidalab_qe/app/submission/global_settings/setting.py
+++ b/src/aiidalab_qe/app/submission/global_settings/setting.py
@@ -117,14 +117,6 @@ class GlobalResourceSettingsPanel(ResourceSettingsPanel[GlobalResourceSettingsMo
                 ],
             )
 
-        def update_options(_, model=code_model):
-            model.update(self._model.DEFAULT_USER_EMAIL, refresh=True)
-
-        code_widget.code_selection.code_select_dropdown.observe(
-            update_options,
-            "options",
-        )
-
         def toggle_widget(_=None, model=code_model, widget=code_widget):
             widget = self.code_widgets[model.name]
             widget.layout.display = "block" if model.is_active else "none"

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -212,13 +212,21 @@ class AppWrapperView(ipw.VBox):
             disabled=True,
         )
 
+        self.setup_resources_link = LinkButton(
+            description="Setup resources",
+            link="../home/code_setup.ipynb",
+            icon="database",
+            disabled=True,
+        )
+
         self.controls = ipw.HBox(
             children=[
                 self.guide_toggle,
                 self.about_toggle,
                 self.calculation_history_link,
+                self.setup_resources_link,
                 self.new_workchain_link,
-            ]
+            ],
         )
         self.controls.add_class("app-controls")
 

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -219,6 +219,10 @@ class ResourceSettingsModel(SettingsModel, HasModels[CodeModel]):
         super().add_model(identifier, model)
         model.update(self.DEFAULT_USER_EMAIL)
 
+    def refresh_codes(self):
+        for _, code_model in self.get_models():
+            code_model.update(self.DEFAULT_USER_EMAIL, refresh=True)
+
     def update_submission_blockers(self):
         self.submission_blockers = list(self._check_submission_blockers())
 
@@ -336,7 +340,6 @@ class ResourceSettingsPanel(SettingsPanel[RSM]):
         code_model.observe(
             self._on_code_resource_change,
             [
-                "options",
                 "selected",
                 "num_cpus",
                 "num_nodes",
@@ -375,9 +378,6 @@ class PluginResourceSettingsModel(ResourceSettingsModel):
             default_calc_job_plugin = code_model.default_calc_job_plugin
             if default_calc_job_plugin in self.global_codes:
                 code_resources: dict = self.global_codes[default_calc_job_plugin]  # type: ignore
-                options = code_resources.get("options", [])
-                if options != code_model.options:
-                    code_model.update(self.DEFAULT_USER_EMAIL, refresh=True)
                 code_model.set_model_state(code_resources)
 
     def get_model_state(self):
@@ -482,11 +482,6 @@ class PluginResourceSettingsPanel(ResourceSettingsPanel[PRSM]):
         ipw.dlink(
             (code_model, "override"),
             (code_widget.num_nodes, "disabled"),
-            lambda override: not override,
-        )
-        ipw.dlink(
-            (code_model, "override"),
-            (code_widget.code_selection.btn_setup_new_code, "disabled"),
             lambda override: not override,
         )
         ipw.dlink(

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -227,6 +227,7 @@ class ResourceSettingsModel(SettingsModel, HasModels[CodeModel]):
             "codes": {
                 identifier: code_model.get_model_state()
                 for identifier, code_model in self.get_models()
+                if code_model.is_ready
             },
         }
 
@@ -358,6 +359,10 @@ class PluginResourceSettingsModel(ResourceSettingsModel):
 
     override = tl.Bool(False)
 
+    def add_model(self, identifier, model: CodeModel):
+        super().add_model(identifier, model)
+        model.activate()
+
     def update(self):
         """Updates the code models from the global resources.
 
@@ -442,7 +447,8 @@ class PluginResourceSettingsPanel(ResourceSettingsPanel[PRSM]):
 
         # Render any active codes
         for _, code_model in self._model.get_models():
-            self._toggle_code(code_model)
+            if code_model.is_active:
+                self._toggle_code(code_model)
 
         return self.code_widgets_container
 

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -687,7 +687,11 @@ class QEAppComputationalResourcesWidget(ipw.VBox):
         """Widget to setup the compute resources, which include the code,
         the number of nodes and the number of cpus.
         """
-        self.code_selection = ComputationalResourcesWidget(**kwargs)
+        self.code_selection = ComputationalResourcesWidget(
+            include_setup_widget=False,
+            fetch_codes=True,  # TODO resolve testing issues when set to `False`
+            **kwargs,
+        )
         self.code_selection.layout.width = "80%"
 
         self.num_nodes = ipw.BoundedIntText(

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -60,13 +60,6 @@ codes:
         nodes: 1
         ntasks_per_node: 2
         parallelization: {}
-      quantumespresso.xspectra:
-        code: null
-        cpus: 1
-        cpus_per_task: 1
-        max_wallclock_seconds: 43200
-        nodes: 1
-        ntasks_per_node: 1
   pdos:
     codes:
       dos:


### PR DESCRIPTION
This PR provides a top level button and a link in step 3 to the new external resource setup notebook in aiidalab-home (https://github.com/aiidalab/aiidalab-home/pull/188). It also removes the code setup widget buttons from the individual code selectors in step 3 (in favor of the external notebook).