### PR TITLE
fix: enable running image on Renku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,9 @@ RUN --mount=from=qe_conda_env,source=${QE_DIR},target=${QE_DIR} \
     verdi daemon stop && \
     mamba run -n aiida-core-services pg_ctl stop && \
     touch /home/${NB_USER}/.FLAG_HOME_INITIALIZED && \
-    cd /home/${NB_USER} && tar -cf /opt/conda/home.tar .
+    # NOTE: The work folder is empty but if included clashes with the work folder in a Renku
+    # session whose permissions cannot be changed.
+    cd /home/${NB_USER} && tar -cf /opt/conda/home.tar --exclude work .
 
 # STAGE 3 - Final stage
 # - Install python dependencies

--- a/before-notebook.d/00_untar-home.sh
+++ b/before-notebook.d/00_untar-home.sh
@@ -15,10 +15,11 @@ if [ ! -e $home/.FLAG_HOME_INITIALIZED ]; then
   fi
 
   echo "Extracting $HOME_TAR to $home"
-  # NOTE: a tar error when deployed to k8s but at the momment not cause any issue
-  # tar: .: Cannot utime: Operation not permitted
-  # tar: .: Cannot change mode to rwxr-s---: Operation not permitted
-  tar -xf $HOME_TAR -C "$home"
+  # NOTE: the added flags to tar are to address some errors that occur in k8s
+  # tar: .: Cannot utime: Operation not permitted -> --touch solves this problem
+  # tar: .: Cannot change mode to rwxr-s---: Operation not permitted -> --no-overwrite-dir solves this problem
+  # this only refers to the metadata and permissions of existing directories, not their contents
+  tar -xf $HOME_TAR -C "$home" --no-overwrite-dir --touch
 else
   echo "$home folder is not empty!"
   ls -lrta "$home"


### PR DESCRIPTION
This enables running the image on Renku.

See the `qe-test-tasko` session launcher on https://renkulab.io/v2/projects/jusong.yeu/aiidalab-qe-app.

The session launcher has the following specs:
![Screenshot From 2025-01-21 13-45-02](https://github.com/user-attachments/assets/520663df-4316-441e-a75e-3dd3af6644a4)
