### PR TITLE
Add `latest` tag

### DIFF
--- a/.github/workflows/docker-build-upload.yml
+++ b/.github/workflows/docker-build-upload.yml
@@ -137,6 +137,7 @@ jobs:
                       type=ref,event=pr
                       type=edge,enable={{is_default_branch}}
                       type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                      latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') }}
             - name: Docker meta (DockerHub) 📝
               id: meta_dockerhub
               uses: docker/metadata-action@v5
@@ -146,6 +147,7 @@ jobs:
                       type=ref,event=pr
                       type=edge,enable={{is_default_branch}}
                       type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                      latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha') }}
 
             - name: Build and push ARM image
               id: build_upload_arm


### PR DESCRIPTION
The new release `v25.04.0` build and push the docker image [v25.04.0](https://hub.docker.com/layers/aiidalab/qe/v25.04.0/images/sha256-c00ddb83ba26ce32153fdc9ba231b647e132c6386bcf595d39083ac5686bd8bc)

But there is still one issue: it does not create a `latest` tag, in this PR, we add the `latest` tag if the branch start with `v` and does not contain `a`. (for this PR, I use `alpha` because I will make an alpha release later to check if this works. We need to change `alpha` to `a back if it works)