### PR TITLE
Implement missing-info warnings

### DIFF
--- a/src/aiidalab_qe/app/configuration/__init__.py
+++ b/src/aiidalab_qe/app/configuration/__init__.py
@@ -11,6 +11,7 @@ import traitlets as tl
 from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_qe.common.infobox import InAppGuide
+from aiidalab_qe.common.mixins import DependentStep
 from aiidalab_qe.common.panel import (
     ConfigurationSettingsModel,
     ConfigurationSettingsPanel,
@@ -27,7 +28,13 @@ from .model import ConfigurationStepModel
 DEFAULT: dict = DEFAULT_PARAMETERS  # type: ignore
 
 
-class ConfigureQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
+class ConfigureQeAppWorkChainStep(
+    ipw.VBox,
+    WizardAppWidgetStep,
+    DependentStep,
+):
+    missing_information_warning = "Missing input structure. Please set it first."
+
     previous_step_state = tl.UseEnum(WizardAppWidgetStep.State)
 
     def __init__(self, model: ConfigurationStepModel, **kwargs):

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -18,6 +18,7 @@ from aiidalab_qe.app.structure.model import StructureStepModel
 from aiidalab_qe.app.submission import SubmitQeAppWorkChainStep
 from aiidalab_qe.app.submission.model import SubmissionStepModel
 from aiidalab_qe.common.infobox import InAppGuide
+from aiidalab_qe.common.mixins import DependentStep
 from aiidalab_qe.common.widgets import LoadingWidget
 from aiidalab_widgets_base import WizardAppWidget
 
@@ -140,7 +141,18 @@ class App(ipw.VBox):
 
     def _render_step(self, step_index):
         step = self.steps[step_index][1]
-        step.render()
+        if step is self.configure_step and not self.structure_model.confirmed:
+            step.show_missing_information_warning()
+        elif step is self.submit_step and not self.configure_model.confirmed:
+            step.show_missing_information_warning()
+        elif step is self.results_step and not self.submit_model.confirmed:
+            step.show_missing_information_warning()
+        elif isinstance(step, DependentStep):
+            step.hide_missing_information_warning()
+            step.render()
+            step.previous_children = step.children
+        else:
+            step.render()
 
     def _update_configuration_step(self):
         if self.structure_model.confirmed:

--- a/src/aiidalab_qe/app/result/__init__.py
+++ b/src/aiidalab_qe/app/result/__init__.py
@@ -3,6 +3,7 @@ import traitlets as tl
 
 from aiida.engine import ProcessState
 from aiidalab_qe.common.infobox import InAppGuide
+from aiidalab_qe.common.mixins import DependentStep
 from aiidalab_qe.common.widgets import LoadingWidget
 from aiidalab_widgets_base import ProcessMonitor, WizardAppWidgetStep
 
@@ -17,8 +18,16 @@ PROCESS_EXCEPTED = "<h4>Workflow is excepted!</h4>"
 PROCESS_RUNNING = "<h4>Workflow is running!</h4>"
 
 
-class ViewQeAppWorkChainStatusAndResultsStep(ipw.VBox, WizardAppWidgetStep):
+class ViewQeAppWorkChainStatusAndResultsStep(
+    ipw.VBox,
+    WizardAppWidgetStep,
+    DependentStep,
+):
     previous_step_state = tl.UseEnum(WizardAppWidgetStep.State)
+
+    missing_information_warning = (
+        "No available results. Did you submit or load a calculation?"
+    )
 
     def __init__(self, model: ResultsStepModel, **kwargs):
         super().__init__(

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -12,6 +12,7 @@ from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_qe.common.code import PluginCodes, PwCodeModel
 from aiidalab_qe.common.infobox import InAppGuide
+from aiidalab_qe.common.mixins import DependentStep
 from aiidalab_qe.common.panel import PluginResourceSettingsModel, ResourceSettingsPanel
 from aiidalab_qe.common.setup_codes import QESetupWidget
 from aiidalab_qe.common.setup_pseudos import PseudosInstallWidget
@@ -23,8 +24,12 @@ from .model import SubmissionStepModel
 DEFAULT: dict = DEFAULT_PARAMETERS  # type: ignore
 
 
-class SubmitQeAppWorkChainStep(ipw.VBox, WizardAppWidgetStep):
-    """Step for submission of a bands workchain."""
+class SubmitQeAppWorkChainStep(
+    ipw.VBox,
+    WizardAppWidgetStep,
+    DependentStep,
+):
+    missing_information_warning = "Missing input structure and/or configuration parameters. Please set them first."
 
     previous_step_state = tl.UseEnum(WizardAppWidgetStep.State)
 

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -1,5 +1,6 @@
 import typing as t
 
+import ipywidgets as ipw
 import traitlets as tl
 
 from aiida import orm
@@ -7,6 +8,23 @@ from aiida.common.exceptions import NotExistent
 from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
 
 T = t.TypeVar("T")
+
+
+class DependentStep:
+    missing_information_warning = "Missing information"
+    previous_children = []
+
+    def show_missing_information_warning(self):
+        self.children = [
+            ipw.HTML(f"""
+                <div class="alert alert-danger">
+                    <b>Warning:</b> {self.missing_information_warning}
+                </div>
+            """)
+        ]
+
+    def hide_missing_information_warning(self):
+        self.children = self.previous_children
 
 
 class HasInputStructure(tl.HasTraits):
@@ -87,12 +105,16 @@ class HasProcess(tl.HasTraits):
 class Confirmable(tl.HasTraits):
     confirmed = tl.Bool(False)
 
+    confirmation_exceptions = [
+        "confirmed",
+    ]
+
     def confirm(self):
         self.confirmed = True
 
     @tl.observe(tl.All)
     def _on_any_change(self, change):
-        if change and change["name"] != "confirmed":
+        if change and change["name"] not in self.confirmation_exceptions:
             self._unconfirm()
 
     def _unconfirm(self):


### PR DESCRIPTION
This PR introduces guards on subsequent steps that inform the user if dependencies have yet to be met, i.e., previous step(s) not confirmed.

### Pros

- Reduced chances of messing up
- Reduced development complexities (due to reduced error potential)
- Self-guiding app

### Cons

- *Reduces user exploration

*Not exactly true. The exploration is still available, but now in a prescribed (correct) order.

@cpignedoli @giovannipizzi thoughts?

![image](https://github.com/user-attachments/assets/1282e076-2b72-405d-85db-63a319c3fb6e)
---
![image](https://github.com/user-attachments/assets/c45bc18b-b857-42b5-9090-83d7fa912007)
---
![image](https://github.com/user-attachments/assets/efd18ee6-a7f9-4102-bc02-5050f65e3d0e)
