### PR TITLE
Handle space/point-group correctly

### DIFF
--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -285,12 +285,11 @@ class WorkChainSummaryModel(ResultsComponentModel):
 
         return report
 
-    def _get_symmetry_group_info(self, structure):
+    def _get_symmetry_group_info(self, structure: orm.StructureData) -> dict:
         from pymatgen.symmetry.analyzer import PointGroupAnalyzer, SpacegroupAnalyzer
 
-        pymatgen_structure = structure.get_pymatgen()
         if any(structure.pbc):
-            analyzer = SpacegroupAnalyzer(structure=pymatgen_structure)
+            analyzer = SpacegroupAnalyzer(structure=structure.get_pymatgen_structure())
             symbol = analyzer.get_space_group_symbol()
             number = analyzer.get_space_group_number()
             return {
@@ -301,7 +300,7 @@ class WorkChainSummaryModel(ResultsComponentModel):
         else:
             from pymatgen.symmetry.analyzer import PointGroupAnalyzer
 
-            analyzer = PointGroupAnalyzer(mol=pymatgen_structure)
+            analyzer = PointGroupAnalyzer(mol=structure.get_pymatgen_molecule())
             return {"point_group": analyzer.get_pointgroup()}
 
     @staticmethod

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -148,10 +148,7 @@ class WorkChainSummaryModel(ResultsComponentModel):
 
         Return a dictionary of the parameters.
         """
-        import spglib
-
         from aiida.orm.utils.serialize import deserialize_unsafe
-        from aiidalab_widgets_base.utils import ase2spglib
 
         qeapp_wc = self.fetch_process_node()
 
@@ -287,6 +284,10 @@ class WorkChainSummaryModel(ResultsComponentModel):
 
     def _get_symmetry_group_info(self, structure: orm.StructureData) -> dict:
         from pymatgen.symmetry.analyzer import PointGroupAnalyzer, SpacegroupAnalyzer
+
+        # HACK once AiiDAlab is updated to use AiiDA 2.6 throughout, we can use the
+        # `get_pymatgen` method directly on the `StructureData` object to obtain the
+        # correct pymatgen object (`Molecule` for 0D systems, `Structure` otherwise).
 
         if any(structure.pbc):
             analyzer = SpacegroupAnalyzer(structure=structure.get_pymatgen_structure())

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -187,8 +187,11 @@ class WorkChainSummaryModel(ResultsComponentModel):
             }
         }
 
-        symmetry_group_info = self._get_symmetry_group_info(structure)
-        report["initial_structure_properties"] |= symmetry_group_info
+        report["initial_structure_properties"] |= {
+            **self._get_symmetry_group_info(structure),
+            "cell_lengths": "{:.3f} {:.3f} {:.3f}".format(*structure.cell_lengths),
+            "cell_angles": "{:.0f} {:.0f} {:.0f}".format(*structure.cell_angles),
+        }
 
         report |= {
             "basic_settings": {
@@ -302,11 +305,7 @@ class WorkChainSummaryModel(ResultsComponentModel):
         analyzer = SpacegroupAnalyzer(structure=clone.get_pymatgen_structure())
         symbol = analyzer.get_space_group_symbol()
         number = analyzer.get_space_group_number()
-        return {
-            "space_group": f"{symbol} ({number})",
-            "cell_lengths": "{:.3f} {:.3f} {:.3f}".format(*structure.cell_lengths),
-            "cell_angles": "{:.0f} {:.0f} {:.0f}".format(*structure.cell_angles),
-        }
+        return {"space_group": f"{symbol} ({number})"}
 
     @staticmethod
     def _get_pymatgen_molecule(structure: orm.StructureData) -> dict:

--- a/src/aiidalab_qe/app/result/components/summary/schema.json
+++ b/src/aiidalab_qe/app/result/components/summary/schema.json
@@ -54,6 +54,11 @@
     "type": "text",
     "description": "The space group of the structure"
   },
+  "point_group": {
+    "title": "Point group",
+    "type": "text",
+    "description": "The point group of the molecule"
+  },
   "cell_lengths": {
     "title": "Cell lengths in Å",
     "type": "text",


### PR DESCRIPTION
This PR uses pymatgen symmetry analyzer classes to extract symmetry group information from the structure for use in the summary.

Resolves #1053