### PR TITLE
Synchronize TableWidget row selection

### DIFF
--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -1235,68 +1235,70 @@ class QeDependentWizardStep(QeWizardStep[QWSM]):
 class TableWidget(anywidget.AnyWidget):
     _esm = """
     function render({ model, el }) {
-      let domElement = document.createElement("div");
-      el.classList.add("custom-table");
-      let selectedIndices = [];
+        let domElement = document.createElement("div");
+        el.classList.add("custom-table");
+        let selectedIndices = [];
 
-      function drawTable() {
-          const data = model.get("data");
-          domElement.innerHTML = "";
-          let innerHTML = '<table><tr>' + data[0].map(header => `<th>${header}</th>`).join('') + '</tr>';
+        function drawTable() {
+            const data = model.get("data");
+            domElement.innerHTML = "";
+            let innerHTML = '<table><tr>' + data[0].map(header => `<th>${header}</th>`).join('') + '</tr>';
 
-          for (let i = 1; i < data.length; i++) {
-              innerHTML += '<tr>' + data[i].map(cell => `<td>${cell}</td>`).join('') + '</tr>';
-          }
+            for (let i = 1; i < data.length; i++) {
+                innerHTML += '<tr>' + data[i].map(cell => `<td>${cell}</td>`).join('') + '</tr>';
+            }
 
-          innerHTML += "</table>";
-          domElement.innerHTML = innerHTML;
+            innerHTML += "</table>";
+            domElement.innerHTML = innerHTML;
 
-          const rows = domElement.querySelectorAll('tr');
-          rows.forEach((row, index) => {
-              if (index > 0) {
-                  row.addEventListener('click', () => {
-                      const rowIndex = index - 1;
-                      if (selectedIndices.includes(rowIndex)) {
-                          selectedIndices = selectedIndices.filter(i => i !== rowIndex);
-                          row.classList.remove('selected-row');
-                      } else {
-                          selectedIndices.push(rowIndex);
-                          row.classList.add('selected-row');
-                      }
-                      model.set('selected_rows', [...selectedIndices]);
-                      model.save_changes();
-                  });
+            const rows = domElement.querySelectorAll('tr');
+            rows.forEach((row, index) => {
+                if (index > 0) {
+                    row.addEventListener('click', () => {
+                        const rowIndex = index - 1;
+                        if (selectedIndices.includes(rowIndex)) {
+                            selectedIndices = selectedIndices.filter(i => i !== rowIndex);
+                            row.classList.remove('selected-row');
+                        } else {
+                            selectedIndices.push(rowIndex);
+                            row.classList.add('selected-row');
+                        }
+                        model.set('selected_rows', [...selectedIndices]);
+                        model.save_changes();
+                    });
 
-                  row.addEventListener('mouseover', () => {
-                      if (!row.classList.contains('selected-row')) {
-                          row.classList.add('hover-row');
-                      }
-                  });
+                    row.addEventListener('mouseover', () => {
+                        if (!row.classList.contains('selected-row')) {
+                            row.classList.add('hover-row');
+                        }
+                    });
 
-                  row.addEventListener('mouseout', () => {
-                      row.classList.remove('hover-row');
-                  });
-              }
-          });
-      }
+                    row.addEventListener('mouseout', () => {
+                        row.classList.remove('hover-row');
+                    });
+                }
+            });
+        }
 
-      drawTable();
-      model.on("change:data", drawTable);
-      model.on("change:selected_rows", (e) => {
-          const newSelection = model.get("selected_rows");
-          // Update row selection based on selected_rows
-          const rows = domElement.querySelectorAll('tr');
-          rows.forEach((row, index) => {
-              if (index > 0) {
-                  if (newSelection.includes(index - 1)) {
-                      row.classList.add('selected-row');
-                  } else {
-                      row.classList.remove('selected-row');
-                  }
-              }
-          });
-      });
-      el.appendChild(domElement);
+        function updateSelection() {
+            const newSelection = model.get("selected_rows");
+            selectedIndices = [...newSelection]; // Synchronize the JavaScript state with the Python state
+            const rows = domElement.querySelectorAll('tr');
+            rows.forEach((row, index) => {
+                if (index > 0) {
+                    if (selectedIndices.includes(index - 1)) {
+                        row.classList.add('selected-row');
+                    } else {
+                        row.classList.remove('selected-row');
+                    }
+                }
+            });
+        }
+
+        drawTable();
+        model.on("change:data", drawTable);
+        model.on("change:selected_rows", updateSelection);
+        el.appendChild(domElement);
     }
     export default { render };
     """


### PR DESCRIPTION
This PR addresses the issue of inconsistent row selection states in the table , in particular when the widget clear a selection in the table , but if you click the table it might retain extra information of the selection. 

An updateSelection function is included to synchronize the selectedIndices array in JavaScript with the selected_rows list from Python

Old

https://github.com/user-attachments/assets/8106b48f-f547-4e41-babc-989715613860




New 

https://github.com/user-attachments/assets/7028ae97-47ea-4903-9158-d4bac43dfd97



