### PR TITLE
Fix selection of indices in `Edit atom tags`

### DIFF
--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -535,14 +535,11 @@ class AddingTagsEditor(ipw.VBox):
         When given a list of atom in selection it will display a HTML table with Index, Element and Tag
         """
         selection = string_range_to_list(self.atom_selection.value)[0]
+        selection = [s for s in selection if s < len(self.structure)]
         current_tags = self.structure.get_tags()
         chemichal_symbols = self.structure.get_chemical_symbols()
 
-        if (
-            selection
-            and (min(selection) >= 0)
-            and (max(selection) <= (len(self.structure) - 1))
-        ):
+        if selection and (min(selection) >= 0):
             table_data = []
             for index in selection:
                 tag = current_tags[index]


### PR DESCRIPTION
Discussed with @mikibonacci and @giovannipizzi 

It is possible to generate slices in the edit atom tags panel, e.g., `1..5` to select the sites with indices `[1, 2, 3, 4, 5]`. However, in case of a structure with 5 sites, `1..10` would fail and the table wouldn't even appear. In our discussion we agreed that we would expect a behavior similar to lists in Python, i.e., we would expect all indices to be selected/printed, as the maximum of the slice is larger than the number of sites.