### PR TITLE
Pin plotly version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     table_widget~=0.0.2
     aiida-qe-xspec>=0.1.0a1
     shakenbreak~=3.3.1
+    plotly~=5.24
 
 python_requires = >=3.9
 


### PR DESCRIPTION

The latest plotly version (v6.0) needs Jupyter Notebook 7.0.

This PR pins the version 5.24, which I tested and work in our docker environment.