### PR TITLE
Set full width for plugin management page

### DIFF
--- a/plugin_list.ipynb
+++ b/plugin_list.ipynb
@@ -1,6 +1,29 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiidalab_widgets_base.utils.loaders import load_css\n",
+    "\n",
+    "load_css(css_path=\"src/aiidalab_qe/app/static/styles\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
The plugin management page uses the same width as other pages.