### PR TITLE
Fix loader margins

### DIFF
--- a/src/aiidalab_qe/app/wizard_app.py
+++ b/src/aiidalab_qe/app/wizard_app.py
@@ -93,7 +93,7 @@ class WizardApp(ipw.VBox):
 
         self._process_loading_message = LoadingWidget(
             message="Loading process",
-            layout=ipw.Layout(display="none"),
+            layout={"display": "none"},
         )
 
         super().__init__(

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -979,9 +979,17 @@ class LoadingWidget(ipw.HBox):
         self.message = ipw.Label(message)
         super().__init__(
             children=[
-                self.message,
-                ipw.HTML("<i class='fa fa-spinner fa-spin fa-2x fa-fw'></i>"),
+                ipw.Label(message),
+                ipw.HTML(
+                    value="<i class='fa fa-spinner fa-spin fa-2x fa-fw'/>",
+                    layout=ipw.Layout(margin="12px 0 6px"),
+                ),
             ],
+            layout=ipw.Layout(
+                justify_content="center",
+                align_items="center",
+                **kwargs.pop("layout", {}),
+            ),
             **kwargs,
         )
         self.add_class("loading")


### PR DESCRIPTION
Fixing an annoying CSS issue where a scroll bar keeps (dis)appearing due to the way the `fa-spin` class is implemented.