### PR TITLE
Use plugin utility to set default starting magnetization

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -50,6 +50,11 @@ class AdvancedConfigurationSettingsPanel(
             "kpoints_distance",
         )
 
+        # NOTE connect pseudos first, as some settings depend on it
+        pseudos_model = PseudosConfigurationSettingsModel()
+        self.pseudos = PseudosConfigurationSettingsPanel(model=pseudos_model)
+        model.add_model("pseudos", pseudos_model)
+
         smearing_model = SmearingConfigurationSettingsModel()
         self.smearing = SmearingConfigurationSettingsPanel(model=smearing_model)
         model.add_model("smearing", smearing_model)
@@ -63,10 +68,6 @@ class AdvancedConfigurationSettingsPanel(
         hubbard_model = HubbardConfigurationSettingsModel()
         self.hubbard = HubbardConfigurationSettingsPanel(model=hubbard_model)
         model.add_model("hubbard", hubbard_model)
-
-        pseudos_model = PseudosConfigurationSettingsModel()
-        self.pseudos = PseudosConfigurationSettingsPanel(model=pseudos_model)
-        model.add_model("pseudos", pseudos_model)
 
     def render(self):
         if self.rendered:

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -44,13 +44,18 @@ class MagnetizationConfigurationSettingsPanel(
         if self.rendered:
             return
 
-        self.description = ipw.HTML("""
-            <div style="margin-bottom: 5px;">
-                <b>Magnetization:</b>
-                <br>
-                Default magnetic moments correspond to theoretical values.
-            </div>
-        """)
+        self.header = ipw.HTML("<b>Magnetization:</b>")
+
+        self.unit = ipw.HTML(
+            value="µ<sub>B</sub>",
+            layout=ipw.Layout(margin="2px 2px 5px"),
+        )
+
+        self.magnetization_type_help = ipw.HTML()
+        ipw.dlink(
+            (self._model, "type_help"),
+            (self.magnetization_type_help, "value"),
+        )
 
         self.magnetization_type = ipw.ToggleButtons(
             style={
@@ -80,11 +85,19 @@ class MagnetizationConfigurationSettingsPanel(
             (self.tot_magnetization, "value"),
         )
 
+        self.tot_magnetization_with_unit = ipw.HBox(
+            children=[
+                self.tot_magnetization,
+                self.unit,
+            ],
+            layout=ipw.Layout(align_items="center"),
+        )
+
         self.kind_moment_widgets = ipw.VBox()
 
         self.container = ipw.VBox(
             children=[
-                self.tot_magnetization,
+                self.tot_magnetization_with_unit,
             ]
         )
 
@@ -99,12 +112,14 @@ class MagnetizationConfigurationSettingsPanel(
 
     def _on_electronic_type_change(self, _):
         self._switch_widgets()
+        self._model.update_type_help()
 
     def _on_spin_type_change(self, _):
         self.refresh(specific="spin")
 
     def _on_magnetization_type_change(self, _):
         self._toggle_widgets()
+        self._model.update_type_help()
 
     def _update(self, specific=""):
         if self.updated:
@@ -152,7 +167,15 @@ class MagnetizationConfigurationSettingsPanel(
                 ],
             )
             self.links.append(link)
-            children.append(kind_moment_widget)
+            children.append(
+                ipw.HBox(
+                    children=[
+                        kind_moment_widget,
+                        self.unit,
+                    ],
+                    layout=ipw.Layout(align_items="center"),
+                )
+            )
 
         self.kind_moment_widgets.children = children
 
@@ -162,23 +185,29 @@ class MagnetizationConfigurationSettingsPanel(
         if self._model.spin_type == "none":
             children = []
         else:
-            children = [self.description]
+            children = [self.header]
             if self._model.electronic_type == "metal":
                 children.extend(
                     [
                         self.magnetization_type,
+                        self.magnetization_type_help,
                         self.container,
                     ]
                 )
             else:
-                children.append(self.tot_magnetization)
+                children.extend(
+                    [
+                        self.magnetization_type_help,
+                        self.tot_magnetization_with_unit,
+                    ],
+                )
         self.children = children
 
     def _toggle_widgets(self):
         if self._model.spin_type == "none" or not self.rendered:
             return
         self.container.children = [
-            self.tot_magnetization
+            self.tot_magnetization_with_unit
             if self._model.type == "tot_magnetization"
             else self.kind_moment_widgets
         ]

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -45,7 +45,7 @@ class MagnetizationConfigurationSettingsPanel(
             return
 
         self.description = ipw.HTML("""
-            <div>
+            <div style="margin-bottom: 5px;">
                 <b>Magnetization:</b>
                 <br>
                 The default starting magnetization is computed as the theoretical
@@ -59,6 +59,7 @@ class MagnetizationConfigurationSettingsPanel(
                 "description_width": "initial",
                 "button_width": "initial",
             },
+            layout=ipw.Layout(margin="0 0 10px 0"),
         )
         ipw.dlink(
             (self._model, "type_options"),

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -8,10 +8,10 @@ class MagnetizationConfigurationSettingsPanel(
     AdvancedConfigurationSubSettingsPanel[MagnetizationConfigurationSettingsModel],
 ):
     """Widget to set the type of magnetization used in the calculation:
-    1) Tot_magnetization: Total majority spin charge - minority spin charge.
-    2) Starting magnetization: Starting spin polarization on atomic type 'i' in a spin polarized (LSDA or noncollinear/spin-orbit) calculation.
+    1) Total magnetization: Total majority spin charge - minority spin charge.
+    2) Magnetic moments: Starting spin polarization on atomic type 'i' in a spin polarized (LSDA or noncollinear/spin-orbit) calculation.
 
-    For Starting magnetization you can set each kind names defined in the StructureData (StructureData.get_kind_names())
+    For Magnetic moments you can set each kind names defined in the StructureData (StructureData.get_kind_names())
     Usually these are the names of the elements in the StructureData
     (For example 'C' , 'N' , 'Fe' . However the StructureData can have defined kinds like 'Fe1' and 'Fe2')
     The widget generate a dictionary that can be used to set initial_magnetic_moments in the builder of PwBaseWorkChain
@@ -48,9 +48,7 @@ class MagnetizationConfigurationSettingsPanel(
             <div style="margin-bottom: 5px;">
                 <b>Magnetization:</b>
                 <br>
-                The default starting magnetization is computed as the theoretical
-                magnetic moment scaled by the valence charge defined in the selected
-                pseudopotential family.
+                Default magnetic moments correspond to theoretical values.
             </div>
         """)
 

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -39,6 +39,10 @@ class MagnetizationConfigurationSettingsPanel(
             self._on_magnetization_type_change,
             "type",
         )
+        self._model.observe(
+            self._on_family_change,
+            "family",
+        )
 
     def render(self):
         if self.rendered:
@@ -121,6 +125,9 @@ class MagnetizationConfigurationSettingsPanel(
         self._toggle_widgets()
         self._model.update_type_help()
 
+    def _on_family_change(self, _):
+        self._model.update_default_starting_magnetization()
+
     def _update(self, specific=""):
         if self.updated:
             return
@@ -151,8 +158,8 @@ class MagnetizationConfigurationSettingsPanel(
         for kind_name in kind_names:
             kind_moment_widget = ipw.BoundedFloatText(
                 description=kind_name,
-                min=-4,
-                max=4,
+                min=-7,
+                max=7,
                 step=0.1,
             )
             link = ipw.link(

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -44,7 +44,15 @@ class MagnetizationConfigurationSettingsPanel(
         if self.rendered:
             return
 
-        self.description = ipw.HTML("<b>Magnetization:</b>")
+        self.description = ipw.HTML("""
+            <div>
+                <b>Magnetization:</b>
+                <br>
+                The default starting magnetization is computed as the theoretical
+                magnetic moment scaled by the valence charge defined in the selected
+                pseudopotential family.
+            </div>
+        """)
 
         self.magnetization_type = ipw.ToggleButtons(
             style={

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -81,8 +81,7 @@ class MagnetizationConfigurationSettingsModel(
                 content="""
                     If a nonzero ground-state magnetization is expected, you
                     <strong>must</strong> assign a nonzero value to at least one atomic
-                    type (note that the app might already provide tentative initial
-                    values to chemical elements that typically display magnetism).
+                    type (note that the app already provide tentative initial values).
                     To simulate an antiferromagnetic state, first, if you have not
                     done so already, please use the atom tag editor <b>(Select
                     structure -> Edit structure -> Edit atom tags)</b> to mark atoms of

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -69,6 +69,7 @@ class MagnetizationConfigurationSettingsModel(
             self.moments = self._get_default_moments()
 
     def update_type_help(self):
+        """Update the type field help text w.r.t the current model state."""
         if self.electronic_type == "insulator" or self.type == "tot_magnetization":
             self.type_help = self._TYPE_HELP_TEMPLATE.format(
                 content="""
@@ -92,6 +93,9 @@ class MagnetizationConfigurationSettingsModel(
             )
 
     def update_default_starting_magnetization(self):
+        """Update the default starting magnetization based on the structure and
+        pseudopotential family.
+        """
         if not self.has_structure:
             # TODO this guard shouldn't be here! It IS here only because in the present
             # implementation, an update is called on app start. This breaks lazy loading
@@ -115,6 +119,7 @@ class MagnetizationConfigurationSettingsModel(
         }
 
     def _to_moment(self, symbol: str, family: PseudoPotentialFamily) -> float:
+        """Convert the default magnetization to an initial magnetic moment."""
         magnetization = (
             self._default_starting_magnetization.get(symbol, 0.1)
             if self._DEFAULT_MOMENTS.get(symbol, {}).get("magmom")

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -30,11 +30,12 @@ class MagnetizationConfigurationSettingsModel(
     type_options = tl.List(
         trait=tl.List(tl.Unicode()),
         default_value=[
-            ["Magnetic moments", "starting_magnetization"],
+            ["Initial magnetic moments", "starting_magnetization"],
             ["Total magnetization", "tot_magnetization"],
         ],
     )
     type = tl.Unicode("starting_magnetization")
+    type_help = tl.Unicode("")
     total = tl.Float(0.0)
     moments = tl.Dict(
         key_trait=tl.Unicode(),  # kind name
@@ -42,34 +43,66 @@ class MagnetizationConfigurationSettingsModel(
         default_value={},
     )
 
+    _TYPE_HELP_TEMPLATE = """
+        <div style="line-height: 1.4; margin-bottom: 5px">
+            {content}
+        </div>
+    """
+
     def update(self, specific=""):  # noqa: ARG002
         if self.spin_type == "none" or not self.has_structure:
             self._defaults["moments"] = {}
         else:
-            try:
-                family = fetch_pseudo_family_by_label(self.family)
-                initial_guess = get_starting_magnetization(self.input_structure, family)
-                self._defaults["moments"] = {
-                    kind.name: round(
-                        initial_guess[kind.name]
-                        * family.get_pseudo(kind.symbol).z_valence,
-                        3,
-                    )
-                    for kind in self.input_structure.kinds
-                }
-            except NotExistent:
-                self._defaults["moments"] = {
-                    kind_name: 0.0
-                    for kind_name in self.input_structure.get_kind_names()
-                }
+            self.update_type_help()
+            self._update_default_moments()
         with self.hold_trait_notifications():
             self.moments = self._get_default_moments()
+
+    def update_type_help(self):
+        if self.electronic_type == "insulator" or self.type == "tot_magnetization":
+            self.type_help = self._TYPE_HELP_TEMPLATE.format(
+                content="""
+                    Constrain the desired total electronic magnetization (difference
+                    between majority and minority spin charge).
+                """
+            )
+        else:
+            self.type_help = self._TYPE_HELP_TEMPLATE.format(
+                content="""
+                    If a nonzero ground-state magnetization is expected, you
+                    <strong>must</strong> assign a nonzero value to at least one atomic
+                    type (note that the app might already provide tentative initial
+                    values to chemical elements that typically display magnetism).
+                    To simulate an antiferromagnetic state, first, if you have not
+                    done so already, please use the atom tag editor <b>(Select
+                    structure -> Edit structure -> Edit atom tags)</b> to mark atoms of
+                    the species of interest as distinct by assigning each a different
+                    integer tag. Once tagged, assign each an initial magnetic moments
+                    of opposite sign.
+                """
+            )
 
     def reset(self):
         with self.hold_trait_notifications():
             self.type = self.traits()["type"].default_value
             self.total = self.traits()["total"].default_value
             self.moments = self._get_default_moments()
+
+    def _update_default_moments(self):
+        try:
+            family = fetch_pseudo_family_by_label(self.family)
+            initial_guess = get_starting_magnetization(self.input_structure, family)
+            self._defaults["moments"] = {
+                kind.name: round(
+                    initial_guess[kind.name] * family.get_pseudo(kind.symbol).z_valence,
+                    3,
+                )
+                for kind in self.input_structure.kinds
+            }
+        except NotExistent:
+            self._defaults["moments"] = {
+                kind_name: 0.0 for kind_name in self.input_structure.get_kind_names()
+            }
 
     def _get_default_moments(self):
         return deepcopy(self._defaults.get("moments", {}))

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -30,7 +30,7 @@ class MagnetizationConfigurationSettingsModel(
     type_options = tl.List(
         trait=tl.List(tl.Unicode()),
         default_value=[
-            ["Starting magnetization", "starting_magnetization"],
+            ["Magnetic moments", "starting_magnetization"],
             ["Total magnetization", "tot_magnetization"],
         ],
     )
@@ -47,10 +47,16 @@ class MagnetizationConfigurationSettingsModel(
             self._defaults["moments"] = {}
         else:
             try:
-                self._defaults["moments"] = get_starting_magnetization(
-                    self.input_structure,
-                    fetch_pseudo_family_by_label(self.family),
-                )
+                family = fetch_pseudo_family_by_label(self.family)
+                initial_guess = get_starting_magnetization(self.input_structure, family)
+                self._defaults["moments"] = {
+                    kind.name: round(
+                        initial_guess[kind.name]
+                        * family.get_pseudo(kind.symbol).z_valence,
+                        3,
+                    )
+                    for kind in self.input_structure.kinds
+                }
             except NotExistent:
                 self._defaults["moments"] = {
                     kind_name: 0.0

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -116,10 +116,12 @@ class MagnetizationConfigurationSettingsModel(
         }
 
     def _to_moment(self, symbol: str, family: PseudoPotentialFamily) -> float:
-        magnetization = self._default_starting_magnetization.get(symbol, 0.0)
-        if self._DEFAULT_MOMENTS.get(symbol, {}).get("magmom"):
-            return magnetization * family.get_pseudo(symbol).z_valence
-        return 0.0
+        magnetization = (
+            self._default_starting_magnetization.get(symbol, 0.1)
+            if self._DEFAULT_MOMENTS.get(symbol, {}).get("magmom")
+            else 0.1
+        )
+        return round(magnetization * family.get_pseudo(symbol).z_valence, 3)
 
     def _get_default_moments(self):
         return deepcopy(self._defaults.get("moments", {}))

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -255,11 +255,7 @@ class AdvancedConfigurationSettingsModel(
             self._on_any_change,
             tl.All,
         )
-        for trait in model.dependencies:
-            ipw.dlink(
-                (self, trait),
-                (model, trait),
-            )
+        super()._link_model(model)
 
     def _update_kpoints_mesh(self, _=None):
         if not self.has_structure:

--- a/src/aiidalab_qe/app/configuration/basic/basic.py
+++ b/src/aiidalab_qe/app/configuration/basic/basic.py
@@ -95,7 +95,7 @@ class BasicConfigurationSettingsPanel(
                     </p>
                     <p>
                         Please go to <b>Advanced settings</b> and override the default
-                        values, specifying appropriate starting magnetization for each
+                        values, specifying appropriate magnetic moments for each
                         species (e.g. with different signs for an antiferromagnetic
                         configuration).
                     </p>

--- a/src/aiidalab_qe/app/configuration/basic/basic.py
+++ b/src/aiidalab_qe/app/configuration/basic/basic.py
@@ -45,6 +45,11 @@ class BasicConfigurationSettingsPanel(
             (self._model, "spin_type"),
             (self.spin_type, "value"),
         )
+        self.spin_type.observe(
+            self._on_spin_type_change,
+            "value",
+        )
+
         self.magnetization_info = ipw.HTML(
             value="""
                 <div style="margin-left: 10px;">
@@ -52,10 +57,6 @@ class BasicConfigurationSettingsPanel(
                 </div>
             """,
             layout=ipw.Layout(visibility="hidden"),
-        )
-        self.spin_type.observe(
-            self._on_spin_type_change,
-            "value",
         )
 
         # Spin-Orbit calculation
@@ -78,6 +79,29 @@ class BasicConfigurationSettingsPanel(
         ipw.link(
             (self._model, "protocol"),
             (self.protocol, "value"),
+        )
+
+        self.warning = ipw.HTML(
+            value="""
+                <div
+                    class="alert alert-warning"
+                    style="line-height: 140%; margin: 10px 0 0"
+                >
+                    <p>
+                        <b>Warning:</b> detected multiples atoms with different tags.
+                        You may be interested in an antiferromagnetic system. Note that
+                        default starting magnetic moments do not distinguish tagged
+                        atoms and are set to the same value.
+                    </p>
+                    <p>
+                        Please go to <b>Advanced settings</b> and override the default
+                        values, specifying appropriate starting magnetization for each
+                        species (e.g. with different signs for an antiferromagnetic
+                        configuration).
+                    </p>
+                </div>
+            """,
+            layout=ipw.Layout(display="none"),
         )
 
         self.children = [
@@ -153,6 +177,7 @@ class BasicConfigurationSettingsPanel(
                     (at the price of longer/costlier calculations).
                 </div>
             """),
+            self.warning,
         ]
 
         self.rendered = True
@@ -161,7 +186,9 @@ class BasicConfigurationSettingsPanel(
         self.refresh(specific="structure")
 
     def _on_spin_type_change(self, _):
-        if self.spin_type.value == "none":
+        if self._model.spin_type == "collinear" and self._model.has_tags:
+            self.warning.layout.display = "flex"
             self.magnetization_info.layout.visibility = "hidden"
         else:
+            self.warning.layout.display = "none"
             self.magnetization_info.layout.visibility = "visible"

--- a/src/aiidalab_qe/app/configuration/basic/basic.py
+++ b/src/aiidalab_qe/app/configuration/basic/basic.py
@@ -56,7 +56,7 @@ class BasicConfigurationSettingsPanel(
                     Set the desired magnetic configuration in <b>advanced</b> settings
                 </div>
             """,
-            layout=ipw.Layout(visibility="hidden"),
+            layout=ipw.Layout(display="none"),
         )
 
         # Spin-Orbit calculation
@@ -186,9 +186,10 @@ class BasicConfigurationSettingsPanel(
         self.refresh(specific="structure")
 
     def _on_spin_type_change(self, _):
-        if self._model.spin_type == "collinear" and self._model.has_tags:
-            self.warning.layout.display = "flex"
-            self.magnetization_info.layout.visibility = "hidden"
+        if self._model.spin_type == "collinear":
+            self.magnetization_info.layout.display = "block"
+            if self._model.has_tags:
+                self.warning.layout.display = "flex"
         else:
+            self.magnetization_info.layout.display = "none"
             self.warning.layout.display = "none"
-            self.magnetization_info.layout.visibility = "visible"

--- a/src/aiidalab_qe/app/configuration/basic/model.py
+++ b/src/aiidalab_qe/app/configuration/basic/model.py
@@ -1,21 +1,22 @@
 import traitlets as tl
 
-from aiida import orm
 from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
+from aiidalab_qe.common.mixins import HasInputStructure
 from aiidalab_qe.common.panel import ConfigurationSettingsModel
 
 DEFAULT: dict = DEFAULT_PARAMETERS  # type: ignore
 
 
-class BasicConfigurationSettingsModel(ConfigurationSettingsModel):
+class BasicConfigurationSettingsModel(
+    ConfigurationSettingsModel,
+    HasInputStructure,
+):
     title = "Basic settings"
     identifier = "workchain"
 
     dependencies = [
         "input_structure",
     ]
-
-    input_structure = tl.Union([tl.Instance(orm.StructureData)], allow_none=True)
 
     protocol_options = tl.List(
         trait=tl.Tuple(tl.Unicode(), tl.Unicode()),

--- a/src/aiidalab_qe/app/configuration/model.py
+++ b/src/aiidalab_qe/app/configuration/model.py
@@ -129,18 +129,7 @@ class ConfigurationStepModel(
             (self, "confirmed"),
             (model, "confirmed"),
         )
-        for dependency in model.dependencies:
-            dependency_parts = dependency.split(".")
-            if len(dependency_parts) == 1:  # from parent, e.g. input_structure
-                target_model = self
-                trait = dependency
-            else:  # from sibling, e.g. workchain.protocol
-                sibling, trait = dependency_parts
-                target_model = self.get_model(sibling)
-            ipw.dlink(
-                (target_model, trait),
-                (model, trait),
-            )
+        super()._link_model(model)
 
     def _get_properties(self):
         properties = []

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -51,7 +51,20 @@ class HasModels(t.Generic[T]):
         return self._models.items()
 
     def _link_model(self, model: T):
-        pass
+        if not hasattr(model, "dependencies"):
+            return
+        for dependency in model.dependencies:
+            dependency_parts = dependency.split(".")
+            if len(dependency_parts) == 1:  # from parent
+                target_model = self
+                trait = dependency
+            else:  # from sibling
+                sibling, trait = dependency_parts
+                target_model = self.get_model(sibling)
+            tl.dlink(
+                (target_model, trait),
+                (model, trait),
+            )
 
 
 class HasProcess(tl.HasTraits):

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -26,6 +26,13 @@ class HasInputStructure(tl.HasTraits):
     def has_pbc(self):
         return not self.has_structure or any(self.input_structure.pbc)
 
+    @property
+    def has_tags(self):
+        return any(
+            not kind_name.isalpha()
+            for kind_name in self.input_structure.get_kind_names()
+        )
+
 
 class HasModels(t.Generic[T]):
     def __init__(self):

--- a/src/aiidalab_qe/utils.py
+++ b/src/aiidalab_qe/utils.py
@@ -1,3 +1,5 @@
+from aiida_pseudo.groups.family import PseudoPotentialFamily
+
 from aiida import orm
 
 
@@ -32,6 +34,6 @@ def enable_pencil_decomposition(component):
     component.settings = orm.Dict({"CMDLINE": ["-pd", ".true."]})
 
 
-def fetch_pseudo_family_by_label(label):
+def fetch_pseudo_family_by_label(label) -> PseudoPotentialFamily:
     """Fetch the pseudo family by label."""
-    return orm.Group.collection.get(label=label)
+    return orm.Group.collection.get(label=label)  # type: ignore

--- a/src/aiidalab_qe/utils.py
+++ b/src/aiidalab_qe/utils.py
@@ -30,3 +30,8 @@ def enable_pencil_decomposition(component):
     """Enable the pencil decomposition for the given component."""
 
     component.settings = orm.Dict({"CMDLINE": ["-pd", ".true."]})
+
+
+def fetch_pseudo_family_by_label(label):
+    """Fetch the pseudo family by label."""
+    return orm.Group.collection.get(label=label)


### PR DESCRIPTION
This PR uses the QE plugin `get_starting_magenetization` utility function to set default initial magnetic moments for the structure when magnetism is turned on. The defaults are set to the default magmom provided by the utility scaled by the Z valence value for the element defined in the selected pseudopotential. Note that for those elements of a zero magmom default, a general default magnetization of 0.1 is returned.

If multiple tags are provided for the same species, a warning is displayed providing some instructions for antiferromagnetic configurations.

Closes #982

---

![Screenshot 2025-01-09 103706](https://github.com/user-attachments/assets/cecd0ab3-e9f1-42fe-bb7c-b00c95b7b8fa)

![Screenshot 2025-01-09 104547](https://github.com/user-attachments/assets/81242a26-7cd5-425b-b43c-33577c815bfd)

![Screenshot 2025-01-09 104615](https://github.com/user-attachments/assets/72e79a49-6139-460b-8360-56397aadcc7b)
