### PR TITLE
Do not set `nbnd` for pdos workchain

### DIFF
--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -124,11 +124,6 @@ def get_builder(codes, structure, parameters, **kwargs):
 def update_inputs(inputs, ctx):
     """Update the inputs using context."""
     inputs.structure = ctx.current_structure
-    inputs.nscf.pw.parameters = inputs.nscf.pw.parameters.get_dict()
-    if ctx.current_number_of_bands:
-        inputs.nscf.pw.parameters.setdefault("SYSTEM", {}).setdefault(
-            "nbnd", ctx.current_number_of_bands
-        )
 
 
 workchain_and_builder = {


### PR DESCRIPTION
fix #999 


In https://github.com/aiidalab/aiidalab-qe/pull/965, `nbands_factor` is used in `PdosWorkChain`, thus we should not set `nbnd` anymore.