### PR TITLE
Adding widget to control aspect ratio of plot 

### DIFF
--- a/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
@@ -258,8 +258,8 @@ class BandsPdosWidget(ipw.VBox):
         )
 
         self.bands_width_percentage = ipw.IntSlider(
-            min=20,
-            max=80,
+            min=10,
+            max=90,
             step=5,
             description="Bands width %:",
             orientation="horizontal",

--- a/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
@@ -235,6 +235,49 @@ class BandsPdosWidget(ipw.VBox):
             "value",
         )
 
+        # Aspect ratio
+        self.horizontal_width_percentage = ipw.IntSlider(
+            min=30,
+            max=100,
+            step=5,
+            description="Horizonal width %:",
+            orientation="horizontal",
+            continuous_update=False,
+            readout=True,
+            readout_format=".0f",
+            style={"description_width": "initial"},
+            layout=ipw.Layout(width="380px"),
+        )
+        ipw.link(
+            (self._model, "horizontal_width_percentage"),
+            (self.horizontal_width_percentage, "value"),
+        )
+        self.horizontal_width_percentage.observe(
+            self._on_horizontal_width_change,
+            "value",
+        )
+
+        self.bands_width_percentage = ipw.IntSlider(
+            min=20,
+            max=80,
+            step=5,
+            description="Bands width %:",
+            orientation="horizontal",
+            continuous_update=False,
+            readout=True,
+            readout_format=".0f",
+            style={"description_width": "initial"},
+            layout=ipw.Layout(width="380px"),
+        )
+        ipw.link(
+            (self._model, "bands_width_percentage"),
+            (self.bands_width_percentage, "value"),
+        )
+        self.bands_width_percentage.observe(
+            self._on_bands_width_change,
+            "value",
+        )
+
         self.legend_interaction_description = ipw.HTML(
             """
                 <div style="line-height: 140%; padding-top: 10px; padding-bottom: 5px; max-width: 600px;">
@@ -289,7 +332,13 @@ class BandsPdosWidget(ipw.VBox):
                 layout=ipw.Layout(margin="0 auto"),
             ),
             self.color_selector,
+            self.horizontal_width_percentage,
         ]
+        if self._model.helper.plot_type == "combined":
+            self.children = [
+                *self.children,
+                self.bands_width_percentage,
+            ]
 
     def _update_bands_projections(self, _):
         """Update the plot with the selected projection."""
@@ -352,3 +401,9 @@ class BandsPdosWidget(ipw.VBox):
 
     def _update_trace_color(self, change):
         self._model.update_trace_color(change["new"])
+
+    def _on_horizontal_width_change(self, change):
+        self._model.update_horizontal_width(change["new"])
+
+    def _on_bands_width_change(self, change):
+        self._model.update_column_width_ratio(change["new"])

--- a/src/aiidalab_qe/common/bands_pdos/model.py
+++ b/src/aiidalab_qe/common/bands_pdos/model.py
@@ -71,6 +71,12 @@ class BandsPdosModel(Model):
     )
     image_format = tl.Unicode("png")
 
+    # Aspect ratio
+    horizontal_width = 850  # pixels
+    horizontal_width_percentage = tl.Int(100)
+
+    bands_width_percentage = tl.Int(70)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -289,6 +295,19 @@ class BandsPdosModel(Model):
 
         # Update the color picker to match the updated trace
         self.color_picker = rgba_to_hex(self.plot.data[self.trace].line.color)
+
+    def update_horizontal_width(self, width_percentage):
+        """Update the horizontal width based on the percentge."""
+        horizontal_width = int((width_percentage / 100) * self.horizontal_width)
+        self.plot.layout.width = horizontal_width
+
+    def update_column_width_ratio(self, bands_width_percentage):
+        """Update the combined_column_widths of the combined plot based on percentage."""
+        bands_width = bands_width_percentage / 100
+        self.plot.update_layout(
+            xaxis={"domain": [0, bands_width]},
+            xaxis2={"domain": [bands_width, 1]},
+        )
 
     def download_image(self, _=None):
         """

--- a/src/aiidalab_qe/common/bands_pdos/model.py
+++ b/src/aiidalab_qe/common/bands_pdos/model.py
@@ -305,8 +305,8 @@ class BandsPdosModel(Model):
         """Update the combined_column_widths of the combined plot based on percentage."""
         bands_width = bands_width_percentage / 100
         self.plot.update_layout(
-            xaxis={"domain": [0, bands_width]},
-            xaxis2={"domain": [bands_width, 1]},
+            xaxis={"domain": [0, bands_width - 0.004]},
+            xaxis2={"domain": [bands_width + 0.004, 1]},
         )
 
     def download_image(self, _=None):


### PR DESCRIPTION
As requested by Carlo, this PR we add widget to change the width of the plots of the bandspdosplot widget. 

For instance , in a 1D GNR the original 
<img width="859" alt="image" src="https://github.com/user-attachments/assets/db289485-857f-4b3b-9b37-29a4c02618de" />

can be modified to 
<img width="859" alt="image" src="https://github.com/user-attachments/assets/06b7d802-48b7-4fe8-ab7d-bed026319dd5" />


The same applied for the bands+pdos plot
<img width="859" alt="image" src="https://github.com/user-attachments/assets/8e143bf8-09ff-4c2c-a8ad-c9395a56670d" />


The user can do modifcations to obtain 
<img width="859" alt="image" src="https://github.com/user-attachments/assets/48f3db97-e19f-467f-954b-46eb3cfd9bfe" />


