### PR TITLE
Shuffle results panel top-level tabs and update default selection

### DIFF
--- a/src/aiidalab_qe/app/result/__init__.py
+++ b/src/aiidalab_qe/app/result/__init__.py
@@ -81,8 +81,8 @@ class ViewQeAppWorkChainStatusAndResultsStep(QeDependentWizardStep[ResultsStepMo
 
         self.panels = {
             "Summary": self.summary_panel,
-            "Results": self.results_panel,
             "Status": self.status_panel,
+            "Results": self.results_panel,
         }
 
         self.toggle_controls = ipw.ToggleButtons(
@@ -118,7 +118,11 @@ class ViewQeAppWorkChainStatusAndResultsStep(QeDependentWizardStep[ResultsStepMo
         self._update_kill_button_layout()
         self._update_clean_scratch_button_layout()
 
-        self.toggle_controls.value = "Summary"
+        self.toggle_controls.value = (
+            "Results"
+            if (process := self._model.fetch_process_node()) and process.is_finished_ok
+            else "Status"
+        )
 
         self.process_monitor = ProcessMonitor(
             timeout=0.5,

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -20,6 +20,8 @@ def test_result_step(app_to_submit, generate_qeapp_workchain):
     step = app.results_step
     app.results_model.process_uuid = generate_qeapp_workchain().node.uuid
     assert step.state == step.State.ACTIVE
+    step.render()
+    assert step.toggle_controls.value == "Status"
 
 
 def test_kill_and_clean_buttons(app_to_submit, generate_qeapp_workchain):


### PR DESCRIPTION
This PR does the following:
1. Reorder results tabs as Summary | Status | Results
2. Sets the default tab dynamically (Status if running, Results if complete)