### PR TITLE
Bump version v24.10.0a8 -> v25.03.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import time
 
 # -- Project information -----------------------------------------------------
 
-version = "v24.10.0a8"
+version = "v25.03.0"
 release = f"{version}-dev"
 project = "Quantum ESPRESSO App"
 copyright_first_year = "2023"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_qe
-version = 24.10.0a8
+version = 25.3.0
 description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -75,7 +75,7 @@ categories =
     quantum
 
 [bumpver]
-current_version = "v24.10.0a8"
+current_version = "v25.03.0"
 version_pattern = "v0Y.0M.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/src/aiidalab_qe/version.py
+++ b/src/aiidalab_qe/version.py
@@ -2,4 +2,4 @@
 
 """This module contains project version information for both the app and the workflow."""
 
-__version__ = "v24.10.0a8"
+__version__ = "v25.03.0"


### PR DESCRIPTION
🎉 Release v25.03.0 is out! 🎉
@giovannipizzi, @cpignedoli – another milestone achieved! 🚀

A huge shoutout to everyone who contributed! Special thanks to @edan-bainglass, @mikibonacci, @AndresOrtegaGuerrero, and @danielhollas for each making 10+ commits since the last release.

Great team and amazing work! 🎊👏

Let’s keep the momentum going and make the next one even better! 🔥