### PR TITLE
Bump QE plugin to 4.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     aiida-core~=2.2,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.8
+    aiida-quantumespresso~=4.9
     aiidalab-widgets-base[optimade]==2.3.0a3
     aiida-pseudo~=1.4
     filelock~=3.8


### PR DESCRIPTION
The new QE plugin introduces the use of "tetrahedra_opt" in the NSCF calculation of the PDOS Workflow. 
This will close #959 , and It will allow the correct calculation of pdos for molecules as well. 
