### PR TITLE
Include Kaleido package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     table_widget~=0.0.2
     shakenbreak~=3.3.1
     plotly~=5.24
+    kaleido~=0.2.1
 
 python_requires = >=3.9
 


### PR DESCRIPTION
Plotly requires the Kaleido package to export images in SVG and PDF formats. This dependency affects the electronic structure plugin, causing a bug when users attempt to download SVG files.