### PR TITLE
Explicitly state Sphinx configuration path

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@
 # Required
 version: 2
 
+sphinx:
+    configuration: docs/source/conf.py
+
 # Set the OS, Python version and other tools you might need
 build:
     os: ubuntu-22.04


### PR DESCRIPTION
This PR addresses a recent ReadTheDocs deprecation. See [blog](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) for details.