### PR TITLE
increase fat bands slider max to 5.0 eV

### DIFF
--- a/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
@@ -135,7 +135,7 @@ class BandsPdosWidget(ipw.VBox):
 
         self.proj_bands_width_slider = ipw.FloatSlider(
             min=0.01,
-            max=2.0,
+            max=5.0,
             step=0.01,
             description="`Fat bands` max width (eV):",
             orientation="horizontal",


### PR DESCRIPTION
This PR fixes #899 , 
The max limit of the widget is set to 5.0 eV