### PR TITLE
Fix installation of vibroscopy plugin in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ARG QE_DIR
 
 USER ${NB_USER}
 RUN mamba create -p ${QE_DIR} --yes qe=${QE_VER} bader && \
+    mamba install -y h5py && \
     mamba clean --all -f -y
 
 # STAGE 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ ARG QE_DIR
 
 USER ${NB_USER}
 RUN mamba create -p ${QE_DIR} --yes qe=${QE_VER} bader && \
-    mamba install -y h5py && \
     mamba clean --all -f -y
 
 # STAGE 2
@@ -61,7 +60,9 @@ RUN wget -c -O hq.tar.gz https://github.com/It4innovations/hyperqueue/releases/d
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 # Install plugin for post-install
-RUN pip install aiida-bader \
+RUN --mount=from=uv,source=/uv,target=/bin/uv \
+    --mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
+     uv pip install --system --cache-dir=${UV_CACHE_DIR} aiida-bader \
      git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
      git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 
@@ -132,7 +133,9 @@ RUN --mount=from=uv,source=/uv,target=/bin/uv \
     uv pip install --strict --system --compile-bytecode --cache-dir=${UV_CACHE_DIR} ${QE_APP_SRC} "aiida-hyperqueue@git+https://github.com/aiidateam/aiida-hyperqueue"
 
 # Install plugin in the final image
-RUN pip install aiida-bader \
+RUN --mount=from=uv,source=/uv,target=/bin/uv \
+--mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
+ uv pip install --system --cache-dir=${UV_CACHE_DIR} aiida-bader \
  git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
  git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,7 @@ RUN wget -c -O hq.tar.gz https://github.com/It4innovations/hyperqueue/releases/d
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 # Install plugin for post-install
-RUN --mount=from=uv,source=/uv,target=/bin/uv \
-    --mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
-     uv pip install --system --strict --cache-dir=${UV_CACHE_DIR} aiida-bader \
+RUN pip install aiida-bader \
      git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
      git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 
@@ -134,9 +132,7 @@ RUN --mount=from=uv,source=/uv,target=/bin/uv \
     uv pip install --strict --system --compile-bytecode --cache-dir=${UV_CACHE_DIR} ${QE_APP_SRC} "aiida-hyperqueue@git+https://github.com/aiidateam/aiida-hyperqueue"
 
 # Install plugin in the final image
-RUN --mount=from=uv,source=/uv,target=/bin/uv \
---mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
- uv pip install --system --strict --cache-dir=${UV_CACHE_DIR} aiida-bader \
+RUN pip install aiida-bader \
  git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
  git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,7 @@ RUN wget -c -O hq.tar.gz https://github.com/It4innovations/hyperqueue/releases/d
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 # Install plugin for post-install
-RUN --mount=from=uv,source=/uv,target=/bin/uv \
-    --mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
-     uv pip install --system --cache-dir=${UV_CACHE_DIR} aiida-bader \
+RUN pip install aiida-bader \
      git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
      git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 
@@ -92,7 +90,7 @@ RUN --mount=from=qe_conda_env,source=${QE_DIR},target=${QE_DIR} \
     verdi code create core.code.installed --label wannier90 --computer=localhost --default-calc-job-plugin wannier90.wannier90 --filepath-executable=/opt/conda/bin/wannier90.x -n && \
     # run post_install for plugin
     python -m aiida_bader post-install && \
-    # python -m aiidalab_qe_vibroscopy setup-phonopy && \
+    python -m aiidalab_qe_vibroscopy setup-phonopy && \
     python -m aiidalab_qe_muon setup-python3 && \
     # wannier90 plugin need SSSP 1.1
     aiida-pseudo install sssp -v 1.1 -x PBE && \
@@ -133,9 +131,7 @@ RUN --mount=from=uv,source=/uv,target=/bin/uv \
     uv pip install --strict --system --compile-bytecode --cache-dir=${UV_CACHE_DIR} ${QE_APP_SRC} "aiida-hyperqueue@git+https://github.com/aiidateam/aiida-hyperqueue"
 
 # Install plugin in the final image
-RUN --mount=from=uv,source=/uv,target=/bin/uv \
---mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
- uv pip install --system --cache-dir=${UV_CACHE_DIR} aiida-bader \
+RUN pip install aiida-bader \
  git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
  git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 


### PR DESCRIPTION
Fix #1265 

Hi @mikibonacci , installing the vibroscopy using `uv` failed, but using `pip` directly works. I tested the image and ran a phonon calculation, it works fine.

So I think we use this temporary quick fix, and look into the issue in the future when we get time.
