### PR TITLE
Fix default magnetic moments for atoms with tags

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -41,10 +41,6 @@ class MagnetizationConfigurationSettingsPanel(
             self._on_magnetization_type_change,
             "type",
         )
-        self._model.observe(
-            self._on_family_change,
-            "family",
-        )
 
     def render(self):
         if self.rendered:
@@ -126,9 +122,6 @@ class MagnetizationConfigurationSettingsPanel(
     def _on_magnetization_type_change(self, _):
         self._toggle_widgets()
         self._model.update_type_help()
-
-    def _on_family_change(self, _):
-        self._model.update_default_starting_magnetization()
 
     def _update(self, specific=""):
         if self.updated:

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -41,6 +41,10 @@ class MagnetizationConfigurationSettingsPanel(
             self._on_magnetization_type_change,
             "type",
         )
+        self._model.observe(
+            self._on_family_change,
+            "family",
+        )
 
     def render(self):
         if self.rendered:
@@ -122,6 +126,9 @@ class MagnetizationConfigurationSettingsPanel(
     def _on_magnetization_type_change(self, _):
         self._toggle_widgets()
         self._model.update_type_help()
+
+    def _on_family_change(self, _):
+        self._model._update_default_moments()
 
     def _update(self, specific=""):
         if self.updated:

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -1,14 +1,11 @@
 from copy import deepcopy
 
 import traitlets as tl
-from aiida_pseudo.groups.family import PseudoPotentialFamily
 
 from aiida_quantumespresso.workflows.protocols.utils import (
     get_magnetization_parameters,
-    get_starting_magnetization,
 )
 from aiidalab_qe.common.mixins import HasInputStructure
-from aiidalab_qe.utils import fetch_pseudo_family_by_label
 
 from ..subsettings import AdvancedCalculationSubSettingsModel
 
@@ -56,14 +53,12 @@ class MagnetizationConfigurationSettingsModel(
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._default_starting_magnetization = {}
 
     def update(self, specific=""):  # noqa: ARG002
         if self.spin_type == "none" or not self.has_structure:
             self._defaults["moments"] = {}
         else:
             self.update_type_help()
-            self.update_default_starting_magnetization()
             self._update_default_moments()
         with self.hold_trait_notifications():
             self.moments = self._get_default_moments()
@@ -93,19 +88,6 @@ class MagnetizationConfigurationSettingsModel(
                 """
             )
 
-    def update_default_starting_magnetization(self):
-        """Update the default starting magnetization based on the structure and
-        pseudopotential family.
-        """
-        if not self.has_structure:
-            # TODO this guard shouldn't be here! It IS here only because in the present
-            # implementation, an update is called on app start. This breaks lazy loading
-            # and should be carefully checked!
-            return
-        family = fetch_pseudo_family_by_label(self.family)
-        initial_guess = get_starting_magnetization(self.input_structure, family)
-        self._default_starting_magnetization = initial_guess
-
     def reset(self):
         with self.hold_trait_notifications():
             self.type = self.traits()["type"].default_value
@@ -113,20 +95,10 @@ class MagnetizationConfigurationSettingsModel(
             self.moments = self._get_default_moments()
 
     def _update_default_moments(self):
-        family = fetch_pseudo_family_by_label(self.family)
         self._defaults["moments"] = {
-            kind.name: self._to_moment(symbol=kind.symbol, family=family)
+            kind.name: self._DEFAULT_MOMENTS.get(kind.symbol, {}).get("magmom", 0.1)
             for kind in self.input_structure.kinds
         }
-
-    def _to_moment(self, symbol: str, family: PseudoPotentialFamily) -> float:
-        """Convert the default magnetization to an initial magnetic moment."""
-        magnetization = (
-            self._default_starting_magnetization.get(symbol, 0.1)
-            if self._DEFAULT_MOMENTS.get(symbol, {}).get("magmom")
-            else 0.1
-        )
-        return round(magnetization * family.get_pseudo(symbol).z_valence, 3)
 
     def _get_default_moments(self):
         return deepcopy(self._defaults.get("moments", {}))


### PR DESCRIPTION
Pinging @edan-bainglass who was refactoring this, but also @mikibonacci and @AndresOrtegaGuerrero as discussed.

This PR will address #1248.

The previous logic was a bit convoluted and resulted in the problem that it doesn't work with tags, see the issue for an example. 
Before describing in more detail, I believe that the fix can be very simple. We simply remove any tags by using `kind.name` and then access the default magnetic moments from the AiiDA-QE plugin.

------------------
Why the current version doesn't work.

Taking `Ni2` with kinds `Ni1` and `Ni2` as an example. First, we call https://github.com/aiidalab/aiidalab-qe/blob/9a7cc724c18413cecb81f8bdc4dfb29638e068bb/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py#L96-L107
which sets `self. _default_starting_magnetization` to `{'Ni1': 0.1, 'Ni2': 0.1}`, as the AiiDA-QE methods do only work with the chemical elements without any sites. Next, we call https://github.com/aiidalab/aiidalab-qe/blob/9a7cc724c18413cecb81f8bdc4dfb29638e068bb/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py#L115-L129
While we use the correct logic of accessing the magnetic moments based on the chemical elements, i.e., `kind.symbol` (`Ni`) in this example, we try to access `self. _default_starting_magnetization` instead of `self._DEFAULT_MOMENTS`. However, as mentioned above, `self. _default_starting_magnetization` only contains the keys with the tags and hence we return again the default of `0.1`. Since we don't use the pseudo family explicitly, and we only want to reproduce the behavior of the AiiDA-QE plugin, I propose the solution mentioned in the beginning: we simply access the default magnetic moments by removing any tag information. Please let me know if I'm missing something.

---

Closes #1248