### PR TITLE
Spruce up advanced panel styling

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -73,9 +73,16 @@ class AdvancedConfigurationSettingsPanel(
         if self.rendered:
             return
 
-        # clean-up workchain settings
+        self.reset_to_defaults_button = ipw.Button(
+            description="Reset to defaults",
+            button_style="primary",
+            icon="undo",
+            layout=ipw.Layout(width="fit-content"),
+        )
+        self.reset_to_defaults_button.on_click(self._on_reset_to_defaults_button_click)
+
         self.clean_workdir = ipw.Checkbox(
-            description="Tick to delete the work directory after the calculation is finished",
+            description="Delete the work directory after the calculation",
             indent=False,
             layout=ipw.Layout(width="fit-content"),
         )
@@ -83,13 +90,6 @@ class AdvancedConfigurationSettingsPanel(
             (self._model, "clean_workdir"),
             (self.clean_workdir, "value"),
         )
-        self.reset_to_defaults_button = ipw.Button(
-            description="Reset to defaults",
-            button_style="warning",
-            icon="undo",
-            layout=ipw.Layout(width="fit-content"),
-        )
-        self.reset_to_defaults_button.on_click(self._on_reset_to_defaults_button_click)
 
         # Smearing setting widget
         self.smearing.render()
@@ -98,8 +98,8 @@ class AdvancedConfigurationSettingsPanel(
         self.kpoints_distance = ipw.BoundedFloatText(
             min=0.0,
             step=0.05,
-            description="K-points distance (1/Å):",
-            style={"description_width": "initial"},
+            description="K-points distance:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "kpoints_distance"),
@@ -110,7 +110,7 @@ class AdvancedConfigurationSettingsPanel(
             (self.kpoints_distance, "disabled"),
             lambda _: not self._model.has_pbc,
         )
-        self.mesh_grid = ipw.HTML()
+        self.mesh_grid = ipw.HTML(layout=ipw.Layout(margin="0 0 0 10px"))
         ipw.dlink(
             (self._model, "mesh_grid"),
             (self.mesh_grid, "value"),
@@ -125,7 +125,7 @@ class AdvancedConfigurationSettingsPanel(
             max=3,
             step=0.01,
             description="Total charge:",
-            style={"description_width": "initial"},
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "total_charge"),
@@ -135,7 +135,7 @@ class AdvancedConfigurationSettingsPanel(
         # Van der Waals setting widget
         self.van_der_waals = ipw.Dropdown(
             description="Van der Waals correction:",
-            style={"description_width": "initial"},
+            style={"description_width": "150px"},
         )
         ipw.dlink(
             (self._model, "van_der_waals_options"),
@@ -153,8 +153,9 @@ class AdvancedConfigurationSettingsPanel(
         self.scf_conv_thr = ipw.BoundedFloatText(
             min=1e-15,
             max=1.0,
-            description="SCF conv.:",
-            style={"description_width": "initial"},
+            format="0.0e",
+            description="SCF:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "scf_conv_thr"),
@@ -167,8 +168,9 @@ class AdvancedConfigurationSettingsPanel(
         self.forc_conv_thr = ipw.BoundedFloatText(
             min=1e-15,
             max=1.0,
-            description="Force conv.:",
-            style={"description_width": "initial"},
+            format="0.0e",
+            description="Force:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "forc_conv_thr"),
@@ -181,8 +183,9 @@ class AdvancedConfigurationSettingsPanel(
         self.etot_conv_thr = ipw.BoundedFloatText(
             min=1e-15,
             max=1.0,
-            description="Energy conv.:",
-            style={"description_width": "initial"},
+            format="0.0e",
+            description="Energy:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "etot_conv_thr"),
@@ -196,8 +199,8 @@ class AdvancedConfigurationSettingsPanel(
             min=20,
             max=1000,
             step=1,
-            description="Max. electron steps:",
-            style={"description_width": "initial"},
+            description="Electronic:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "electron_maxstep"),
@@ -208,8 +211,8 @@ class AdvancedConfigurationSettingsPanel(
             min=50,
             max=1000,
             step=1,
-            description="Max. optimization steps:",
-            style={"description_width": "initial"},
+            description="Ionic:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "optimization_maxsteps"),
@@ -219,48 +222,38 @@ class AdvancedConfigurationSettingsPanel(
 
         self.children = [
             InAppGuide(identifier="advanced-settings"),
-            ipw.HBox(
-                children=[
-                    self.clean_workdir,
-                    self.reset_to_defaults_button,
-                ],
-                layout=ipw.Layout(
-                    justify_content="space-between",
-                    margin="0 0 10px 0",
-                ),
-            ),
+            self.reset_to_defaults_button,
+            self.clean_workdir,
             self.total_charge,
             self.van_der_waals,
             self.magnetization,
-            ipw.HTML("<b>Convergence thresholds:</b>"),
-            ipw.HBox(
-                children=[
-                    self.forc_conv_thr,
-                    self.etot_conv_thr,
-                    self.scf_conv_thr,
-                ],
-                layout=ipw.Layout(justify_content="space-between"),
-            ),
-            ipw.HBox(
-                children=[
-                    self.electron_maxstep,
-                    self.optimization_maxsteps,
-                ],
-            ),
+            ipw.HTML("<b>Convergence thresholds</b>"),
+            self.forc_conv_thr,
+            self.etot_conv_thr,
+            self.scf_conv_thr,
+            ipw.HTML("<b>Maximum cycle steps</b>"),
+            self.electron_maxstep,
+            self.optimization_maxsteps,
             self.smearing,
+            ipw.HTML("<b>K-points</b>"),
             ipw.HTML("""
-                <div>
+                <div style="line-height: 1.4; margin-bottom: 5px;">
                     The k-points mesh density of the SCF calculation is set by the
-                    <b>protocol</b>. The value below represents the maximum distance
-                    between the k-points in each direction of reciprocal space. Smaller
-                    is more accurate and costly.
+                    <b>protocol</b>.
+                    <br>
+                    The value below represents the maximum distance between k-points
+                    in each direction of reciprocal space.
+                    <br>
+                    Smaller is more accurate and costly.
                 </div>
             """),
             ipw.HBox(
                 children=[
                     self.kpoints_distance,
+                    ipw.HTML("Å<sup>-1</sup>"),
                     self.mesh_grid,
-                ]
+                ],
+                layout=ipw.Layout(align_items="center"),
             ),
             self.hubbard,
             self.pseudos,

--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -7,6 +7,7 @@ import ipywidgets as ipw
 
 from aiidalab_qe.common.infobox import InAppGuide
 from aiidalab_qe.common.panel import ConfigurationSettingsPanel
+from aiidalab_qe.common.widgets import HBoxWithUnits
 
 from .hubbard import (
     HubbardConfigurationSettingsModel,
@@ -84,7 +85,7 @@ class AdvancedConfigurationSettingsPanel(
         self.clean_workdir = ipw.Checkbox(
             description="Delete the work directory after the calculation",
             indent=False,
-            layout=ipw.Layout(width="fit-content"),
+            layout=ipw.Layout(width="fit-content", margin="5px 2px"),
         )
         ipw.link(
             (self._model, "clean_workdir"),
@@ -153,7 +154,6 @@ class AdvancedConfigurationSettingsPanel(
         self.scf_conv_thr = ipw.BoundedFloatText(
             min=1e-15,
             max=1.0,
-            format="0.0e",
             description="SCF:",
             style={"description_width": "150px"},
         )
@@ -226,16 +226,38 @@ class AdvancedConfigurationSettingsPanel(
             self.clean_workdir,
             self.total_charge,
             self.van_der_waals,
-            self.magnetization,
-            ipw.HTML("<b>Convergence thresholds</b>"),
-            self.forc_conv_thr,
-            self.etot_conv_thr,
+            ipw.HTML("<h2>Convergence</h2>"),
+            ipw.HTML("""
+                <div style="line-height: 1.4; margin-bottom: 5px;">
+                    Control the convergence criteria of the self-consistent field (SCF)
+                    geometry optimization cycles.
+                </div>
+            """),
+            ipw.HTML("<h4>Thresholds</h4>"),
+            ipw.HTML("""
+                <div style="line-height: 1.4; margin-bottom: 5px;">
+                    Setting thresholds for energy, force, and self-consistency ensures calculation accuracy and stability.
+                    <br>
+                    Lower values increase the accuracy but also the computational cost.
+                    <br>
+                    The default values are set by the <b>protocol</b> are usually a
+                    good starting point.
+                </div>
+            """),
+            HBoxWithUnits(self.forc_conv_thr, "a.u."),
+            HBoxWithUnits(self.etot_conv_thr, "a.u."),
             self.scf_conv_thr,
-            ipw.HTML("<b>Maximum cycle steps</b>"),
+            ipw.HTML("<h4>Maximum cycle steps</h4>"),
+            ipw.HTML("""
+                <div style="line-height: 1.4; margin-bottom: 5px;">
+                    Setting a maximum number of electronic and ionic optimization steps
+                    ensures that the calculation does not run indefinitely.
+                </div>
+            """),
             self.electron_maxstep,
             self.optimization_maxsteps,
             self.smearing,
-            ipw.HTML("<b>K-points</b>"),
+            ipw.HTML("<h2>K-points</h2>"),
             ipw.HTML("""
                 <div style="line-height: 1.4; margin-bottom: 5px;">
                     The k-points mesh density of the SCF calculation is set by the
@@ -249,12 +271,12 @@ class AdvancedConfigurationSettingsPanel(
             """),
             ipw.HBox(
                 children=[
-                    self.kpoints_distance,
-                    ipw.HTML("Å<sup>-1</sup>"),
+                    HBoxWithUnits(self.kpoints_distance, "Å<sup>-1</sup>"),
                     self.mesh_grid,
                 ],
                 layout=ipw.Layout(align_items="center"),
             ),
+            self.magnetization,
             self.hubbard,
             self.pseudos,
         ]

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
@@ -28,9 +28,8 @@ class HubbardConfigurationSettingsPanel(
             return
 
         self.activate_hubbard_checkbox = ipw.Checkbox(
-            description="",
+            description="Define U values",
             indent=False,
-            layout=ipw.Layout(max_width="10%"),
         )
         ipw.link(
             (self._model, "is_active"),
@@ -44,7 +43,6 @@ class HubbardConfigurationSettingsPanel(
         self.define_eigenvalues_checkbox = ipw.Checkbox(
             description="Define eigenvalues",
             indent=False,
-            layout=ipw.Layout(max_width="30%"),
         )
         ipw.link(
             (self._model, "has_eigenvalues"),
@@ -64,12 +62,8 @@ class HubbardConfigurationSettingsPanel(
         self.container = ipw.VBox()
 
         self.children = [
-            ipw.HBox(
-                children=[
-                    ipw.HTML("<b>Hubbard (DFT+U)</b>"),
-                    self.activate_hubbard_checkbox,
-                ]
-            ),
+            ipw.HTML("<b>Hubbard (DFT+U)</b>"),
+            self.activate_hubbard_checkbox,
             self.container,
         ]
 
@@ -107,16 +101,13 @@ class HubbardConfigurationSettingsPanel(
 
         children = []
 
-        if self._model.input_structure:
-            children.append(ipw.HTML("Define U value [eV] "))
-
         for label in self._model.orbital_labels:
             float_widget = ipw.BoundedFloatText(
                 description=label,
                 min=0,
                 max=20,
                 step=0.1,
-                layout={"width": "160px"},
+                style={"description_width": "150px"},
             )
             link = ipw.link(
                 (self._model, "parameters"),
@@ -130,7 +121,14 @@ class HubbardConfigurationSettingsPanel(
                 ],
             )
             self.links.append(link)
-            children.append(float_widget)
+            children.append(
+                ipw.HBox(
+                    children=[
+                        float_widget,
+                        ipw.HTML("eV"),
+                    ],
+                )
+            )
 
         if self._model.needs_eigenvalues_widget:
             children.append(self.eigenvalues_container)
@@ -158,7 +156,7 @@ class HubbardConfigurationSettingsPanel(
 
             for state_index in range(num_states):
                 eigenvalues_up = ipw.Dropdown(
-                    description=f"{state_index+1}",
+                    description=f"{state_index + 1}",
                     layout=ipw.Layout(width="65px"),
                     style={"description_width": "initial"},
                 )
@@ -191,7 +189,7 @@ class HubbardConfigurationSettingsPanel(
                 spin_up_row.children += (eigenvalues_up,)
 
                 eigenvalues_down = ipw.Dropdown(
-                    description=f"{state_index+1}",
+                    description=f"{state_index + 1}",
                     layout=ipw.Layout(width="65px"),
                     style={"description_width": "initial"},
                 )

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
@@ -1,5 +1,7 @@
 import ipywidgets as ipw
 
+from aiidalab_qe.common.widgets import HBoxWithUnits
+
 from ..subsettings import AdvancedConfigurationSubSettingsPanel
 from .model import HubbardConfigurationSettingsModel
 
@@ -36,10 +38,13 @@ class HubbardConfigurationSettingsPanel(
             (self.activate_hubbard_checkbox, "value"),
         )
 
-        self.eigenvalues_help = ipw.HTML(
-            value="For transition metals and lanthanoids, the starting eigenvalues can be defined (Magnetic calculation).",
-            layout=ipw.Layout(width="auto"),
-        )
+        self.eigenvalues_help = ipw.HTML("""
+            <div style="line-height: 1.4; margin-bottom: 5px;">
+                For transition metals and lanthanoids, the starting eigenvalues can be defined (magnetic calculation).
+                <br>
+                It is useful to suggest the desired orbital occupations when the default choice takes another path.
+            </div>
+        """)
         self.define_eigenvalues_checkbox = ipw.Checkbox(
             description="Define eigenvalues",
             indent=False,
@@ -62,7 +67,7 @@ class HubbardConfigurationSettingsPanel(
         self.container = ipw.VBox()
 
         self.children = [
-            ipw.HTML("<b>Hubbard (DFT+U)</b>"),
+            ipw.HTML("<h2>Hubbard (DFT+U)</h2>"),
             self.activate_hubbard_checkbox,
             self.container,
         ]
@@ -121,14 +126,7 @@ class HubbardConfigurationSettingsPanel(
                 ],
             )
             self.links.append(link)
-            children.append(
-                ipw.HBox(
-                    children=[
-                        float_widget,
-                        ipw.HTML("eV"),
-                    ],
-                )
-            )
+            children.append(HBoxWithUnits(float_widget, "eV"))
 
         if self._model.needs_eigenvalues_widget:
             children.append(self.eigenvalues_container)
@@ -151,8 +149,15 @@ class HubbardConfigurationSettingsPanel(
             (kind_name, num_states),
         ) in enumerate(self._model.applicable_kind_names):
             label_layout = ipw.Layout(justify_content="flex-start", width="50px")
-            spin_up_row = ipw.HBox([ipw.Label("Up:", layout=label_layout)])
-            spin_down_row = ipw.HBox([ipw.Label("Down:", layout=label_layout)])
+            spin_row_layout = ipw.Layout(grid_gap="5px")
+            spin_up_row = ipw.HBox(
+                children=[ipw.Label("Up:", layout=label_layout)],
+                layout=spin_row_layout,
+            )
+            spin_down_row = ipw.HBox(
+                children=[ipw.Label("Down:", layout=label_layout)],
+                layout=spin_row_layout,
+            )
 
             for state_index in range(num_states):
                 eigenvalues_up = ipw.Dropdown(
@@ -224,7 +229,13 @@ class HubbardConfigurationSettingsPanel(
             children.append(
                 ipw.HBox(
                     [
-                        ipw.Label(kind_name, layout=label_layout),
+                        ipw.Label(
+                            kind_name,
+                            layout=ipw.Layout(
+                                justify_content="flex-start",
+                                width="80px",
+                            ),
+                        ),
                         ipw.VBox(
                             children=[
                                 spin_up_row,

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -48,12 +48,9 @@ class MagnetizationConfigurationSettingsPanel(
         if self.rendered:
             return
 
-        self.header = ipw.HTML("<b>Magnetization:</b>")
+        self.header = ipw.HTML("<b>Magnetization</b>")
 
-        self.unit = ipw.HTML(
-            value="µ<sub>B</sub>",
-            layout=ipw.Layout(margin="2px 2px 5px"),
-        )
+        self.unit = ipw.HTML("µ<sub>B</sub>")
 
         self.magnetization_type_help = ipw.HTML()
         ipw.dlink(
@@ -62,11 +59,8 @@ class MagnetizationConfigurationSettingsPanel(
         )
 
         self.magnetization_type = ipw.ToggleButtons(
-            style={
-                "description_width": "initial",
-                "button_width": "initial",
-            },
-            layout=ipw.Layout(margin="0 0 10px 0"),
+            style={"button_width": "initial"},
+            layout=ipw.Layout(margin="0 0 5px"),
         )
         ipw.dlink(
             (self._model, "type_options"),
@@ -82,7 +76,7 @@ class MagnetizationConfigurationSettingsPanel(
             max=100,
             step=1,
             description="Total magnetization:",
-            style={"description_width": "initial"},
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "total"),
@@ -94,7 +88,6 @@ class MagnetizationConfigurationSettingsPanel(
                 self.tot_magnetization,
                 self.unit,
             ],
-            layout=ipw.Layout(align_items="center"),
         )
 
         self.kind_moment_widgets = ipw.VBox()
@@ -161,6 +154,7 @@ class MagnetizationConfigurationSettingsPanel(
                 min=-7,
                 max=7,
                 step=0.1,
+                style={"description_width": "150px"},
             )
             link = ipw.link(
                 (self._model, "moments"),
@@ -180,7 +174,6 @@ class MagnetizationConfigurationSettingsPanel(
                         kind_moment_widget,
                         self.unit,
                     ],
-                    layout=ipw.Layout(align_items="center"),
                 )
             )
 

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -1,5 +1,7 @@
 import ipywidgets as ipw
 
+from aiidalab_qe.common.widgets import HBoxWithUnits
+
 from ..subsettings import AdvancedConfigurationSubSettingsPanel
 from .model import MagnetizationConfigurationSettingsModel
 
@@ -48,9 +50,9 @@ class MagnetizationConfigurationSettingsPanel(
         if self.rendered:
             return
 
-        self.header = ipw.HTML("<b>Magnetization</b>")
+        self.header = ipw.HTML("<h2>Magnetization</h2>")
 
-        self.unit = ipw.HTML("µ<sub>B</sub>")
+        self.unit = "µ<sub>B</sub>"
 
         self.magnetization_type_help = ipw.HTML()
         ipw.dlink(
@@ -83,11 +85,9 @@ class MagnetizationConfigurationSettingsPanel(
             (self.tot_magnetization, "value"),
         )
 
-        self.tot_magnetization_with_unit = ipw.HBox(
-            children=[
-                self.tot_magnetization,
-                self.unit,
-            ],
+        self.tot_magnetization_with_unit = HBoxWithUnits(
+            self.tot_magnetization,
+            self.unit,
         )
 
         self.kind_moment_widgets = ipw.VBox()
@@ -168,14 +168,7 @@ class MagnetizationConfigurationSettingsPanel(
                 ],
             )
             self.links.append(link)
-            children.append(
-                ipw.HBox(
-                    children=[
-                        kind_moment_widget,
-                        self.unit,
-                    ],
-                )
-            )
+            children.append(HBoxWithUnits(kind_moment_widget, "µ<sub>B</sub>"))
 
         self.kind_moment_widgets.children = children
 

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -82,7 +82,8 @@ class MagnetizationConfigurationSettingsModel(
                 content="""
                     If a nonzero ground-state magnetization is expected, you
                     <strong>must</strong> assign a nonzero value to at least one atomic
-                    type (note that the app already provide tentative initial values).
+                    type (the app already provides tentative initial values).
+                    <br>
                     To simulate an antiferromagnetic state, first, if you have not
                     done so already, please use the atom tag editor <b>(Select
                     structure -> Edit structure -> Edit atom tags)</b> to mark atoms of

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -97,13 +97,15 @@ class PseudosConfigurationSettingsModel(
 
     PSEUDO_HELP_WO_SOC = """
         <div class="pseudo-text">
-            If you are unsure, select 'SSSP efficiency', which for most
-            calculations will produce sufficiently accurate results at
-            comparatively small computational costs. If your calculations require a
-            higher accuracy, select 'SSSP accuracy' or 'PseudoDojo stringent',
-            which will be computationally more expensive. SSSP is the standard
-            solid-state pseudopotentials. The PseudoDojo used here has the SR
-            relativistic type.
+            If you are unsure, select 'SSSP efficiency', which for most calculations
+            will produce sufficiently accurate results at comparatively small
+            computational costs.
+            <br>
+            If your calculations require a higher accuracy, select 'SSSP accuracy' or
+            'PseudoDojo stringent', which will be computationally more expensive.
+            <br>
+            SSSP is the standard solid-state pseudopotentials.
+            The PseudoDojo version used here is the SR relativistic type.
         </div>
     """
 

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -7,7 +7,7 @@ import traitlets as tl
 
 from aiida import orm
 from aiida.plugins import DataFactory, GroupFactory
-from aiidalab_qe.common.widgets import LoadingWidget
+from aiidalab_qe.common.widgets import HBoxWithUnits, LoadingWidget
 from aiidalab_widgets_base.utils import StatusHTML
 
 from ..subsettings import AdvancedConfigurationSubSettingsPanel
@@ -134,7 +134,7 @@ class PseudosConfigurationSettingsPanel(
         )
 
         self.children = [
-            ipw.HTML("<h4 style='margin-bottom: 0;'>Accuracy and precision</h4>"),
+            ipw.HTML("<h2>Accuracy and precision</h2>"),
             ipw.HTML("""
                 <div class="pseudo-text">
                     The exchange-correlation functional and pseudopotential library is
@@ -158,7 +158,7 @@ class PseudosConfigurationSettingsPanel(
                     self.family_help,
                 ],
             ),
-            ipw.HTML("<b>Pseudopotentials</b>"),
+            ipw.HTML("<h4>Pseudopotentials</h4>"),
             ipw.HTML("""
                 <div class="pseudo-text">
                     The pseudopotential for each kind of atom in the structure can be
@@ -172,28 +172,23 @@ class PseudosConfigurationSettingsPanel(
                 </div>
             """),  # noqa: RUF001
             self.setter_widget,
-            ipw.HTML("<b>Cutoffs</b>"),
+            ipw.HTML("<h4>Cutoffs</h4>"),
             ipw.HTML("""
                 <div style="line-height: 1.4;">
-                    The cutoffs used for the calculation are the maximum of the
-                    default cutoffs from all pseudopotentials.
+                    The
+                    <a
+                        href="https://www.quantum-espresso.org/Doc/INPUT_PW.html#idm312"
+                        target="_blank"
+                    >
+                        default cutoffs
+                    </a> used for the calculation are the maximum of the default cutoffs
+                    from all pseudopotentials.
+                    <br>
                     You can override them here.
                 </div>
             """),
-            ipw.HBox(
-                children=[
-                    self.ecutwfc,
-                    ipw.HTML("Ry"),
-                ],
-                layout=ipw.Layout(align_items="center"),
-            ),
-            ipw.HBox(
-                children=[
-                    self.ecutrho,
-                    ipw.HTML("Ry"),
-                ],
-                layout=ipw.Layout(align_items="center"),
-            ),
+            HBoxWithUnits(self.ecutwfc, "Ry"),
+            HBoxWithUnits(self.ecutrho, "Ry"),
             self._status_message,
         ]
 
@@ -249,13 +244,11 @@ class PseudosConfigurationSettingsPanel(
             pseudo_family_link = "http://www.pseudo-dojo.org/"
 
         self.family_prompt.value = f"""
-            <div class="pseudo-text">
-                <b>
-                    <a href="{pseudo_family_link}" target="_blank">
-                        Pseudopotential family
-                    </a>
-                </b>
-            </div>
+            <h4>
+                <a href="{pseudo_family_link}" target="_blank">
+                    Pseudopotential family
+                </a>
+            </h4>
         """
 
     def _show_loading(self):

--- a/src/aiidalab_qe/app/configuration/advanced/smearing/smearing.py
+++ b/src/aiidalab_qe/app/configuration/advanced/smearing/smearing.py
@@ -1,5 +1,7 @@
 import ipywidgets as ipw
 
+from aiidalab_qe.common.widgets import HBoxWithUnits
+
 from ..subsettings import AdvancedConfigurationSubSettingsPanel
 from .model import SmearingConfigurationSettingsModel
 
@@ -20,7 +22,7 @@ class SmearingConfigurationSettingsPanel(
             return
 
         self.smearing = ipw.Dropdown(
-            description="Smearing type:",
+            description="Type:",
             style={"description_width": "150px"},
         )
         ipw.dlink(
@@ -34,7 +36,7 @@ class SmearingConfigurationSettingsPanel(
 
         self.degauss = ipw.FloatText(
             step=0.005,
-            description="Smearing width:",
+            description="Width:",
             style={"description_width": "150px"},
         )
         ipw.link(
@@ -43,10 +45,15 @@ class SmearingConfigurationSettingsPanel(
         )
 
         self.children = [
-            ipw.HTML("<b>Smearing</b>"),
+            ipw.HTML("<h2>Smearing</h2>"),
             ipw.HTML("""
                 <div style="line-height: 1.4; margin-bottom: 5px;">
-                    The smearing type and width is set by the chosen <b>protocol</b>.
+                    Smear electronic state occupations near the Fermi level to
+                    simulate finite temperature.
+                    <br>
+                    This helps to stabilize the SCF calculation and is important for metallic systems.
+                    <br>
+                    The smearing type and width are set by the chosen <b>protocol</b>.
                     <br>
                     Changes are not advised unless you've mastered
                     <a href="http://theossrv1.epfl.ch/Main/ElectronicTemperature"
@@ -54,12 +61,7 @@ class SmearingConfigurationSettingsPanel(
                 </div>
             """),
             self.smearing,
-            ipw.HBox(
-                children=[
-                    self.degauss,
-                    ipw.HTML("Ry"),
-                ],
-            ),
+            HBoxWithUnits(self.degauss, "Ry"),
         ]
 
         self.rendered = True

--- a/src/aiidalab_qe/app/configuration/advanced/smearing/smearing.py
+++ b/src/aiidalab_qe/app/configuration/advanced/smearing/smearing.py
@@ -21,7 +21,7 @@ class SmearingConfigurationSettingsPanel(
 
         self.smearing = ipw.Dropdown(
             description="Smearing type:",
-            style={"description_width": "initial"},
+            style={"description_width": "150px"},
         )
         ipw.dlink(
             (self._model, "type_options"),
@@ -34,8 +34,8 @@ class SmearingConfigurationSettingsPanel(
 
         self.degauss = ipw.FloatText(
             step=0.005,
-            description="Smearing width (Ry):",
-            style={"description_width": "initial"},
+            description="Smearing width:",
+            style={"description_width": "150px"},
         )
         ipw.link(
             (self._model, "degauss"),
@@ -43,19 +43,22 @@ class SmearingConfigurationSettingsPanel(
         )
 
         self.children = [
+            ipw.HTML("<b>Smearing</b>"),
             ipw.HTML("""
-                <p>
+                <div style="line-height: 1.4; margin-bottom: 5px;">
                     The smearing type and width is set by the chosen <b>protocol</b>.
-                    It is not advised unless you've mastered <b>smearing effects</b>
-                    (click <a href="http://theossrv1.epfl.ch/Main/ElectronicTemperature"
-                    target="_blank">here</a> for a discussion).
-                </p>
+                    <br>
+                    Changes are not advised unless you've mastered
+                    <a href="http://theossrv1.epfl.ch/Main/ElectronicTemperature"
+                    target="_blank"><b>smearing effects</b></a>.
+                </div>
             """),
+            self.smearing,
             ipw.HBox(
                 children=[
-                    self.smearing,
                     self.degauss,
-                ]
+                    ipw.HTML("Ry"),
+                ],
             ),
         ]
 

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -169,7 +169,7 @@ class FilenameDisplayWidget(ipw.Box):
             overflow:hidden;
             text-overflow:ellipsis;
             {width_style}">
-            {icon} {change['new']}
+            {icon} {change["new"]}
         </div>
         """
 
@@ -537,7 +537,7 @@ class AddingTagsEditor(ipw.VBox):
                 symbol = chemichal_symbols[index]
                 if tag == 0:
                     tag = ""
-                table_data.append([f"{index+ 1}", f"{symbol}", f"{tag}"])
+                table_data.append([f"{index + 1}", f"{symbol}", f"{tag}"])
 
             # Create an HTML table
             table_html = "<table>"
@@ -1328,3 +1328,18 @@ class TableWidget(anywidget.AnyWidget):
     """
     data = traitlets.List().tag(sync=True)
     selected_rows = traitlets.List().tag(sync=True)
+
+
+class HBoxWithUnits(ipw.HBox):
+    def __init__(self, widget: ipw.ValueWidget, units: str, **kwargs):
+        super().__init__(
+            children=[
+                widget,
+                ipw.HTML(units),
+            ],
+            layout=ipw.Layout(
+                align_items="center",
+                grid_gap="2px",
+            ),
+            **kwargs,
+        )

--- a/tests/configuration/test_advanced.py
+++ b/tests/configuration/test_advanced.py
@@ -140,10 +140,10 @@ def test_advanced_hubbard_settings(generate_structure_data):
     assert model.orbital_labels == ["Co - 3d", "O - 2p", "Li - 2s"]
 
     # Change the Hubbard U parameters for Co, O, and Li
-    hubbard_parameters = hubbard.hubbard_widget.children[1:]  # type: ignore
-    hubbard_parameters[0].value = 1  # Co - 3d
-    hubbard_parameters[1].value = 2  # O - 2p
-    hubbard_parameters[2].value = 3  # Li - 2s
+    hubbard_parameters = hubbard.hubbard_widget.children[:]  # type: ignore
+    hubbard_parameters[0].children[0].value = 1  # Co - 3d
+    hubbard_parameters[1].children[0].value = 2  # O - 2p
+    hubbard_parameters[2].children[0].value = 3  # Li - 2s
 
     assert model.parameters == {
         "Co - 3d": 1.0,

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -230,7 +230,7 @@ def test_pseudo_upload_widget(generate_upf_data):
     w.cutoffs = [30, 240]
     w.render()
 
-    message = "Recommended ecutwfc: <b>{ecutwfc} Ry</b> ecutrho: <b>{ecutrho} Ry</b>"
+    message = "ψ: <b>{ecutwfc} Ry</b> | ρ: <b>{ecutrho} Ry</b>"  # noqa: RUF001
 
     assert w.pseudo.filename == "O_old.upf"
     assert w.kind_name == "O1"


### PR DESCRIPTION
This PR is mostly cosmetic, applying the following styles to the advanced settings panel:

- Vertically align widgets
- Add more sub-section headings and emphasize style (`h2` & `h4` tags)
- Make widget labels clear and concise
- Add more help text (thanks @AndresOrtegaGuerrero 🙏)
- Reduce help text overflow where appropriate
- Move units from label to right of input widgets (using new `HBoxWithUnits` widget)
- Move Hubbard U check box down
- Covert functional selector to toggle buttons
- Reduce verbosity in pseudopotential widgets by moving some description up into help text
- Add link for more info on pseudopotential cutoffs (thanks @AndresOrtegaGuerrero 🙏)

---

![image](https://github.com/user-attachments/assets/2a01c4b3-fd2b-4689-a169-eb02abe99577)
