### PR TITLE
Fix the phonopy version in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,6 @@ RUN set -ex; \
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 
-# Additional plugins
-RUN pip uninstall -y phonopy && \
-    pip install aiida-bader \
-    git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
-    git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
-
 RUN mkdir -p ${PSEUDO_FOLDER} && \
     python -m aiidalab_qe download-pseudos --dest ${PSEUDO_FOLDER}
 
@@ -129,6 +123,11 @@ RUN --mount=from=qe_conda_env,source=${QE_DIR},target=${QE_DIR} \
     verdi code create core.code.installed --label python --computer=localhost --default-calc-job-plugin pythonjob.pythonjob --filepath-executable=/opt/conda/bin/python -n && \
     verdi code create core.code.installed --label bader --computer=localhost --default-calc-job-plugin bader.bader --filepath-executable=${QE_DIR}/bin/bader -n && \
     verdi code create core.code.installed --label wannier90 --computer=localhost --default-calc-job-plugin wannier90.wannier90 --filepath-executable=/opt/conda/bin/wannier90.x -n && \
+    # Additional plugins
+    pip uninstall -y phonopy && \
+    pip install aiida-bader \
+    git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
+    git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0 && \
     # run post_install for plugin
     python -m aiida_bader post-install && \
     python -m aiidalab_qe_vibroscopy setup-phonopy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,8 @@ RUN set -ex; \
 ENV PSEUDO_FOLDER=/tmp/pseudo
 
 # Additional plugins
-RUN pip install aiida-bader \
+RUN pip uninstall -y phonopy && \
+    pip install aiida-bader \
     git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0 \
     git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0
 


### PR DESCRIPTION
`aiidalab-qe` will install `pyhonopy==2.38`, and the `aiidalab-qe-vibroscopy` needs `phonopy==2.25.0`.

A quick solution: when building the image, we first uninstall the one installed by `aiidalab-qe` in the system's conda, and then install the `aiidalab-qe-vibroscopy`.
