### PR TITLE
Split the action into: build-upload and build-test

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,111 @@
+---
+name: Build Docker image and test
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+        tags:
+            - v*
+    workflow_dispatch:
+
+env:
+    FORCE_COLOR: 1
+    IMAGE_NAME: aiidalab/qe
+    BUILDKIT_PROGRESS: plain
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build-test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+
+            - name: Login to GitHub Container Registry 🔑
+              uses: docker/login-action@v2
+              if: ${{ !github.event.pull_request.head.repo.fork }}
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Login to DockerHub 🔑
+              uses: docker/login-action@v2
+              if: ${{ !github.event.pull_request.head.repo.fork }}
+              with:
+                  registry: docker.io
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Docker meta (GHCR) 📝
+              id: meta_ghcr
+              uses: docker/metadata-action@v5
+              with:
+                  images: |
+                      name=ghcr.io/${{ env.IMAGE_NAME }}
+                  tags: |
+                      type=ref,event=pr
+                      type=edge,enable={{is_default_branch}}
+                      type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+            - name: Build and push images (GHCR)
+              id: build-upload
+              uses: docker/build-push-action@v5
+              with:
+                  # Provide multiple comma/line-separated tags:
+                  tags: >
+                      ${{ steps.meta_ghcr.outputs.tags }}
+                  load: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+                  push: ${{ ! (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
+                  context: .
+                  platforms: linux/amd64
+                  cache-to: |
+                      type=gha,scope=${{ github.workflow }},mode=min
+                  cache-from: |
+                      type=gha,scope=${{ github.workflow }}
+
+            - name: Set Up Python 🐍
+              uses: actions/setup-python@v5
+              with:
+                  python-version: 3.11
+
+            - name: Install Dev Dependencies 📦
+              run: pip install -r requirements-docker.txt
+
+            - name: Set jupyter token env
+              run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
+            - name: Run pytest for Chrome
+              run: pytest -sv --driver Chrome tests_integration/
+              env:
+                  # We'd like to identify the image by its unique digest, i.e ghcr.io/aiidalab/qe@sha256:<digest>
+                  # but that sadly does not work when the image is loaded to Docker locally and not published on ghcr.io
+                  # as is the case for PRs from forks. Hence this super-ugly ternary expression...
+                  # For forks, we take the image as ghcr.io/aiidalab/qe:pr-XXX
+                  # which is stored in the steps.meta_ghcr.outputs.tags variable
+                  QE_IMAGE: >-
+                      ${{
+                          github.event_name == 'pull_request' &&
+                          github.event.pull_request.head.repo.fork &&
+                          steps.meta_ghcr.outputs.tags ||
+                          format('ghcr.io/{0}@{1}', env.IMAGE_NAME, steps.build-upload.outputs.imageid)
+                      }}
+
+            - name: Upload screenshots as artifacts
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Screenshots
+                  path: screenshots/
+                  if-no-files-found: error

--- a/.github/workflows/docker-build-upload.yml
+++ b/.github/workflows/docker-build-upload.yml
@@ -3,6 +3,8 @@ name: Build Docker image and upload
 
 on:
     pull_request:
+        branches:
+            - main
     push:
         branches:
             - main
@@ -23,6 +25,19 @@ concurrency:
 
 jobs:
     build-upload:
+    # The key line: we only proceed if:
+    #  1) It's a 'push' to main or a tag that starts with 'v'
+    #     (i.e. 'refs/heads/main' or 'refs/tags/v...')
+    #  OR
+    #  2) It's a PR, but NOT from a fork (fork == false).
+        if: |
+            (github.event_name == 'push' && (
+              startsWith(github.ref, 'refs/heads/main') ||
+              startsWith(github.ref, 'refs/tags/v')
+            ))
+            ||
+            (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+
         runs-on: ubuntu-latest
 
         steps:
@@ -64,6 +79,7 @@ jobs:
                       type=ref,event=pr
                       type=edge,enable={{is_default_branch}}
                       type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
             - name: Docker meta (DockerHub)
               id: meta_dockerhub
               uses: docker/metadata-action@v5
@@ -72,14 +88,12 @@ jobs:
                   tags: |
                       type=ref,event=pr
                       type=edge,enable={{is_default_branch}}
-                      # type=match,pattern=v(\d+\.\d+(\.\d+)?),group=1
                       type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
             - name: Build and push images (GHCR + DockerHub)
               id: build-upload
               uses: docker/build-push-action@v5
               with:
-                  # Provide multiple comma/line-separated tags:
                   tags: >
                       ${{ steps.meta_ghcr.outputs.tags }},
                       ${{ steps.meta_dockerhub.outputs.tags }}

--- a/.github/workflows/docker-build-upload.yml
+++ b/.github/workflows/docker-build-upload.yml
@@ -1,5 +1,5 @@
 ---
-name: Build Docker image
+name: Build Docker image and upload
 
 on:
     pull_request:
@@ -22,7 +22,7 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    build-test-upload:
+    build-upload:
         runs-on: ubuntu-latest
 
         steps:
@@ -91,38 +91,3 @@ jobs:
                       type=gha,scope=${{ github.workflow }},mode=min
                   cache-from: |
                       type=gha,scope=${{ github.workflow }}
-
-            - name: Set Up Python 🐍
-              uses: actions/setup-python@v5
-              with:
-                  python-version: 3.11
-
-            - name: Install Dev Dependencies 📦
-              run: pip install -r requirements-docker.txt
-
-            - name: Set jupyter token env
-              run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
-
-            - name: Run pytest for Chrome
-              run: pytest -sv --driver Chrome tests_integration/
-              env:
-                  # We'd like to identify the image by its unique digest, i.e ghcr.io/aiidalab/qe@sha256:<digest>
-                  # but that sadly does not work when the image is loaded to Docker locally and not published on ghcr.io
-                  # as is the case for PRs from forks. Hence this super-ugly ternary expression...
-                  # For forks, we take the image as ghcr.io/aiidalab/qe:pr-XXX
-                  # which is stored in the steps.meta_ghcr.outputs.tags variable
-                  QE_IMAGE: >-
-                      ${{
-                          github.event_name == 'pull_request' &&
-                          github.event.pull_request.head.repo.fork &&
-                          steps.meta_ghcr.outputs.tags ||
-                          format('ghcr.io/{0}@{1}', env.IMAGE_NAME, steps.build-upload.outputs.imageid)
-                      }}
-
-            - name: Upload screenshots as artifacts
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: Screenshots
-                  path: screenshots/
-                  if-no-files-found: error


### PR DESCRIPTION
Fix https://github.com/aiidalab/aiidalab-qe/issues/1271

Previously, there was only one action to:
- build the image and upload (amd64 ~8mins, arm64 ~2h)
- test the app using the built image

Therefore, one needs to wait 2 h to see the result of the test.

In this PR, we separate the action into two:
- build-test: build only the amd64 (only ~ 8mins), and test the app
- build both amd64 and arm64 and upload ( ~ 2h)

For a normal PR from the fork, the `build-upload` will not triggered.