### PR TITLE
Update the condition to build latest

### DIFF
--- a/.github/workflows/docker-build-upload.yml
+++ b/.github/workflows/docker-build-upload.yml
@@ -204,16 +204,16 @@ jobs:
                   BASE_TAG="${{ needs.build-amd.outputs.base_tags_dockerhub }}"
                   docker buildx imagetools create -t ${BASE_TAG} ${BASE_TAG}-amd ${BASE_TAG}-arm
 
-            # Create a “latest” manifest only if the tag is a proper release (not alpha)
+            # Create a “latest” manifest only if the tag is a proper release (not a)
             - name: Create and push manifest for GHCR latest
-              if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha')
+              if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'a') && !contains(github.ref, 'b') && !contains(github.ref, 'rc')
               run: |
                   docker buildx imagetools create -t ghcr.io/${{ env.IMAGE_NAME }}:latest \
                     ${{ needs.build-amd.outputs.base_tags_ghcr }}-amd \
                     ${{ needs.build-amd.outputs.base_tags_ghcr }}-arm
 
             - name: Create and push manifest for DockerHub latest
-              if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'alpha')
+              if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'a') && !contains(github.ref, 'b') && !contains(github.ref, 'rc')
               run: |
                   docker buildx imagetools create -t docker.io/${{ env.IMAGE_NAME }}:latest \
                     ${{ needs.build-amd.outputs.base_tags_dockerhub }}-amd \


### PR DESCRIPTION
This condition ensures that the manifest creation only occurs for tags that start with `refs/tags/v` and do not include `a`, `b`, or `rc`.