### PR TITLE
Label the computer as `localhost` in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG HQ_VER=0.19.0
 
 ARG UV_CACHE_DIR=/tmp/uv_cache
 ARG QE_APP_SRC=/tmp/quantum-espresso
-ARG HQ_COMPUTER="localhost-hq"
+ARG HQ_COMPUTER="localhost"
 
 FROM ghcr.io/astral-sh/uv:${UV_VER} AS uv
 
@@ -125,7 +125,8 @@ COPY --from=qe_conda_env ${QE_DIR} ${QE_DIR}
 
 USER root
 
-COPY ./before-notebook.d/* /usr/local/bin/before-notebook.d/
+# We exclude 42_setup-hq-computer.sh file because the computer is already steup, thus it is not needed in the final image.
+COPY ./before-notebook.d/00_untar-home.sh ./before-notebook.d/43_start-hq.sh /usr/local/bin/before-notebook.d/
 
 ENV HQ_COMPUTER=$HQ_COMPUTER
 

--- a/before-notebook.d/42_setup-hq-computer.sh
+++ b/before-notebook.d/42_setup-hq-computer.sh
@@ -2,6 +2,13 @@
 
 set -x
 
+# Disable and rename the default 'localhost' computer to 'localhost-non-hq'.
+# This is necessary because we will create a new 'localhost' computer
+# configured with HyperQueue as the job management system.
+verdi computer disable localhost aiida@localhost
+python -c "from aiida import orm, load_profile;load_profile();orm.load_computer(label='localhost').label = 'localhost-non-hq'"
+
+
 # computer
 verdi computer show ${HQ_COMPUTER} || verdi computer setup        \
   --non-interactive                                               \
@@ -16,6 +23,3 @@ verdi computer show ${HQ_COMPUTER} || verdi computer setup        \
 verdi computer configure core.local "${HQ_COMPUTER}"              \
   --non-interactive                                               \
   --safe-interval 5.0
-
-# disable the localhost which is set in base image
-verdi computer disable localhost aiida@localhost


### PR DESCRIPTION
As discussed with @unkcpz  and @edan-bainglass , we propose the following changes:
- Use `localhost` as the default computer's name in the Docker image, which is consistent with the app's default setting. This also makes it easy for plugin developers to set up their code.
- Keep the old computer from the full-stack image but change its label to `localhost-non-hq`, as @edan-bainglass suggested. The reason to keep it, because @unkcpz  suggested, if we delete the old `localhost`, we may delete the user's data in the volume that is associated with the `localhost`.
