### PR TITLE
Default workdir clean on demo server

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -45,7 +45,7 @@ class AdvancedConfigurationSettingsModel(
     electronic_type = tl.Unicode()
     spin_orbit = tl.Unicode()
 
-    clean_workdir = tl.Bool(False)
+    clean_workdir = tl.Bool(DEFAULT["advanced"]["clean_workdir"])
     override = tl.Bool(False)
     total_charge = tl.Float(DEFAULT["advanced"]["tot_charge"])
     van_der_waals_options = tl.List(

--- a/src/aiidalab_qe/app/parameters/__init__.py
+++ b/src/aiidalab_qe/app/parameters/__init__.py
@@ -1,7 +1,54 @@
+from collections.abc import Mapping
 from importlib import resources
+from pathlib import Path
 
 import yaml
 
 from aiidalab_qe.app import parameters
 
+
+def recursive_merge(d1, d2):
+    """Merge dictionary `d2` into dictionary `d1` recursively.
+
+    - For keys that are in both dictionaries:
+        - If values are dictionaries, merge them recursively.
+        - Otherwise, overwrite the value in `d1` with the value in `d2`.
+    - Keys in `d2` not in `d1` are added to `d1`.
+
+    Parameters
+    ----------
+    `d1` : `dict`
+        The dictionary to merge into.
+    `d2` : `dict`
+        The dictionary to merge from.
+
+    Returns
+    -------
+    `dict`
+        The merged dictionary.
+
+    Examples
+    --------
+    >>> d1 = {'a': 1, 'b': {'c': 2, 'd': 3}}
+    >>> d2 = {'b': {'c': 4, 'e': 5}}
+    >>> recursive_merge(d1, d2)
+    {'a': 1, 'b': {'c': 4, 'd': 3, 'e': 5}}
+    """
+    for key, value in d2.items():
+        if key in d1:
+            if isinstance(d1[key], Mapping) and isinstance(value, Mapping):
+                recursive_merge(d1[key], value)
+            else:
+                d1[key] = value
+        else:
+            d1[key] = value
+    return d1
+
+
 DEFAULT_PARAMETERS = yaml.safe_load(resources.read_text(parameters, "qeapp.yaml"))
+
+
+custom_config_file = Path.home() / ".aiidalab" / "quantumespresso" / "config.yml"
+if custom_config_file.exists():
+    custom_config = yaml.safe_load(custom_config_file.read_text())
+    DEFAULT_PARAMETERS = recursive_merge(DEFAULT_PARAMETERS, custom_config)

--- a/src/aiidalab_qe/app/parameters/qeapp.yaml
+++ b/src/aiidalab_qe/app/parameters/qeapp.yaml
@@ -15,6 +15,7 @@ workchain:
 
 ## Advanced pw settings
 advanced:
+    clean_workdir: false
     pseudo_family:
         library: SSSP
         version: 1.3


### PR DESCRIPTION
This PR implement a merging mechanism for custom app defaults configurations. Users can now drop a custom `config.yml` in the `/home/jovyan/.aiidalab/quantumespresso/` directory. The file follows the structure of the `qeapp.yml` default configurations file, though it does not strictly require the inclusion of all fields. The custom `config.yml` file is processed and merged recursively into the object created from processing `qeapp.yml`.

Closes #1006

**Note**: I had to modify the updating procedure of relaxation type options and value (PBC-dependent) to accommodate these changes, though I think perhaps this was actually just a bug in that implementation.