### PR TITLE
Add info relaxed structure results tab 

### DIFF
--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -28,20 +28,16 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
             self.atom_coordinates_table = TableWidget()
             self._generate_table(structure.get_ase())
 
-            # Basic widgets
-            children = [
+            # Get information from the structure
+            structure_info = self._get_structure_info(structure)
+
+            # Add the children to the container
+            self.results_container.children = [
+                structure_info,
                 self.widget,
                 self.table_description,
                 self.atom_coordinates_table,
             ]
-
-            # Add structure info if it is a relaxed structure
-            if "relax" in self._model.properties:
-                self._initialize_structure_info(structure)
-                children.insert(0, self.structure_info)
-
-            # Add the children to the container
-            self.results_container.children = tuple(children)
 
             self.atom_coordinates_table.observe(self._change_selection, "selected_rows")
             # Listen for changes in self.widget.displayed_selection and update the table
@@ -54,8 +50,8 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
         ngl._set_size("100%", "300px")
         ngl.control.zoom(0.0)
 
-    def _initialize_structure_info(self, structure):
-        self.structure_info = ipw.HTML(
+    def _get_structure_info(self, structure):
+        return ipw.HTML(
             f"""
             <div style='line-height: 1.4;'>
                 <strong>PK:</strong> {structure.pk}<br>

--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -57,7 +57,6 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
     def _initialize_structure_info(self, structure):
         self.structure_info = ipw.HTML(
             f"""
-            <h3 style='margin-bottom: 8px;'>Structure properties</h3>
             <div style='line-height: 1.4;'>
                 <strong>PK:</strong> {structure.pk}<br>
                 <strong>Label:</strong> {structure.label}<br>

--- a/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/structure.py
@@ -28,10 +28,8 @@ class StructureResultsPanel(ResultsPanel[StructureResultsModel]):
             self.atom_coordinates_table = TableWidget()
             self._generate_table(structure.get_ase())
 
-            # Get information from the structure
             structure_info = self._get_structure_info(structure)
 
-            # Add the children to the container
             self.results_container.children = [
                 structure_info,
                 self.widget,


### PR DESCRIPTION
This PR closes https://github.com/aiidalab/aiidalab-qe/issues/928
The displayed information includes the PK, label, description, creation time, and number of atoms.

Structure Creation Details: Knowing when the structure was created and its PK helps users efficiently search for and reuse it in new calculations. The PK also helps to locate the structure within the database.

Interaction with Selection Widget: The number of atoms reminds the user the structure's size (on the tab), enabling them to interact effectively with the selection widget.

![image](https://github.com/user-attachments/assets/74c4ef99-f0c6-4bb9-87fe-a0f5c192646b)
