### PR TITLE
Adjust panel outline width to fit content

### DIFF
--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -84,6 +84,7 @@ class PluginOutline(ipw.HBox):
                     </div>
                 """),
             ],
+            layout=ipw.Layout(width="fit-content"),
             **kwargs,
         )
 


### PR DESCRIPTION
We were getting ... for long descriptions, even though there is plenty of space 🙂