### PR TITLE
Remove aiida-qe-xspec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     aiida-wannier90-workflows==2.3.0
     anywidget==0.9.13
     table_widget~=0.0.2
-    aiida-qe-xspec>=0.1.0a1
     shakenbreak~=3.3.1
     plotly~=5.24
 


### PR DESCRIPTION
XPS/XAS plugins are migrated out, so the `aiida-qe-xspec` should not be a dependency.