### PR TITLE
Using tetrahedra_lin is gaussian smearing is used

### DIFF
--- a/src/aiidalab_qe/plugins/pdos/workchain.py
+++ b/src/aiidalab_qe/plugins/pdos/workchain.py
@@ -84,13 +84,14 @@ def get_builder(codes, structure, parameters, **kwargs):
         projwfc_overrides["parameters"]["PROJWFC"] = {
             "degauss": parameters["pdos"]["pdos_degauss"]
         }
+        # Using Gaussian smearing with 'tetrahedra_opt' in NSCF calculations
+        # causes projwfc.x to fail in producing projections.
+        # This issue occurs in 3D, 2D, and 1D systems, as well as in molecules.
+        # To avoid this, we use 'tetrahedra_lin' instead when 'pdos_degauss' is set.
+        nscf_overrides["pw"]["parameters"]["SYSTEM"]["occupations"] = "tetrahedra_lin"
 
     # Update the nscf kpoints distance from the setting panel
     nscf_overrides["kpoints_distance"] = parameters["pdos"]["nscf_kpoints_distance"]
-
-    # Since tetrahedra_opt doesnt produce projections in projwfc for molecules we use tetrahedra_lin
-    if structure.pbc == (False, False, False):
-        nscf_overrides["pw"]["parameters"]["SYSTEM"]["occupations"] = "tetrahedra_lin"
 
     overrides = {
         "scf": scf_overrides,


### PR DESCRIPTION
If the gaussian smearing option is selected the projwfc.x does not generate projections. 
This behaviour is for molecules, and crystals. 
Here we fix this issue by using `tetrahedra_lin` if the gaussian smearing is required. 
If not `tetrahedra_opt` is used