### PR TITLE
Check for null exit status

### DIFF
--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -131,9 +131,8 @@ class WorkChainSummaryModel(ResultsComponentModel):
 
     def generate_failure_report(self):
         """Generate a html for reporting the failure of the `QeAppWorkChain`."""
-        if not (process_node := self.fetch_process_node()):
-            return
-        if process_node.exit_status == 0:
+        process_node = self.fetch_process_node()
+        if not process_node and process_node.exit_status:
             return
         final_calcjob = self._get_final_calcjob(process_node)
         env = Environment()


### PR DESCRIPTION
Only escaped if exit status was 0, but need to escape if it is `None`