### PR TITLE
Adding relax max_step widget

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -203,6 +203,17 @@ class AdvancedConfigurationSettingsPanel(
             (self.electron_maxstep, "value"),
         )
 
+        self.optimization_maxsteps = ipw.BoundedIntText(
+            min=50,
+            max=1000,
+            step=1,
+            description="Max. optimization steps:",
+            style={"description_width": "initial"},
+        )
+        ipw.link(
+            (self._model, "optimization_maxsteps"),
+            (self.optimization_maxsteps, "value"),
+        )
         self.pseudos.render()
 
         self.children = [
@@ -229,7 +240,12 @@ class AdvancedConfigurationSettingsPanel(
                 ],
                 layout=ipw.Layout(justify_content="space-between"),
             ),
-            self.electron_maxstep,
+            ipw.HBox(
+                children=[
+                    self.electron_maxstep,
+                    self.optimization_maxsteps,
+                ],
+            ),
             self.smearing,
             ipw.HTML("""
                 <div>

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -69,6 +69,8 @@ class AdvancedConfigurationSettingsModel(
     scf_conv_thr = tl.Float(0.0)
     scf_conv_thr_step = tl.Float(1e-10)
     electron_maxstep = tl.Int(80)
+    optimization_maxsteps = tl.Int(50)
+
     kpoints_distance = tl.Float(0.0)
     mesh_grid = tl.Unicode("")
 
@@ -109,6 +111,7 @@ class AdvancedConfigurationSettingsModel(
             },
             "clean_workdir": self.clean_workdir,
             "kpoints_distance": self.kpoints_distance,
+            "optimization_maxsteps": self.optimization_maxsteps,
         }
 
         hubbard: HubbardConfigurationSettingsModel = self.get_model("hubbard")  # type: ignore
@@ -192,6 +195,7 @@ class AdvancedConfigurationSettingsModel(
             pseudos.ecutrho = parameters["pw"]["parameters"]["SYSTEM"]["ecutrho"]
 
         self.kpoints_distance = parameters.get("kpoints_distance", 0.15)
+        self.optimization_maxsteps = parameters.get("optimization_maxsteps", 50)
 
         if (pw_parameters := parameters.get("pw", {}).get("parameters")) is not None:
             self._set_pw_parameters(pw_parameters)
@@ -237,6 +241,7 @@ class AdvancedConfigurationSettingsModel(
             self.electron_maxstep = self._get_default("electron_maxstep")
             self.spin_orbit = self._get_default("spin_orbit")
             self.kpoints_distance = self._get_default("kpoints_distance")
+            self.optimization_maxsteps = self._get_default("optimization_maxsteps")
 
     def _get_default(self, trait):
         return self._defaults.get(trait, self.traits()[trait].default_value)

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -175,6 +175,14 @@ class QeAppWorkChain(WorkChain):
             "base": parameters["advanced"],
             "base_final_scf": parameters["advanced"],
         }
+        # nsteps only for relaxation workflow
+        relax_overrides["base"]["pw"]["parameters"]["CONTROL"]["nstep"] = parameters[
+            "advanced"
+        ]["optimization_maxsteps"]
+        relax_overrides["base_final_scf"]["pw"]["parameters"]["CONTROL"]["nstep"] = (
+            parameters["advanced"]["optimization_maxsteps"]
+        )
+
         protocol = parameters["workchain"]["protocol"]
 
         relax_builder = PwRelaxWorkChain.get_builder_from_protocol(

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -2,6 +2,7 @@ advanced:
   clean_workdir: false
   initial_magnetic_moments: null
   kpoints_distance: 0.12
+  optimization_maxsteps: 50
   pseudo_family: SSSP/1.3/PBEsol/efficiency
   pw:
     parameters:


### PR DESCRIPTION
This pull request addresses issue #748 by introducing a widget that allows users to set the maximum number of steps for structural relaxation calculations in Quantum ESPRESSO. The default is 50 steps, but some systems may require more to achieve convergence. This feature prevents premature termination of calculations due to insufficient iteration limits. Additionally, systems requiring tighter convergence criteria, such as those involved in phonon calculations, may benefit from increased step limits.

![image](https://github.com/user-attachments/assets/0e3e2f5a-610d-480d-ac4f-aa4da15d1251)
