### PR TITLE
Label the computer as `localhost` in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG HQ_VER=0.19.0
 
 ARG UV_CACHE_DIR=/tmp/uv_cache
 ARG QE_APP_SRC=/tmp/quantum-espresso
-ARG HQ_COMPUTER="localhost-hq"
+ARG HQ_COMPUTER="localhost"
 
 FROM ghcr.io/astral-sh/uv:${UV_VER} AS uv
 
@@ -125,7 +125,8 @@ COPY --from=qe_conda_env ${QE_DIR} ${QE_DIR}
 
 USER root
 
-COPY ./before-notebook.d/* /usr/local/bin/before-notebook.d/
+# We exclude 42_setup-hq-computer.sh file because the computer is already steup, thus it is not needed in the final image.
+COPY ./before-notebook.d/00_untar-home.sh ./before-notebook.d/43_start-hq.sh /usr/local/bin/before-notebook.d/
 
 ENV HQ_COMPUTER=$HQ_COMPUTER
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG HQ_VER=0.19.0
 
 ARG UV_CACHE_DIR=/tmp/uv_cache
 ARG QE_APP_SRC=/tmp/quantum-espresso
-ARG HQ_COMPUTER="localhost"
+ARG COMPUTER_LABEL="localhost"
 
 FROM ghcr.io/astral-sh/uv:${UV_VER} AS uv
 
@@ -52,7 +52,7 @@ FROM build_deps AS home_build
 ARG UV_CACHE_DIR
 ARG QE_DIR
 ARG HQ_VER
-ARG HQ_COMPUTER
+ARG COMPUTER_LABEL
 
 # Install hq binary
 RUN wget -c -O hq.tar.gz https://github.com/It4innovations/hyperqueue/releases/download/v${HQ_VER}/hq-v${HQ_VER}-linux-x64.tar.gz && \
@@ -78,14 +78,12 @@ RUN --mount=from=uv,source=/uv,target=/bin/uv \
 
 COPY ./before-notebook.d/* /usr/local/bin/before-notebook.d/
 
-ENV HQ_COMPUTER=$HQ_COMPUTER
-
 # TODO: Remove PGSQL and daemon log files, and other unneeded files
 RUN --mount=from=qe_conda_env,source=${QE_DIR},target=${QE_DIR} \
     bash /usr/local/bin/before-notebook.d/20_start-postgresql.sh && \
     bash /usr/local/bin/before-notebook.d/40_prepare-aiida.sh && \
     bash /usr/local/bin/before-notebook.d/42_setup-hq-computer.sh && \
-    python -m aiidalab_qe install-qe --computer ${HQ_COMPUTER} && \
+    python -m aiidalab_qe install-qe --computer ${COMPUTER_LABEL} && \
     python -m aiidalab_qe install-pseudos --source ${PSEUDO_FOLDER} && \
     verdi daemon stop && \
     mamba run -n aiida-core-services pg_ctl stop && \
@@ -104,7 +102,7 @@ FROM ghcr.io/aiidalab/full-stack:${FULL_STACK_VER}
 ARG QE_DIR
 ARG QE_APP_SRC
 ARG UV_CACHE_DIR
-ARG HQ_COMPUTER
+ARG COMPUTER_LABEL
 USER ${NB_USER}
 
 WORKDIR /tmp
@@ -128,7 +126,7 @@ USER root
 # We exclude 42_setup-hq-computer.sh file because the computer is already steup, thus it is not needed in the final image.
 COPY ./before-notebook.d/00_untar-home.sh ./before-notebook.d/43_start-hq.sh /usr/local/bin/before-notebook.d/
 
-ENV HQ_COMPUTER=$HQ_COMPUTER
+ENV COMPUTER_LABEL=$COMPUTER_LABEL
 
 # Remove content of $HOME
 # '-mindepth=1' ensures that we do not remove the home directory itself.

--- a/before-notebook.d/42_setup-hq-computer.sh
+++ b/before-notebook.d/42_setup-hq-computer.sh
@@ -2,17 +2,17 @@
 
 set -x
 
-# Disable and rename the default 'localhost' computer to 'localhost-non-hq'.
+# Disable and rename the default 'localhost' computer to 'localhost-legacy'.
 # This is necessary because we will create a new 'localhost' computer
 # configured with HyperQueue as the job management system.
 verdi computer disable localhost aiida@localhost
-verdi computer relabel localhost localhost-non-hq
+verdi computer relabel localhost localhost-legacy
 
 
 # computer
-verdi computer show ${HQ_COMPUTER} || verdi computer setup        \
+verdi computer show ${COMPUTER_LABEL} || verdi computer setup        \
   --non-interactive                                               \
-  --label "${HQ_COMPUTER}"                                        \
+  --label "${COMPUTER_LABEL}"                                        \
   --description "local computer with hyperqueue scheduler"        \
   --hostname "localhost"                                          \
   --transport core.local                                          \
@@ -20,6 +20,6 @@ verdi computer show ${HQ_COMPUTER} || verdi computer setup        \
   --work-dir /home/${NB_USER}/aiida_run/                          \
   --mpirun-command "mpirun -np {num_cpus}"
 
-verdi computer configure core.local "${HQ_COMPUTER}"              \
+verdi computer configure core.local "${COMPUTER_LABEL}"              \
   --non-interactive                                               \
   --safe-interval 5.0

--- a/before-notebook.d/42_setup-hq-computer.sh
+++ b/before-notebook.d/42_setup-hq-computer.sh
@@ -2,6 +2,13 @@
 
 set -x
 
+# Disable and rename the default 'localhost' computer to 'localhost-non-hq'.
+# This is necessary because we will create a new 'localhost' computer
+# configured with HyperQueue as the job management system.
+verdi computer disable localhost aiida@localhost
+verdi computer relabel localhost localhost-non-hq
+
+
 # computer
 verdi computer show ${HQ_COMPUTER} || verdi computer setup        \
   --non-interactive                                               \
@@ -16,6 +23,3 @@ verdi computer show ${HQ_COMPUTER} || verdi computer setup        \
 verdi computer configure core.local "${HQ_COMPUTER}"              \
   --non-interactive                                               \
   --safe-interval 5.0
-
-# disable the localhost which is set in base image
-verdi computer disable localhost aiida@localhost

--- a/before-notebook.d/43_start-hq.sh
+++ b/before-notebook.d/43_start-hq.sh
@@ -66,7 +66,7 @@ run-one-constantly hq worker start --cpus=${CPU_LIMIT} --resource "mem=sum(${MEM
 # In addition, set default mpiprocs and memor per machine
 # TODO: this will be run every time the container start, we need a lock file to prevent it.
 job_poll_interval="2.0"
-computer_name=${HQ_COMPUTER}
+computer_name=${COMPUTER_LABEL}
 python -c "
 from aiida import load_profile; from aiida.orm import load_computer;
 load_profile();

--- a/before-notebook.d/43_start-hq.sh
+++ b/before-notebook.d/43_start-hq.sh
@@ -52,6 +52,13 @@ if [ -f "$CPU_QUOTA_PATH" ] && [ -f "$CPU_PERIOD_PATH" ]; then
 else
   CPU_LIMIT=$(nproc)
 fi
+
+# Temporary fix for https://github.com/aiidalab/aiidalab-qe/issues/1193
+# Ensure CPU_LIMIT is at least 1
+if [ "$CPU_LIMIT" -le 0 ]; then
+  CPU_LIMIT=1
+fi
+
 echo "Number of CPUs allocated: $CPU_LIMIT"
 
 # Start HQ server and worker

--- a/before-notebook.d/43_start-hq.sh
+++ b/before-notebook.d/43_start-hq.sh
@@ -32,6 +32,10 @@ if [ -f "$MEMORY_LIMIT_PATH" ]; then
     MEMORY_LIMIT=4096
   else
     MEMORY_LIMIT=$(echo "scale=0; $MEMORY_LIMIT / (1024 * 1024)" | bc)
+    # Temporary fix for https://github.com/aiidalab/aiidalab-qe/issues/1193
+    if [ "$MEMORY_LIMIT" -gt 1024000 ]; then
+      MEMORY_LIMIT=4096
+    fi
   fi
 else
   MEMORY_LIMIT=4096
@@ -56,7 +60,7 @@ fi
 # Temporary fix for https://github.com/aiidalab/aiidalab-qe/issues/1193
 # Ensure CPU_LIMIT is at least 1
 if [ "$CPU_LIMIT" -le 0 ]; then
-  CPU_LIMIT=1
+  CPU_LIMIT=4
 fi
 
 echo "Number of CPUs allocated: $CPU_LIMIT"


### PR DESCRIPTION
I closed PR #1191 and created a new one with the same content, but this time from the main repository instead of a forked one.

As discussed with @unkcpz  and @edan-bainglass , we propose the following changes:
- Use `localhost` as the default computer's name in the Docker image, which is consistent with the app's default setting. This also makes it easy for plugin developers to set up their code.
- Keep the old computer from the full-stack image but change its label to `localhost-non-hq`, as @edan-bainglass suggested. The reason to keep it, because @unkcpz  suggested, if we delete the old `localhost`, we may delete the user's data in the volume that is associated with the `localhost`.


