### PR TITLE
Fix `LinkButton` styles

### DIFF
--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -43,6 +43,7 @@
 
 .link-button {
   padding: 0;
+  width: fit-content;
 }
 
 .link-button a {

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -1164,7 +1164,7 @@ class LinkButton(ipw.HTML):
                 role="button"
                 href="{link}"
                 target="{"_self" if in_place else "_blank"}"
-                style="cursor: default; width: fit-content; {style_}"
+                style="cursor: default; {style_}"
             >
         """
         if icon:


### PR DESCRIPTION
Styles were applied to the `LinkButton`'s inner anchor tag. Here, a `link-button` CSS class is added directly to the `LinkButton` class (inherits `ipywidgets.HTML`).