### PR TITLE
Cache node per thread to reduce DB calls

### DIFF
--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 import typing as t
 from copy import deepcopy
 
@@ -156,10 +157,14 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
         self.level = level
         self.on_inspect = on_inspect
         super().__init__(**kwargs)
+        self._node: dict[int, ProcessNodeType] = {}  # thread_id: node
 
     @property
     def node(self) -> ProcessNodeType:
-        return orm.load_node(self.uuid)  # type: ignore
+        if (tid := threading.get_ident()) not in self._node:
+            node = orm.load_node(self.uuid)
+            self._node[tid] = node
+        return self._node[tid]
 
     def initialize(self):
         self._build_header()


### PR DESCRIPTION
As the current implementation makes significant use of AiiDA nodes, good to cache them. Here I use a cache dict to store the node instance per thread id, to avoid DB session issues.