### PR TITLE
Add XPS resource

### DIFF
--- a/src/aiidalab_qe/plugins/xas/resources.py
+++ b/src/aiidalab_qe/plugins/xas/resources.py
@@ -10,7 +10,7 @@ from aiidalab_qe.common.panel import (
 class XasResourceSettingsModel(PluginResourceSettingsModel):
     """Model for the XAS plugin."""
 
-    title = "XAS Structure"
+    title = "XAS"
     identifier = "xas"
 
     def __init__(self, **kwargs):

--- a/src/aiidalab_qe/plugins/xps/__init__.py
+++ b/src/aiidalab_qe/plugins/xps/__init__.py
@@ -1,6 +1,7 @@
 from aiidalab_qe.common.panel import PluginOutline
 
 from .model import XpsConfigurationSettingsModel
+from .resources import XpsResourceSettingsModel, XpsResourceSettingsPanel
 from .result import XpsResultsModel, XpsResultsPanel
 from .setting import XpsConfigurationSettingsPanel
 from .structure_examples import structure_examples
@@ -17,6 +18,10 @@ xps = {
     "configuration": {
         "panel": XpsConfigurationSettingsPanel,
         "model": XpsConfigurationSettingsModel,
+    },
+    "resources": {
+        "panel": XpsResourceSettingsPanel,
+        "model": XpsResourceSettingsModel,
     },
     "result": {
         "panel": XpsResultsPanel,

--- a/src/aiidalab_qe/plugins/xps/resources.py
+++ b/src/aiidalab_qe/plugins/xps/resources.py
@@ -1,0 +1,32 @@
+"""Resource panel for XPS plugin."""
+
+from aiidalab_qe.common.code.model import PwCodeModel
+from aiidalab_qe.common.panel import (
+    PluginResourceSettingsModel,
+    PluginResourceSettingsPanel,
+)
+
+
+class XpsResourceSettingsModel(PluginResourceSettingsModel):
+    """Model for the XPS plugin."""
+
+    title = "XPS Structure"
+    identifier = "xps"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.add_models(
+            {
+                "pw": PwCodeModel(
+                    name="pw.x",
+                    description="pw.x",
+                    default_calc_job_plugin="quantumespresso.pw",
+                ),
+            }
+        )
+
+
+class XpsResourceSettingsPanel(
+    PluginResourceSettingsPanel[XpsResourceSettingsModel],
+):
+    """Panel for configuring the XPS plugin."""

--- a/src/aiidalab_qe/plugins/xps/resources.py
+++ b/src/aiidalab_qe/plugins/xps/resources.py
@@ -10,7 +10,7 @@ from aiidalab_qe.common.panel import (
 class XpsResourceSettingsModel(PluginResourceSettingsModel):
     """Model for the XPS plugin."""
 
-    title = "XPS Structure"
+    title = "XPS"
     identifier = "xps"
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Fix #1070 

In the new code resource design, every property plugin needs a resource panel, even if the plugin does not have an additional code other than the `pw.x`, as in the XPS plugin. 