### PR TITLE
Removing num_atom from thresholds

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -93,7 +93,6 @@ class AdvancedConfigurationSettingsModel(
             self._update_kpoints_mesh()
 
     def get_model_state(self):
-        num_atoms = len(self.input_structure.sites) if self.input_structure else 1
         parameters = {
             "initial_magnetic_moments": None,
             "pw": {
@@ -103,10 +102,10 @@ class AdvancedConfigurationSettingsModel(
                     },
                     "CONTROL": {
                         "forc_conv_thr": self.forc_conv_thr,
-                        "etot_conv_thr": self.etot_conv_thr * num_atoms,
+                        "etot_conv_thr": self.etot_conv_thr,
                     },
                     "ELECTRONS": {
-                        "conv_thr": self.scf_conv_thr * num_atoms,
+                        "conv_thr": self.scf_conv_thr,
                         "electron_maxstep": self.electron_maxstep,
                     },
                 }

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -7,10 +7,10 @@ advanced:
   pw:
     parameters:
       CONTROL:
-        etot_conv_thr: 2.0e-05
+        etot_conv_thr: 1.0e-05
         forc_conv_thr: 0.0001
       ELECTRONS:
-        conv_thr: 4.0e-10
+        conv_thr: 2.0e-10
         electron_maxstep: 80
       SYSTEM:
         degauss: 0.015


### PR DESCRIPTION
The values of forc_conv_thr and conv_thr were updated based on the number of atoms, following the protocol in AiiDA-QuantumESPRESSO. However, this approach contradicts the intent of manually setting convergence thresholds. This becomes problematic for large systems, as the thresholds become too loose, potentially affecting the accuracy of the calculations. This solve #1220 