### PR TITLE
Discard capturing of loaded stylesheets

### DIFF
--- a/calculation_history.ipynb
+++ b/calculation_history.ipynb
@@ -31,7 +31,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
     "from aiidalab_widgets_base.utils.loaders import load_css\n",
     "\n",
     "load_css(css_path=\"src/aiidalab_qe/app/static/styles\")"

--- a/delete.ipynb
+++ b/delete.ipynb
@@ -35,7 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
     "from aiidalab_widgets_base.utils.loaders import load_css\n",
     "\n",
     "load_css(css_path=\"src/aiidalab_qe/app/static/styles\")"

--- a/download.ipynb
+++ b/download.ipynb
@@ -35,7 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
     "from aiidalab_widgets_base.utils.loaders import load_css\n",
     "\n",
     "load_css(css_path=\"src/aiidalab_qe/app/static/styles\")"

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -35,7 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
     "from aiidalab_widgets_base.utils.loaders import load_css\n",
     "\n",
     "load_css(css_path=\"src/aiidalab_qe/app/static/styles\")"

--- a/plugin_list.ipynb
+++ b/plugin_list.ipynb
@@ -35,7 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%capture\n",
     "from aiidalab_widgets_base.utils.loaders import load_css\n",
     "\n",
     "load_css(css_path=\"src/aiidalab_qe/app/static/styles\")"


### PR DESCRIPTION
#1128 incorrectly applied `%%capture` to the style-loading cells, effectively consuming the stylesheets. This PR removes the captures.