### PR TITLE
Adding pencil decomposition for dos.x by default

### DIFF
--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -42,6 +42,7 @@ def update_resources(builder, codes):
     set_component_resources(builder.projwfc, codes.get("projwfc"))
     enable_pencil_decomposition(builder.scf.pw)
     enable_pencil_decomposition(builder.nscf.pw)
+    enable_pencil_decomposition(builder.dos)
 
     # disable the parallelization setting for projwfc
     # npool = codes["pw"]["parallelization"]["npool"]


### PR DESCRIPTION
This fixes https://github.com/aiidalab/aiidalab-qe/issues/1122

This because we risk to have too many processors and few plane waves. The problem is also present for projwfc.x, but there is not -pd option.

For projwfc.x, we can simply add something in the documentation of the app.