### PR TITLE
Correct observation order of code selection

### DIFF
--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -282,11 +282,11 @@ class ResourceSettingsPanel(SettingsPanel[RSM]):
         else:
             code_widget = self.code_widgets[code_model.name]
         if not code_model.is_rendered:
-            self._render_code_widget(code_model, code_widget)
             code_widget.observe(
                 code_widget.update_resources,
                 "value",
             )
+            self._render_code_widget(code_model, code_widget)
 
     def _render_code_widget(
         self,


### PR DESCRIPTION
Moved observation of code selector above its initial setting to ensure that the resource update, which also sets max CPUs, is triggered.