### PR TITLE
Adding information optimized structure in results

### DIFF
--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -56,7 +56,6 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
     def _initialize_structure_info(self, structure):
         self.structure_info = ipw.HTML(
             f"""
-            <h3 style='margin-bottom: 8px;'>Structure properties</h3>
             <div style='line-height: 1.4;'>
                 <strong>PK:</strong> {structure.pk}<br>
                 <strong>Label:</strong> {structure.label}<br>


### PR DESCRIPTION
This PR closes https://github.com/aiidalab/aiidalab-qe/issues/928
The displayed information includes the PK, label, description, creation time, and number of atoms.

Structure Creation Details: Knowing when the structure was created and its PK helps users efficiently search for and reuse it in new calculations. The PK also helps to locate the structure within the database.

Interaction with Selection Widget: The number of atoms reminds the user the structure's size (on the tab), enabling them to interact effectively with the selection widget.
![image](https://github.com/user-attachments/assets/d763db14-0f03-4caa-a6f5-a39db3b57ce6)
