### PR TITLE
Fix labels in `BandsPdosPlotly`

### DIFF
--- a/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
@@ -152,7 +152,7 @@ class BandsPdosPlotly:
         }
 
         if self.plot_type != "combined":
-            axis_settings["title"] = "Density of states (eV)"
+            axis_settings["title"] = "Energy (eV)"
             axis_settings["range"] = self.SETTINGS["horizontal_range_pdos"]
             axis_settings.pop("side")
             axis_settings.pop("automargin")
@@ -176,6 +176,9 @@ class BandsPdosPlotly:
             "linecolor": self.SETTINGS["axis_linecolor"],
             "zerolinewidth": 2,
         }
+        
+        if self.plot_type != "combined":
+            axis_settings["title"] = "Density of states"
 
         return go.layout.YAxis(**axis_settings)
 

--- a/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
@@ -176,7 +176,7 @@ class BandsPdosPlotly:
             "linecolor": self.SETTINGS["axis_linecolor"],
             "zerolinewidth": 2,
         }
-        
+
         if self.plot_type != "combined":
             axis_settings["title"] = "Density of states"
 

--- a/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
@@ -115,7 +115,7 @@ class BandsPdosPlotly:
             return None
 
         bandyaxis = go.layout.YAxis(
-            title={"text": "Electronic Bands (eV)", "standoff": 1},
+            title={"text": "Energy - E<sub>Fermi</sub> (eV)", "standoff": 1},
             side="left",
             showgrid=True,
             showline=True,
@@ -152,7 +152,7 @@ class BandsPdosPlotly:
         }
 
         if self.plot_type != "combined":
-            axis_settings["title"] = "Energy (eV)"
+            axis_settings["title"] = "Energy - E<sub>Fermi</sub> (eV)"
             axis_settings["range"] = self.SETTINGS["horizontal_range_pdos"]
             axis_settings.pop("side")
             axis_settings.pop("automargin")

--- a/tests/test_plugins_bands.py
+++ b/tests/test_plugins_bands.py
@@ -31,7 +31,7 @@ def test_result(generate_qeapp_workchain):
     assert model.bands_data["pathlabels"]
 
     assert widget.plot.layout.xaxis.title.text == "k-points"
-    assert widget.plot.layout.yaxis.title.text == "Electronic Bands (eV)"
+    assert widget.plot.layout.yaxis.title.text == "Energy - E<sub>Fermi</sub> (eV)"
     assert isinstance(widget.plot.layout.xaxis.rangeslider, go.layout.xaxis.Rangeslider)
     assert model.bands_data["pathlabels"][0] == list(widget.plot.layout.xaxis.ticktext)
 

--- a/tests/test_plugins_electronic_structure.py
+++ b/tests/test_plugins_electronic_structure.py
@@ -34,7 +34,7 @@ def test_electronic_structure(generate_qeapp_workchain):
     # Check Bands axis
     assert widget.plot.layout.xaxis.title.text == "k-points"
     assert widget.plot.layout.xaxis2.title.text == "Density of states"
-    assert widget.plot.layout.yaxis.title.text == "Electronic Bands (eV)"
+    assert widget.plot.layout.yaxis.title.text == "Energy - E<sub>Fermi</sub> (eV)"
     assert isinstance(
         widget.plot.layout.xaxis.rangeslider,
         go.layout.xaxis.Rangeslider,

--- a/tests/test_plugins_pdos.py
+++ b/tests/test_plugins_pdos.py
@@ -28,5 +28,5 @@ def test_result(generate_qeapp_workchain):
     assert not model.bands_data
     assert model.pdos_data
 
-    assert widget.plot.layout.xaxis.title.text == "Density of states (eV)"
-    assert widget.plot.layout.yaxis.title.text is None
+    assert widget.plot.layout.xaxis.title.text == "Energy (eV)"
+    assert widget.plot.layout.yaxis.title.text == "Density of states"

--- a/tests/test_plugins_pdos.py
+++ b/tests/test_plugins_pdos.py
@@ -28,5 +28,5 @@ def test_result(generate_qeapp_workchain):
     assert not model.bands_data
     assert model.pdos_data
 
-    assert widget.plot.layout.xaxis.title.text == "Energy (eV)"
+    assert widget.plot.layout.xaxis.title.text == "Energy - E<sub>Fermi</sub> (eV)"
     assert widget.plot.layout.yaxis.title.text == "Density of states"


### PR DESCRIPTION
As discussed in the meeting, there was a bug when plotting only the (P)DOS.

The x-axis was labeled as "Density of States" instead of "Energy (eV)" and no y-label was added.