### PR TITLE
Reorder top controls

### DIFF
--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -74,7 +74,7 @@ class QeApp:
 
         # setup UI controls
         self.controller = AppWrapperContoller(self.model, self.view)
-        self.controller.enable_controls()
+        self.controller.enable_toggles()
 
     def _load_styles(self):
         """Load CSS styles from the static directory."""

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -21,9 +21,31 @@
 }
 
 .app-controls {
+  display: flex;
+  flex-direction: row;
   margin: 0 auto;
   align-items: center;
 }
+
+.app-toggles {
+  margin-right: 5px;
+  padding-right: 5px;
+  border-right: 2px solid var(--jp-border-color1);
+}
+
+@media (max-width: 768px) {
+  .app-controls {
+    flex-direction: column;
+  }
+  .app-toggles {
+    order: 1;
+    margin: 0;
+    margin-top: 10px;
+    padding: 0;
+    border-right: none;
+  }
+}
+
 .app-controls button,
 .app-controls .link-button {
   width: fit-content;
@@ -44,6 +66,8 @@
 .link-button {
   padding: 0;
   width: fit-content;
+  color: white;
+  background-color: var(--color-primary);
 }
 
 .link-button a {

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -28,9 +28,9 @@
 }
 
 .app-toggles {
-  margin-right: 5px;
-  padding-right: 5px;
-  border-right: 2px solid var(--jp-border-color1);
+  margin-left: 5px;
+  padding-left: 5px;
+  border-left: 2px solid var(--jp-border-color1);
 }
 
 @media (max-width: 768px) {
@@ -38,11 +38,10 @@
     flex-direction: column;
   }
   .app-toggles {
-    order: 1;
     margin: 0;
     margin-top: 10px;
     padding: 0;
-    border-right: none;
+    border-left: none;
   }
 }
 

--- a/src/aiidalab_qe/app/static/styles/infobox.css
+++ b/src/aiidalab_qe/app/static/styles/infobox.css
@@ -11,10 +11,12 @@
 .info-box.in-app-guide.show {
   display: flex !important;
 }
-.guide ol {
+.about ol {
+  margin-top: 5px;
   list-style: none;
+  line-height: 2;
 }
-.guide p:last-of-type {
+.about p:last-of-type {
   margin-bottom: 0.5em;
 }
 .in-app-guide:has(#guide-header),

--- a/src/aiidalab_qe/app/static/styles/variables.css
+++ b/src/aiidalab_qe/app/static/styles/variables.css
@@ -8,4 +8,7 @@
   --color-info: #00bcd4;
   --color-info-dark: #0097a7;
   --color-primary: #007bff;
+  --color-aiida-blue: #0096dd;
+  --color-aiida-green: #2fb808;
+  --color-aiida-orange: #ff7d17;
 }

--- a/src/aiidalab_qe/app/static/styles/variables.css
+++ b/src/aiidalab_qe/app/static/styles/variables.css
@@ -7,4 +7,5 @@
   --color-failed: #f2dede;
   --color-info: #00bcd4;
   --color-info-dark: #0097a7;
+  --color-primary: #007bff;
 }

--- a/src/aiidalab_qe/app/static/templates/about.jinja
+++ b/src/aiidalab_qe/app/static/templates/about.jinja
@@ -1,9 +1,48 @@
 <div class="about">
-  <p>
-    The Quantum ESPRESSO app (or QE app for short) is a graphical front end for calculating materials properties using
-    <a href="https://www.quantum-espresso.org/" target="_blank">Quantum ESPRESSO</a> (QE).
-    Each property is calculated by workflows powered by the <a href="https://www.aiida.net/" target="_bland">AiiDA</a>
-    engine, and maintained in the <a href="https://aiida-quantumespresso.readthedocs.io/en/latest/"
-      target="_blank">aiida-quantumespresso</a> plugin and many other plugins developed by the AiiDA community.
-  </p>
+    <p>
+      The Quantum ESPRESSO app (or QE app for short) is a graphical front end for calculating materials properties using
+      <a href="https://www.quantum-espresso.org/" target="_blank">Quantum ESPRESSO</a> (QE).
+      Each property is calculated by workflows powered by the <a href="https://www.aiida.net/" target="_bland">AiiDA</a>
+      engine, and maintained in the <a href="https://aiida-quantumespresso.readthedocs.io/en/latest/"
+        target="_blank">aiida-quantumespresso</a> plugin and many other plugins developed by the AiiDA community.
+    </p>
+    <p>
+      The QE app allows you to calculate properties in a simple 4-step process:
+    </p>
+    <ol>
+      <li>
+        🔍 <strong>Step 1:</strong> Select the structure you want to run.
+      </li>
+      <li>
+        ⚙️ <strong>Step 2:</strong> Select the properties you are interested in.
+      </li>
+      <li>
+        💻 <strong>Step 3:</strong> Choose the computational resources you want to run on and submit your workflow.
+      </li>
+      <li>
+        🚀 <strong>Step 4:</strong> Monitor and view your workflow results.
+      </li>
+    </ol>
+    <p>
+      New users can go straight to the first step and select their structure.
+    </p>
+    <p>
+      Completed workflows can be viewed in the <strong>Calculation history</strong> section.
+    </p>
+    <p>
+      To start a new calculation in a separate tab, click the <strong>New calculation</strong> button.
+    </p>
+    <p>
+      You can also check out the
+      <a href="https://aiidalab-qe.readthedocs.io/tutorials/basic.html" target="_blank">basic</a> tutorial to get
+      started
+      with the Quantum ESPRESSO app, or try out the
+      <a href="https://aiidalab-qe.readthedocs.io/tutorials/advanced.html" target="_blank">advanced</a> tutorial to
+      learn
+      additional features offered by the app.
+    </p>
+    <p>
+      For a more in-depth dive into the app's features, please refer to the
+      <a href="https://aiidalab-qe.readthedocs.io/howto/index.html" target="_blank">how-to guides</a>.
+    </p>
 </div>

--- a/src/aiidalab_qe/app/static/templates/guide.jinja
+++ b/src/aiidalab_qe/app/static/templates/guide.jinja
@@ -1,53 +1,7 @@
 <div class="guide">
-  <div>
-    <p>
-      The QE app allows you to calculate properties in a simple 4-step process:
-    </p>
-    <ol>
-      <li>
-        🔍 <strong>Step 1:</strong> Select the structure you want to run.
-      </li>
-      <li>
-        ⚙️ <strong>Step 2:</strong> Select the properties you are interested in.
-      </li>
-      <li>
-        💻 <strong>Step 3:</strong> Choose the computational resources you want to run on and submit your workflow.
-      </li>
-      <li>
-        🚀 <strong>Step 4:</strong> Monitor and view your workflow results.
-      </li>
-    </ol>
-  </div>
-
-  <div>
-    <p>
-      New users can go straight to the first step and select their structure.
-    </p>
-    <p>
-      Completed workflows can be viewed in the <strong>Calculation history</strong> section.
-    </p>
-    <p>
-      To start a new calculation in a separate tab, click the <strong>New calculation</strong> button.
-    </p>
-    <p>
-      You can also check out the
-      <a href="https://aiidalab-qe.readthedocs.io/tutorials/basic.html" target="_blank">basic</a> tutorial to get
-      started
-      with the Quantum ESPRESSO app, or try out the
-      <a href="https://aiidalab-qe.readthedocs.io/tutorials/advanced.html" target="_blank">advanced</a> tutorial to
-      learn
-      additional features offered by the app.
-    </p>
-    <p>
-      For a more in-depth dive into the app's features, please refer to the
-      <a href="https://aiidalab-qe.readthedocs.io/howto/index.html" target="_blank">how-to guides</a>.
-    </p>
-  </div>
-
-  <div>
-    <h3>In-app guides</h3>
-    <p>
-      Alternatively, you can select one of our in-app guides below to walk through an example use case.
-    </p>
-  </div>
+  <p>
+    We provide here tutorials in the form of in-app guides to walk you through example use cases.
+    <br>
+    To activate a guide, select a category below, then select the specific guide you wish to activate.
+  </p>
 </div>

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -112,6 +112,7 @@ class SubmitQeAppWorkChainStep(QeConfirmableDependentWizardStep[SubmissionStepMo
         self.refresh_resources_button = ipw.Button(
             description="Refresh resources",
             icon="refresh",
+            tooltip="Refresh the list of available codes",
             button_style="warning",
             layout=ipw.Layout(width="fit-content", margin="2px 2px 12px"),
         )

--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -112,7 +112,7 @@ class SubmitQeAppWorkChainStep(QeConfirmableDependentWizardStep[SubmissionStepMo
         self.refresh_resources_button = ipw.Button(
             description="Refresh resources",
             icon="refresh",
-            button_style="primary",
+            button_style="warning",
             layout=ipw.Layout(width="fit-content", margin="2px 2px 12px"),
         )
         self.refresh_resources_button.on_click(self._refresh_resources)

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -48,10 +48,10 @@ class AppWrapperContoller:
         self._view = view
         self._set_event_handlers()
 
-    def enable_controls(self) -> None:
-        """Enable the control buttons at the top of the app."""
-        for control in self._view.controls.children:
-            control.disabled = False
+    def enable_toggles(self) -> None:
+        """Enable the toggle buttons at the top of the app."""
+        for toggle in self._view.toggles.children:
+            toggle.disabled = False
 
     @without_triggering("about_toggle")
     def _on_guide_toggle(self, change: dict):
@@ -186,8 +186,8 @@ class AppWrapperView(ipw.VBox):
             button_style="",
             icon="book",
             value=False,
-            description="Getting started",
-            tooltip="Learn how to use the app",
+            description="Tutorials",
+            tooltip="Learn how to use the app through dedicated in-app guides",
             disabled=True,
         )
 
@@ -229,14 +229,28 @@ class AppWrapperView(ipw.VBox):
             disabled=True,
         )
 
-        self.controls = ipw.HBox(
+        self.toggles = ipw.HBox(
             children=[
                 self.guide_toggle,
                 self.about_toggle,
+            ],
+        )
+        self.toggles.add_class("app-toggles")
+
+        self.external_links = ipw.HBox(
+            children=[
                 self.calculation_history_link,
                 self.setup_resources_link,
                 self.download_examples_link,
                 self.new_workchain_link,
+            ],
+        )
+        self.external_links.add_class("app-external-links")
+
+        self.controls = ipw.HBox(
+            children=[
+                self.toggles,
+                self.external_links,
             ],
         )
         self.controls.add_class("app-controls")

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -239,7 +239,7 @@ class AppWrapperView(ipw.VBox):
         )
         self.external_links.add_class("app-external-links")
 
-        self.controls = ipw.HBox(
+        self.controls = ipw.Box(
             children=[
                 self.toggles,
                 self.external_links,

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -205,6 +205,7 @@ class AppWrapperView(ipw.VBox):
             description="Calculation history",
             link="./calculation_history.ipynb",
             icon="list",
+            style_="background-color: var(--color-aiida-orange)",
             disabled=True,
         )
 
@@ -212,6 +213,7 @@ class AppWrapperView(ipw.VBox):
             description="Setup resources",
             link="../home/code_setup.ipynb",
             icon="database",
+            style_="background-color: var(--color-aiida-blue)",
             disabled=True,
         )
 
@@ -219,6 +221,7 @@ class AppWrapperView(ipw.VBox):
             description="New calculation",
             link="./qe.ipynb",
             icon="plus-circle",
+            style_="background-color: var(--color-aiida-green)",
             disabled=True,
         )
 

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -215,13 +215,6 @@ class AppWrapperView(ipw.VBox):
             disabled=True,
         )
 
-        self.download_examples_link = LinkButton(
-            description="Download examples",
-            link="./examples.ipynb",
-            icon="download",
-            disabled=True,
-        )
-
         self.new_workchain_link = LinkButton(
             description="New calculation",
             link="./qe.ipynb",
@@ -241,7 +234,6 @@ class AppWrapperView(ipw.VBox):
             children=[
                 self.calculation_history_link,
                 self.setup_resources_link,
-                self.download_examples_link,
                 self.new_workchain_link,
             ],
         )

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -185,6 +185,7 @@ class AppWrapperView(ipw.VBox):
             description="Calculation history",
             link="./calculation_history.ipynb",
             icon="list",
+            tooltip="View a list of previous calculations",
             style_="background-color: var(--color-aiida-orange)",
             disabled=True,
         )
@@ -193,6 +194,7 @@ class AppWrapperView(ipw.VBox):
             description="Setup resources",
             link="../home/code_setup.ipynb",
             icon="database",
+            tooltip="Setup computational resources for your calculations",
             style_="background-color: var(--color-aiida-blue)",
             disabled=True,
         )
@@ -201,6 +203,7 @@ class AppWrapperView(ipw.VBox):
             description="New calculation",
             link="./qe.ipynb",
             icon="plus-circle",
+            tooltip="Open a new calculation in a separate tab",
             style_="background-color: var(--color-aiida-green)",
             disabled=True,
         )

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -181,26 +181,6 @@ class AppWrapperView(ipw.VBox):
 
         subtitle = ipw.HTML("<h3 id='subtitle'>🎉 Happy computing 🎉</h3>")
 
-        self.guide_toggle = ipw.ToggleButton(
-            layout=ipw.Layout(width="auto"),
-            button_style="",
-            icon="book",
-            value=False,
-            description="Tutorials",
-            tooltip="Learn how to use the app through dedicated in-app guides",
-            disabled=True,
-        )
-
-        self.about_toggle = ipw.ToggleButton(
-            layout=ipw.Layout(width="auto"),
-            button_style="",
-            icon="info",
-            value=False,
-            description="About",
-            tooltip="Learn about the app",
-            disabled=True,
-        )
-
         self.calculation_history_link = LinkButton(
             description="Calculation history",
             link="./calculation_history.ipynb",
@@ -225,6 +205,36 @@ class AppWrapperView(ipw.VBox):
             disabled=True,
         )
 
+        self.external_links = ipw.HBox(
+            children=[
+                self.calculation_history_link,
+                self.setup_resources_link,
+                self.new_workchain_link,
+            ],
+        )
+
+        self.guide_toggle = ipw.ToggleButton(
+            layout=ipw.Layout(width="auto"),
+            button_style="",
+            icon="book",
+            value=False,
+            description="Tutorials",
+            tooltip="Learn how to use the app through dedicated in-app guides",
+            disabled=True,
+        )
+
+        self.about_toggle = ipw.ToggleButton(
+            layout=ipw.Layout(width="auto"),
+            button_style="",
+            icon="info",
+            value=False,
+            description="About",
+            tooltip="Learn about the app",
+            disabled=True,
+        )
+
+        self.external_links.add_class("app-external-links")
+
         self.toggles = ipw.HBox(
             children=[
                 self.guide_toggle,
@@ -233,19 +243,10 @@ class AppWrapperView(ipw.VBox):
         )
         self.toggles.add_class("app-toggles")
 
-        self.external_links = ipw.HBox(
-            children=[
-                self.calculation_history_link,
-                self.setup_resources_link,
-                self.new_workchain_link,
-            ],
-        )
-        self.external_links.add_class("app-external-links")
-
         self.controls = ipw.Box(
             children=[
-                self.toggles,
                 self.external_links,
+                self.toggles,
             ],
         )
         self.controls.add_class("app-controls")

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -1353,8 +1353,6 @@ class ArchiveImporter(ipw.VBox):
             description="Calculation history",
             link="./calculation_history.ipynb",
             icon="list",
-            class_="mod-primary",
-            style_="color: white;",
             layout=ipw.Layout(
                 width="fit-content",
                 margin="2px 0 2px auto",

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -1151,6 +1151,7 @@ class LinkButton(ipw.HTML):
         class_="",
         style_="",
         icon="",
+        tooltip="",
         disabled=False,
         **kwargs,
     ):
@@ -1160,6 +1161,7 @@ class LinkButton(ipw.HTML):
             <a
                 role="button"
                 href="{link}"
+                title="{tooltip or description}"
                 target="{"_self" if in_place else "_blank"}"
                 style="cursor: default; {style_}"
             >

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -7,14 +7,14 @@ class TestWrapper:
         self._instansiate_mvc_components()
         assert self.view.guide_toggle.disabled is True
         assert self.view.about_toggle.disabled is True
-        self.controller.enable_controls()
+        self.controller.enable_toggles()
         assert self.view.guide_toggle.disabled is False
         assert self.view.about_toggle.disabled is False
 
     def test_guide_toggle(self):
         """Test guide_toggle method."""
         self._instansiate_mvc_components()
-        self.controller.enable_controls()
+        self.controller.enable_toggles()
         self.controller._on_guide_toggle({"new": True})
         self._assert_guide_is_on()
         self.controller._on_guide_toggle({"new": False})
@@ -23,7 +23,7 @@ class TestWrapper:
     def test_about_toggle(self):
         """Test about_toggle method."""
         self._instansiate_mvc_components()
-        self.controller.enable_controls()
+        self.controller.enable_toggles()
         self.controller._on_about_toggle({"new": True})
         self._assert_about_is_on()
         self.controller._on_about_toggle({"new": False})
@@ -32,7 +32,7 @@ class TestWrapper:
     def test_toggle_switch(self):
         """Test toggle_switch method."""
         self._instansiate_mvc_components()
-        self.controller.enable_controls()
+        self.controller.enable_toggles()
         self._assert_no_info()
         self.controller._on_guide_toggle({"new": True})
         self._assert_guide_is_on()


### PR DESCRIPTION
This PR does the following:
- Moves Getting started content over to About
- Renames Getting started as Tutorials
- Groups toggle buttons and external links separately
- Uses CSS to dynamically control button layout

---

https://github.com/user-attachments/assets/ebb45a76-011d-4c36-aed6-778938bcbf34