### PR TITLE
UV_CACHE_DIR need do be the ARG for stage3 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN --mount=from=uv,source=/uv,target=/bin/uv \
 # - Install QE codes and pseudopotentials
 # - Archive home folder
 FROM build_deps AS home_build
+ARG UV_CACHE_DIR
 ARG QE_DIR
 ARG HQ_VER
 ARG HQ_COMPUTER


### PR DESCRIPTION
I think since the folder is used for the aiida-pseudo installation workaround, this change is needed. I don't know on the github CI it does not require this change, I need this to run `docker build -it ` in my local laptop.