### PR TITLE
Adding information optimized structure in results

### DIFF
--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -27,10 +27,7 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
             """)
             self.atom_coordinates_table = TableWidget()
             self._generate_table(structure.get_ase())
-            self.atom_coordinates_table.observe(self._change_selection, "selected_rows")
-            # Listen for changes in self.widget.displayed_selection and update the table
-            self.widget.observe(self._update_table_selection, "displayed_selection")
-
+            
             # Basic widgets
             children = [
                 self.widget,
@@ -45,6 +42,9 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
 
             # Add the children to the container
             self.results_container.children = tuple(children)
+            self.atom_coordinates_table.observe(self._change_selection, "selected_rows")
+            # Listen for changes in self.widget.displayed_selection and update the table
+            self.widget.observe(self._update_table_selection, "displayed_selection")
 
         # HACK to resize the NGL viewer in cases where it auto-rendered when its
         # container was not displayed, which leads to a null width. This hack restores

--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -1,6 +1,7 @@
 import ipywidgets as ipw
 
 from aiidalab_qe.common.panel import ResultsPanel
+from aiidalab_qe.common.time import format_time, relative_time
 from aiidalab_qe.common.widgets import TableWidget
 from aiidalab_widgets_base.viewers import StructureDataViewer
 
@@ -26,12 +27,22 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
             """)
             self.atom_coordinates_table = TableWidget()
             self._generate_table(structure.get_ase())
-            self.results_container.children = [
+            self.atom_coordinates_table.observe(self._change_selection, "selected_rows")
+
+            # Basic widgets
+            children = [
                 self.widget,
                 self.table_description,
                 self.atom_coordinates_table,
             ]
-            self.atom_coordinates_table.observe(self._change_selection, "selected_rows")
+
+            # Add structure info if it is a relaxed structure
+            if "relax" in self._model.properties:
+                self._initialize_structure_info(structure)
+                children.insert(0, self.structure_info)
+
+            # Add the children to the container
+            self.results_container.children = tuple(children)
 
         # HACK to resize the NGL viewer in cases where it auto-rendered when its
         # container was not displayed, which leads to a null width. This hack restores
@@ -39,6 +50,20 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
         ngl = self.widget._viewer
         ngl._set_size("100%", "300px")
         ngl.control.zoom(0.0)
+
+    def _initialize_structure_info(self, structure):
+        self.structure_info = ipw.HTML(
+            f"""
+            <h3 style='margin-bottom: 8px;'>Structure properties</h3>
+            <div style='line-height: 1.4;'>
+                <strong>PK:</strong> {structure.pk}<br>
+                <strong>Label:</strong> {structure.label}<br>
+                <strong>Description:</strong> {structure.description}<br>
+                <strong>Number of atoms:</strong> {len(structure.sites)}<br>
+                <strong>Creation time:</strong> {format_time(structure.ctime)} ({relative_time(structure.ctime)})<br>
+            </div>
+            """
+        )
 
     def _generate_table(self, structure):
         data = [

--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -28,6 +28,8 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
             self.atom_coordinates_table = TableWidget()
             self._generate_table(structure.get_ase())
             self.atom_coordinates_table.observe(self._change_selection, "selected_rows")
+            # Listen for changes in self.widget.displayed_selection and update the table
+            self.widget.observe(self._update_table_selection, "displayed_selection")
 
             # Basic widgets
             children = [

--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -27,7 +27,7 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
             """)
             self.atom_coordinates_table = TableWidget()
             self._generate_table(structure.get_ase())
-            
+
             # Basic widgets
             children = [
                 self.widget,


### PR DESCRIPTION
This PR closes #928 
The displayed information includes the PK, label, description, creation time, and number of atoms. 

Structure Creation Details: Knowing when the structure was created and its PK helps users efficiently search for and reuse it in new calculations. The PK also helps to locate the structure within the database.

Interaction with Selection Widget: The number of atoms reminds the user the structure's size (on the tab), enabling them to interact effectively with the selection widget.

<img width="1120" alt="Screenshot 2025-01-07 at 21 45 14" src="https://github.com/user-attachments/assets/1c3ca8d5-3c4a-4c3d-a5d3-f478e1fc12ef" />
