### PR TITLE
Add bader, wannier90 and pythonjob codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG QE_VER
 ARG QE_DIR
 
 USER ${NB_USER}
-RUN mamba create -p ${QE_DIR} --yes qe=${QE_VER} && \
+RUN mamba create -p ${QE_DIR} --yes qe=${QE_VER} bader && \
     mamba clean --all -f -y
 
 # STAGE 2
@@ -59,11 +59,10 @@ RUN wget -c -O hq.tar.gz https://github.com/It4innovations/hyperqueue/releases/d
     tar xf hq.tar.gz -C /opt/conda/
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
-# temporary solution to install aiida-pseudos from repo to avoid downloading issues
+# Install plugin
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
-     uv pip install --system --strict --cache-dir=${UV_CACHE_DIR} \
-     "aiida-pseudo@git+https://github.com/aiidateam/aiida-pseudo"
+     uv pip install --system --strict --cache-dir=${UV_CACHE_DIR} aiida-bader
 
 RUN mkdir -p ${PSEUDO_FOLDER} && \
     python -m aiidalab_qe download-pseudos --dest ${PSEUDO_FOLDER}
@@ -85,6 +84,15 @@ RUN --mount=from=qe_conda_env,source=${QE_DIR},target=${QE_DIR} \
     bash /usr/local/bin/before-notebook.d/42_setup-hq-computer.sh && \
     python -m aiidalab_qe install-qe --computer ${COMPUTER_LABEL} && \
     python -m aiidalab_qe install-pseudos --source ${PSEUDO_FOLDER} && \
+    # steup code: pythonjob, bader, wannier90 code
+    verdi code create core.code.installed --label python --computer=localhost --default-calc-job-plugin pythonjob.pythonjob --filepath-executable=/opt/conda/bin/python -n && \
+    verdi code create core.code.installed --label bader --computer=localhost --default-calc-job-plugin bader.bader --filepath-executable=${QE_DIR}/bin/bader -n && \
+    verdi code create core.code.installed --label wannier90 --computer=localhost --default-calc-job-plugin wannier90.wannier90 --filepath-executable=/opt/conda/bin/wannier90.x -n && \
+    # bader plugin install PSL pseudo
+    python -m aiida_bader post-install && \
+    # wannier90 plugin need SSSP 1.1
+    aiida-pseudo install sssp -v 1.1 -x PBE && \
+    aiida-pseudo install sssp -v 1.1 -x PBEsol && \
     verdi daemon stop && \
     mamba run -n aiida-core-services pg_ctl stop && \
     touch /home/${NB_USER}/.FLAG_HOME_INITIALIZED && \
@@ -126,6 +134,22 @@ COPY --from=home_build /opt/conda/hq /usr/local/bin/
 COPY --from=qe_conda_env ${QE_DIR} ${QE_DIR}
 
 USER root
+# download and compile wannier90
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gfortran libblas-dev liblapack-dev git openmpi-bin && \
+    git clone --depth=1 https://github.com/wannier-developers/wannier90.git /tmp/wannier90 && \
+    cd /tmp/wannier90 && \
+    cp config/make.inc.gfort make.inc && \
+    make wannier && \
+    cp wannier90.x /opt/conda/bin/wannier90.x && \
+    # Keep only runtime LAPACK (liblapack3), remove dev tools
+    apt-get remove --purge -y \
+        gfortran libblas-dev liblapack-dev git && \
+    apt-get install -y --no-install-recommends liblapack3 && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/wannier90
 
 # We exclude 42_setup-hq-computer.sh file because the computer is already steup, thus it is not needed in the final image.
 COPY ./before-notebook.d/00_untar-home.sh ./before-notebook.d/43_start-hq.sh /usr/local/bin/before-notebook.d/

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.9
+    aiida-quantumespresso==4.9.0
     aiidalab-widgets-base[optimade]~=2.4.0
     aiida-pseudo~=1.4
     filelock~=3.8

--- a/tests_integration/test_image.py
+++ b/tests_integration/test_image.py
@@ -28,7 +28,7 @@ def test_pseudos_families_are_installed(aiidalab_exec, nb_user):
     assert "SSSP" in output
     assert "PseudoDojo" in output
 
-    # Two lines of header, 
+    # Two lines of header,
     # 4 sssp pseudos latest
     # 8 pseudodojo pseudos latest
     # 2 sssp pseudos 1.1

--- a/tests_integration/test_image.py
+++ b/tests_integration/test_image.py
@@ -28,5 +28,8 @@ def test_pseudos_families_are_installed(aiidalab_exec, nb_user):
     assert "SSSP" in output
     assert "PseudoDojo" in output
 
-    # Two lines of header, 8 pseudos
-    assert len(output.splitlines()) == 14
+    # Two lines of header, 
+    # 4 sssp pseudos latest
+    # 8 pseudodojo pseudos latest
+    # 2 sssp pseudos 1.1
+    assert len(output.splitlines()) == 16


### PR DESCRIPTION
This PR tries to pre-set up some necessary codes/pseudos for some core plugins that we maintain.

- **Bader**: install Bader in the same conda env as the QE
- **Wannier90**: because we need to use the latest source code from GitHub, we compile Wannier90 from scratch. 
- **AiiDA codes**: Bader, Wannier90, PythonJob
- **Pseudos**: Bader needs PAW, and Wannier90 needs SSSP 1.1.


With all this added, the size compared to the previous one:

| Image       | Size   |
|-------------|--------|
| New image   | 5.5 GB |
| Old image   | 4.92 GB |
