### PR TITLE
Fix pymatgen dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     filelock~=3.8
     importlib-resources~=5.2
     aiida-wannier90-workflows==2.3.0
+    pymatgen==2024.5.1
 python_requires = >=3.9
 
 [options.packages.find]


### PR DESCRIPTION
Recent pymatgen release (2024.8.9) marks `is_rare_earth_metal` as deprecated on 1.1.25, from which point it has raised a test-failing deprecation warning. This PR aims to resolve this matter by fixing the dependency to the 2024.5.1. Note that we don't use `is_rare_earth_metal` in the app or plugin. The warning is raised because pymatgen was still using it in certain places. Assumption is that they will remediate this shortly, at which point, we can soften the hard dependency (if required).