### PR TITLE
Pop relax port if not relaxation

### DIFF
--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -226,17 +226,10 @@ class WorkChainSummaryModel(ResultsComponentModel):
             },
         }
 
-        # Extract the pw calculation parameters from the workchain's inputs
-        # energy_cutoff is same for all pw calculations when pseudopotentials are fixed
-        # as well as the smearing settings (smearing and degauss) and scf kpoints distance
-        # read from the first pw calculation of relax workflow.
-        # It is safe then to extract these parameters from the first pw calculation, since the
-        # builder is anyway set with subworkchain inputs even it is not run which controlled by
-        # the properties inputs.
-        relax = inputs.relax.base
-        pw_parameters = relax.pw.parameters.get_dict()
+        # Extract the pw calculation parameters from the ui_parameters
+        pw_parameters = ui_parameters["advanced"].get("pw", {}).get("parameters", {})
         system = pw_parameters["SYSTEM"]
-        occupation = system["occupations"]
+        occupation = system.get("occupations", "fixed")
         report["advanced_settings"] |= {
             "energy_cutoff_wfc": f"{system['ecutwfc']} Ry",
             "energy_cutoff_rho": f"{system['ecutrho']} Ry",
@@ -248,7 +241,7 @@ class WorkChainSummaryModel(ResultsComponentModel):
                 "degauss": f"{system['degauss']} Ry",
             }
         inv_ang = "Å<sup>-1</sup>"
-        kpoints = relax.kpoints_distance.base.attributes.get("value")
+        kpoints = ui_parameters["advanced"]["kpoints_distance"]
         report["advanced_settings"]["scf_kpoints_distance"] = f"{kpoints} {inv_ang}"
         if "bands" in inputs:
             key = "bands_kpoints_distance"

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -229,7 +229,7 @@ class WorkChainSummaryModel(ResultsComponentModel):
         # Extract the pw calculation parameters from the ui_parameters
         pw_parameters = ui_parameters["advanced"].get("pw", {}).get("parameters", {})
         system = pw_parameters["SYSTEM"]
-        occupation = system.get("occupations", "fixed")
+        occupation = "fixed" if basic["electronic_type"] == "insulator" else "smearing"
         report["advanced_settings"] |= {
             "energy_cutoff_wfc": f"{system['ecutwfc']} Ry",
             "energy_cutoff_rho": f"{system['ecutrho']} Ry",

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -278,18 +278,20 @@ class SubmissionStepModel(
         )
 
         codes = parameters["codes"]["global"]["codes"]
-
-        builder.relax.base.pw.metadata.options.resources = {
-            "num_machines": codes.get("quantumespresso__pw")["nodes"],
-            "num_mpiprocs_per_machine": codes.get("quantumespresso__pw")[
-                "ntasks_per_node"
-            ],
-            "num_cores_per_mpiproc": codes.get("quantumespresso__pw")["cpus_per_task"],
-        }
-        mws = codes.get("quantumespresso__pw")["max_wallclock_seconds"]
-        builder.relax.base.pw.metadata.options["max_wallclock_seconds"] = mws
-        parallelization = codes["quantumespresso__pw"]["parallelization"]
-        builder.relax.base.pw.parallelization = orm.Dict(dict=parallelization)
+        if "relax" in builder:
+            builder.relax.base.pw.metadata.options.resources = {
+                "num_machines": codes.get("quantumespresso__pw")["nodes"],
+                "num_mpiprocs_per_machine": codes.get("quantumespresso__pw")[
+                    "ntasks_per_node"
+                ],
+                "num_cores_per_mpiproc": codes.get("quantumespresso__pw")[
+                    "cpus_per_task"
+                ],
+            }
+            mws = codes.get("quantumespresso__pw")["max_wallclock_seconds"]
+            builder.relax.base.pw.metadata.options["max_wallclock_seconds"] = mws
+            parallelization = codes["quantumespresso__pw"]["parallelization"]
+            builder.relax.base.pw.parallelization = orm.Dict(dict=parallelization)
 
         return builder
 

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -231,7 +231,6 @@ class QeAppWorkChain(WorkChain):
                 setattr(builder, name, plugin_builder._inputs(prune=True))
             else:
                 builder.pop(name, None)
-        print(builder)
         return builder
 
     def setup(self):

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -185,26 +185,31 @@ class QeAppWorkChain(WorkChain):
 
         protocol = parameters["workchain"]["protocol"]
 
-        relax_builder = PwRelaxWorkChain.get_builder_from_protocol(
-            code=codes["global"]["codes"].get("quantumespresso__pw")["code"],
-            structure=structure,
-            protocol=protocol,
-            relax_type=RelaxType(parameters["workchain"]["relax_type"]),
-            electronic_type=ElectronicType(parameters["workchain"]["electronic_type"]),
-            spin_type=SpinType(parameters["workchain"]["spin_type"]),
-            initial_magnetic_moments=parameters["advanced"]["initial_magnetic_moments"],
-            overrides=relax_overrides,
-            **kwargs,
-        )
-        enable_pencil_decomposition(relax_builder.base.pw)
-        # pop the inputs that are excluded from the expose_inputs
-        relax_builder.pop("structure", None)
-        relax_builder.pop("clean_workdir", None)
-        relax_builder.pop("base_final_scf", None)  # never run a final scf
-        builder.relax = relax_builder
+        if "relax" in properties:
+            relax_builder = PwRelaxWorkChain.get_builder_from_protocol(
+                code=codes["global"]["codes"].get("quantumespresso__pw")["code"],
+                structure=structure,
+                protocol=protocol,
+                relax_type=RelaxType(parameters["workchain"]["relax_type"]),
+                electronic_type=ElectronicType(
+                    parameters["workchain"]["electronic_type"]
+                ),
+                spin_type=SpinType(parameters["workchain"]["spin_type"]),
+                initial_magnetic_moments=parameters["advanced"][
+                    "initial_magnetic_moments"
+                ],
+                overrides=relax_overrides,
+                **kwargs,
+            )
+            enable_pencil_decomposition(relax_builder.base.pw)
+            # pop the inputs that are excluded from the expose_inputs
+            relax_builder.pop("structure", None)
+            relax_builder.pop("clean_workdir", None)
+            relax_builder.pop("base_final_scf", None)  # never run a final scf
+            builder.relax = relax_builder
+        else:
+            builder.pop("relax")
 
-        if properties is None:
-            properties = []
         builder.properties = orm.List(list=properties)
         # clean workdir
         clean_workdir = orm.Bool(parameters["advanced"]["clean_workdir"])
@@ -226,7 +231,7 @@ class QeAppWorkChain(WorkChain):
                 setattr(builder, name, plugin_builder._inputs(prune=True))
             else:
                 builder.pop(name, None)
-
+        print(builder)
         return builder
 
     def setup(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -818,7 +818,8 @@ def generate_qeapp_workchain(
         builder = app.submit_model._create_builder(parameters)
 
         inputs = builder._inputs()
-        inputs["relax"]["base_final_scf"] = deepcopy(inputs["relax"]["base"])
+        if "relax" in inputs:
+            inputs["relax"]["base_final_scf"] = deepcopy(inputs["relax"]["base"])
 
         if run_bands:
             # Setting up inputs for bands_projwfc


### PR DESCRIPTION
Currently, the `relax` port always exists in the builder even if the `relax` is not required, and the summary report also depends on the `relax` input.

This PR fixes this by:
- If no relaxation is required, the `relax` port will be popped out.
- The summary parameters are read from `ui_parameters` instead of `relax` port.


This fixes the wrong number of jobs in the status tree.
![image](https://github.com/user-attachments/assets/13251e73-3ce2-401d-8ecf-42dcc19aead3)
