### PR TITLE
Bump version v25.03.0 -> v25.04.0a1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import time
 
 # -- Project information -----------------------------------------------------
 
-version = "v25.03.0"
+version = "v25.04.0a1"
 release = f"{version}-dev"
 project = "Quantum ESPRESSO App"
 copyright_first_year = "2023"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_qe
-version = 25.3.0
+version = 25.4.0a1
 description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -77,7 +77,7 @@ categories =
     quantum
 
 [bumpver]
-current_version = "v25.03.0"
+current_version = "v25.04.0a1"
 version_pattern = "v0Y.0M.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/src/aiidalab_qe/version.py
+++ b/src/aiidalab_qe/version.py
@@ -2,4 +2,4 @@
 
 """This module contains project version information for both the app and the workflow."""
 
-__version__ = "v25.03.0"
+__version__ = "v25.04.0a1"


### PR DESCRIPTION
Release the alpha version of `v25.04.0` to include some critical fixes since `v25.03.0`.