### PR TITLE
Add `from_nodes` class method to instantiate a `BandsPdosModel` from AiiDA nodes

### DIFF
--- a/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
@@ -7,31 +7,9 @@ from .model import BandsPdosModel
 
 
 class BandsPdosWidget(ipw.VBox):
-    """
-    A widget for plotting band structure and projected density of states (PDOS) data.
+    """A widget for plotting band structure and projected density of states (PDOS)."""
 
-    Parameters
-    ----------
-    - bands (optional): A node containing band structure data.
-    - pdos (optional): A node containing PDOS data.
-
-    Attributes
-    ----------
-    - description: HTML description of the widget.
-    - dos_atoms_group: Dropdown widget to select the grouping of atoms for PDOS plotting.
-    - dos_plot_group: Dropdown widget to select the type of PDOS contributions to plot.
-    - selected_atoms: Text widget to select specific atoms for PDOS plotting.
-    - update_plot_button: Button widget to update the plot.
-    - download_button: Button widget to download the data.
-    - project_bands_box: Checkbox widget to choose whether projected bands should be plotted.
-    - plot_widget: Plotly widget for band structure and PDOS plot.
-    - bands_widget: Output widget to display the bandsplot widget.
-    """
-
-    def __init__(self, model: BandsPdosModel, bands=None, pdos=None, **kwargs):
-        if bands is None and pdos is None:
-            raise ValueError("Either bands or pdos must be provided")
-
+    def __init__(self, model: BandsPdosModel, **kwargs):
         super().__init__(
             children=[LoadingWidget("Loading widgets")],
             **kwargs,
@@ -48,9 +26,6 @@ class BandsPdosWidget(ipw.VBox):
         )
 
         self.rendered = False
-
-        self._model.bands = bands
-        self._model.pdos = pdos
 
     def render(self):
         if self.rendered:

--- a/src/aiidalab_qe/plugins/bands/result/model.py
+++ b/src/aiidalab_qe/plugins/bands/result/model.py
@@ -6,14 +6,3 @@ class BandsResultsModel(ResultsModel):
     identifier = "bands"
 
     _this_process_label = "BandsWorkChain"
-
-    def get_bands_node(self):
-        outputs = self._get_child_outputs()
-        if "bands" in outputs:
-            return outputs.bands
-        elif "bands_projwfc" in outputs:
-            return outputs.bands_projwfc
-        else:
-            # If neither 'bands' nor 'bands_projwfc' exist, use 'bands_output' itself
-            # This is the case for compatibility with older versions of the plugin
-            return outputs

--- a/src/aiidalab_qe/plugins/bands/result/result.py
+++ b/src/aiidalab_qe/plugins/bands/result/result.py
@@ -8,8 +8,8 @@ from .model import BandsResultsModel
 
 class BandsResultsPanel(ResultsPanel[BandsResultsModel]):
     def _render(self):
-        bands_node = self._model.get_bands_node()
-        model = BandsPdosModel()
-        widget = BandsPdosWidget(model=model, bands=bands_node)
+        bands_node = self._model.fetch_child_process_node()
+        model = BandsPdosModel.from_nodes(bands_node=bands_node)
+        widget = BandsPdosWidget(model=model)
         widget.render()
         self.children = [widget]

--- a/src/aiidalab_qe/plugins/electronic_structure/result/model.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/result/model.py
@@ -17,20 +17,6 @@ class ElectronicStructureResultsModel(ResultsModel):
     _pdos_process_label = "PdosWorkChain"
     _pdos_process_uuid = None
 
-    def get_pdos_node(self):
-        return self._get_child_outputs("pdos")
-
-    def get_bands_node(self):
-        outputs = self._get_child_outputs("bands")
-        if "bands" in outputs:
-            return outputs.bands
-        elif "bands_projwfc" in outputs:
-            return outputs.bands_projwfc
-        else:
-            # If neither 'bands' nor 'bands_projwfc' exist, use 'bands_output' itself
-            # This is the case for compatibility with older versions of the plugin
-            return outputs
-
     @property
     def include(self):
         return all(identifier in self.properties for identifier in self.identifiers)

--- a/src/aiidalab_qe/plugins/electronic_structure/result/result.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/result/result.py
@@ -8,9 +8,9 @@ from .model import ElectronicStructureResultsModel
 
 class ElectronicStructureResultsPanel(ResultsPanel[ElectronicStructureResultsModel]):
     def _render(self):
-        bands_node = self._model.get_bands_node()
-        pdos_node = self._model.get_pdos_node()
-        model = BandsPdosModel()
-        widget = BandsPdosWidget(model=model, bands=bands_node, pdos=pdos_node)
+        bands_node = self._model.fetch_child_process_node("bands")
+        pdos_node = self._model.fetch_child_process_node("pdos")
+        model = BandsPdosModel.from_nodes(bands_node=bands_node, pdos_node=pdos_node)
+        widget = BandsPdosWidget(model=model)
         widget.render()
         self.children = [widget]

--- a/src/aiidalab_qe/plugins/pdos/result/model.py
+++ b/src/aiidalab_qe/plugins/pdos/result/model.py
@@ -6,6 +6,3 @@ class PdosResultsModel(ResultsModel):
     identifier = "pdos"
 
     _this_process_label = "PdosWorkChain"
-
-    def get_pdos_node(self):
-        return self._get_child_outputs()

--- a/src/aiidalab_qe/plugins/pdos/result/result.py
+++ b/src/aiidalab_qe/plugins/pdos/result/result.py
@@ -8,8 +8,8 @@ from .model import PdosResultsModel
 
 class PdosResultsPanel(ResultsPanel[PdosResultsModel]):
     def _render(self):
-        pdos_node = self._model.get_pdos_node()
-        model = BandsPdosModel()
-        widget = BandsPdosWidget(model=model, pdos=pdos_node)
+        pdos_node = self._model.fetch_child_process_node()
+        model = BandsPdosModel.from_nodes(pdos_node=pdos_node)
+        widget = BandsPdosWidget(model=model)
         widget.render()
         self.children = [widget]


### PR DESCRIPTION
This PR adjusts the bands-pdos MVC component by removing the required bands/pdos `AttributeDict` nodes from the widget constructor and adding a `from_nodes` class method to the model that takes care of the `AttributeDict` extraction. This is one in several future PRs that aims to both make this MVC component more usable outside of the app (for local plotting of the electronic structure), and prepare the component for the future unification of electronic structure results tabs.