### PR TITLE
Bump aiidalab-widgets-base dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     aiida-core~=2.2,<3
     Jinja2~=3.0
     aiida-quantumespresso~=4.9
-    aiidalab-widgets-base[optimade]==2.3.0a3
+    aiidalab-widgets-base[optimade]~=2.3
     aiida-pseudo~=1.4
     filelock~=3.8
     importlib-resources~=5.2


### PR DESCRIPTION
Depend on the stable version of the awb library.