### PR TITLE
Make pseudopotential subsection title consistent

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -73,12 +73,6 @@ class PseudosConfigurationSettingsPanel(
             (self.family_help, "value"),
         )
 
-        self.functional_prompt = ipw.HTML("""
-            <div class="pseudo-text"><b>
-                Exchange-correlation  functional</b>
-            </div>
-        """)
-
         self.functional_help = ipw.HTML("""
             <div class="pseudo-text">
                 The exchange-correlation energy is calculated using this functional.
@@ -146,7 +140,7 @@ class PseudosConfigurationSettingsPanel(
             """),
             ipw.VBox(
                 children=[
-                    self.functional_prompt,
+                    ipw.HTML("<h4>Exchange-correlation functional</h4>"),
                     self.functional,
                     self.functional_help,
                 ],


### PR DESCRIPTION
Made heading for functionals subsection `h4` for consistency.

![image](https://github.com/user-attachments/assets/6745024f-23fe-4bb4-af48-33eccff39949)
