### PR TITLE
Use `aiida-pseudo` latest repo version to bypass pseudo download issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     Jinja2~=3.0
     aiida-quantumespresso~=4.7
     aiidalab-widgets-base[optimade]==2.3.0a2
-    aiida-pseudo~=1.4
+    aiida-pseudo@git+https://github.com/aiidateam/aiida-pseudo.git
     filelock~=3.8
     importlib-resources~=5.2
     aiida-wannier90-workflows==2.3.0


### PR DESCRIPTION
This PR resolves the issue with downloading pseudos (due to missing certificates) that is failing the docker image build. The fix is to temporarily pin the `aiida-pseudo` dependency to the latest repo version, as the matter is fixed there (by https://github.com/aiidateam/aiida-pseudo/pull/179).

On merge, open an issue to revert to standard version pinning once `aiida-pseudo` releases a new version.

Closes #1026