### PR TITLE
Use new `metadata.process_labels` entry point to fetch plugin process human-readable labels

### DIFF
--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -11,11 +11,38 @@ from aiida import orm
 from aiida.common.links import LinkType
 from aiida.engine import ProcessState
 from aiida.tools.graph.graph_traversers import traverse_graph
+from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_qe.common.mixins import HasProcess
 from aiidalab_qe.common.mvc import Model
 from aiidalab_qe.common.widgets import LoadingWidget
 
 from .state import STATE_ICONS
+
+TITLE_MAPPING = {
+    "QeAppWorkChain": "Quantum ESPRESSO app workflow",
+    "PwRelaxWorkChain": "Structure relaxation workflow manager",
+    "PwBaseWorkChain": {
+        "scf": "SCF workflow",
+        "nscf": "NSCF workflow",
+        "bands": "Bands workflow",
+        "relax": "Structure relaxation workflow",
+        "md": "Molecular dynamics workflow",
+    },
+    "PwCalculation": {
+        "scf": "SCF cycle",
+        "nscf": "NSCF cycle",
+        "bands": "Band structure calculation",
+        "relax": "Structure geometry optimization",
+        "md": "Molecular dynamics simulation",
+    },
+} | {
+    process: human_readable
+    for metadata in get_entry_items(
+        "aiidalab_qe.properties",
+        "metadata",
+    ).values()
+    for process, human_readable in metadata.get("process_labels", {}).items()
+}
 
 
 class SimplifiedProcessTreeModel(Model, HasProcess):
@@ -123,31 +150,6 @@ ProcessNodeType = t.TypeVar("ProcessNodeType", bound=orm.ProcessNode)
 
 
 class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
-    _TITLE_MAPPING = {
-        "QeAppWorkChain": "Quantum ESPRESSO app workflow",
-        "BandsWorkChain": "Electronic band structure workflow",
-        "PwBandsWorkChain": "Electronic band structure workflow",
-        "ProjwfcBandsWorkChain": "Electronic band structure workflow",
-        "PwRelaxWorkChain": "Structure relaxation workflow manager",
-        "PdosWorkChain": "Projected density of states workflow",
-        "PwBaseWorkChain": {
-            "scf": "SCF workflow",
-            "nscf": "NSCF workflow",
-            "bands": "Bands workflow",
-            "relax": "Structure relaxation workflow",
-            "md": "Molecular dynamics workflow",
-        },
-        "PwCalculation": {
-            "scf": "Run SCF cycle",
-            "nscf": "Run NSCF cycle",
-            "bands": "Compute bands",
-            "relax": "Optimize structure geometry",
-            "md": "Run molecular dynamics simulation",
-        },
-        "DosCalculation": "Compute density of states",
-        "ProjwfcCalculation": "Compute projections",
-    }
-
     def __init__(
         self,
         node: ProcessNodeType,
@@ -213,8 +215,8 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
             parameters = inputs.parameters.base.attributes.all
             calculation: str = parameters["CONTROL"]["calculation"]
             calculation = calculation.replace("vc-", "")
-            return self._TITLE_MAPPING.get(label, {}).get(calculation, label)
-        return self._TITLE_MAPPING.get(label, label)
+            return TITLE_MAPPING.get(label, {}).get(calculation, label)
+        return TITLE_MAPPING.get(label, label)
 
 
 class ProcessTreeBranches(ipw.VBox):

--- a/src/aiidalab_qe/plugins/bands/__init__.py
+++ b/src/aiidalab_qe/plugins/bands/__init__.py
@@ -21,4 +21,12 @@ bands = {
         "model": BandsResourceSettingsModel,
     },
     "workchain": workchain_and_builder,
+    "metadata": {
+        "process_labels": {
+            "BandsWorkChain": "Electronic band structure workflow",
+            "PwBandsWorkChain": "Electronic band structure workflow",
+            "ProjwfcBandsWorkChain": "Electronic band structure workflow",
+            "ProjwfcCalculation": "Orbital projection calculation",
+        }
+    },
 }

--- a/src/aiidalab_qe/plugins/pdos/__init__.py
+++ b/src/aiidalab_qe/plugins/pdos/__init__.py
@@ -21,4 +21,11 @@ pdos = {
         "model": PdosResourceSettingsModel,
     },
     "workchain": workchain_and_builder,
+    "metadata": {
+        "process_labels": {
+            "PdosWorkChain": "Projected density of states workflow",
+            "DosCalculation": "Density of states calculation",
+            "ProjwfcCalculation": "Orbital projection calculation",
+        }
+    },
 }

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -14,8 +14,8 @@ from aiidalab_qe.app.result.components.status import (
     WorkChainStatusPanel,
 )
 from aiidalab_qe.common.process.tree import (
+    TITLE_MAPPING,
     CalcJobTreeNode,
-    ProcessTreeNode,
     SimplifiedProcessTree,
     SimplifiedProcessTreeModel,
     WorkChainTreeNode,
@@ -147,7 +147,7 @@ class TestSimplifiedProcessTree(TreeTestingMixin):
     def test_update_on_process_change(self, mock_qeapp_workchain):
         self.model.process_uuid = mock_qeapp_workchain.uuid
         assert self.tree.rendered
-        human_label = ProcessTreeNode._TITLE_MAPPING["QeAppWorkChain"]
+        human_label = TITLE_MAPPING["QeAppWorkChain"]
         assert self.tree.trunk.label.value == human_label
         assert not self.tree.trunk.collapsed
         assert len(self.tree.trunk.branches) == 1
@@ -157,7 +157,7 @@ class TestSimplifiedProcessTree(TreeTestingMixin):
         assert self.relax_workchain_node.level == 1
         assert self.relax_workchain_node.emoji.value == "✅"
         assert self.relax_workchain_node.state.value == "finished"
-        human_label = ProcessTreeNode._TITLE_MAPPING["PwRelaxWorkChain"]
+        human_label = TITLE_MAPPING["PwRelaxWorkChain"]
         assert self.relax_workchain_node.label.value == human_label
         assert isinstance(self.relax_workchain_node.label, ipw.HTML)
         assert self.relax_workchain_node.collapsed
@@ -190,7 +190,7 @@ class TestSimplifiedProcessTree(TreeTestingMixin):
         assert self.base_workchain_node.level == 2
         assert self.base_workchain_node.emoji.value == "✅"
         assert self.base_workchain_node.state.value == "finished"
-        human_label = ProcessTreeNode._TITLE_MAPPING["PwBaseWorkChain"]["relax"]
+        human_label = TITLE_MAPPING["PwBaseWorkChain"]["relax"]
         assert self.base_workchain_node.label.value == human_label
         assert isinstance(self.base_workchain_node.label, ipw.HTML)
         assert len(self.base_workchain_node.branches) == 1
@@ -217,7 +217,7 @@ class TestSimplifiedProcessTree(TreeTestingMixin):
         assert self.calcjob_node.level == 3
         assert self.calcjob_node.emoji.value == "✅"
         assert self.calcjob_node.state.value == "finished"
-        human_label = ProcessTreeNode._TITLE_MAPPING["PwCalculation"]["relax"]
+        human_label = TITLE_MAPPING["PwCalculation"]["relax"]
         assert isinstance(self.calcjob_node.label, ipw.Button)
         assert self.calcjob_node.label.description == human_label
 


### PR DESCRIPTION
This PR introduces a new key to a plugin's outline:

```
{
  ...
  "metadata": {
    "process_labels": {
      "MyWorkChain": "Super cool workflow",
      "MyCalcJob": "Super important calculation",
      ...
    }
  }
}
```

By suggestion (@superstar54), we nest the `process_labels` key under `metadata` for future extension.

In the process tree, we concatenate these labels from discovered plugins to the process-class-name-to-human-readable-label map.