### PR TITLE
Fix process tree issues

### DIFF
--- a/src/aiidalab_qe/app/result/components/status/status.py
+++ b/src/aiidalab_qe/app/result/components/status/status.py
@@ -66,7 +66,9 @@ class WorkChainStatusPanel(ResultsComponent[WorkChainStatusModel]):
         self.to_advanced_view_button.on_click(self._switch_to_advanced_view)
 
         simplified_tree_container = ipw.VBox(
-            children=[self.simplified_process_tree],
+            children=[
+                self.simplified_process_tree,
+            ],
         )
 
         simplified_tree_node_view_container = ipw.VBox(

--- a/src/aiidalab_qe/app/result/components/status/tree.py
+++ b/src/aiidalab_qe/app/result/components/status/tree.py
@@ -108,12 +108,14 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
             "nscf": "NSCF workflow",
             "bands": "Bands workflow",
             "relax": "Structure relaxation workflow",
+            "md": "Molecular dynamics workflow",
         },
         "PwCalculation": {
             "scf": "Run SCF cycle",
             "nscf": "Run NSCF cycle",
             "bands": "Compute bands",
             "relax": "Optimize structure geometry",
+            "md": "Run molecular dynamics simulation",
         },
         "DosCalculation": "Compute density of states",
         "ProjwfcCalculation": "Compute projections",
@@ -186,6 +188,7 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
         if label in ("PwBaseWorkChain", "PwCalculation"):
             inputs = node.inputs.pw if label == "PwBaseWorkChain" else node.inputs
             calculation: str = inputs.parameters.get_dict()["CONTROL"]["calculation"]
+            calculation = calculation.replace("vc-", "")
             return self._TITLE_MAPPING.get(label, {}).get(calculation, label)
         return self._TITLE_MAPPING.get(label, label)
 

--- a/src/aiidalab_qe/app/result/components/status/tree.py
+++ b/src/aiidalab_qe/app/result/components/status/tree.py
@@ -77,11 +77,32 @@ class SimplifiedProcessTree(ipw.VBox):
         self.children = [
             self.collapse_button,
             self.trunk,
-            ipw.HTML("""
-                <div style="margin-top: 5px; font-style: italic;">
-                    *workflow will re-submit failed calculations
-                </div>
-            """),
+            ipw.HBox(
+                children=[
+                    ipw.HTML(
+                        value="*",
+                        layout=ipw.Layout(margin="0"),
+                    ),
+                    ipw.HTML(
+                        value="""
+                            <div style="font-style: italic;">
+                                workflow will automatically re-submit failed calculations
+                                <br>
+                                <b>(advanced users)</b> click
+                                <a
+                                    href="https://aiida.readthedocs.io/projects/aiida-core/en/stable/howto/workchains_restart.html"
+                                    target="_blank"
+                                >here</a> to learn how AiiDA handles errors
+                            </div>
+                        """,
+                        layout=ipw.Layout(margin="0"),
+                    ),
+                ],
+                layout=ipw.Layout(
+                    align_items="flex-start",
+                    margin="5px 0 0 0",
+                ),
+            ),
         ]
 
     def _update(self):

--- a/src/aiidalab_qe/app/static/styles/status.css
+++ b/src/aiidalab_qe/app/static/styles/status.css
@@ -21,6 +21,14 @@
   }
 }
 
+.simplified-view .widget-button {
+  min-height: 28px;
+}
+
+.filename-display {
+  min-height: 32px;
+}
+
 /* Process tree */
 
 .rolling-output {
@@ -48,10 +56,6 @@
 
 .simplified-process-tree .widget-html-content {
   line-height: 1.5;
-}
-
-.simplified-process-tree .widget-button {
-  height: fit-content;
 }
 
 .simplified-process-tree .tree-node-toggle:focus:enabled,
@@ -96,6 +100,7 @@
 
 .simplified-process-tree .calculation-link {
   color: var(--color-link);
+  margin: 0 2px;
 }
 
 .simplified-process-tree .calculation-link:hover:enabled,

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -159,6 +159,7 @@ class FilenameDisplayWidget(ipw.Box):
         self.max_width = max_width
         self._html = ipw.HTML()
         super().__init__([self._html], **kwargs)
+        self.add_class("filename-display")
 
     @traitlets.observe("value")
     def _observe_filename(self, change):


### PR DESCRIPTION
This PR handles a styling issue (casuing some buttons to have odd height) and a process label issue (now handling "vc-" labels). It also adds a link to the docs to learn more about how the restart feature works.