### PR TITLE
prevent false negatives in tag filter by using ref_name

### DIFF
--- a/.github/workflows/docker-build-upload.yml
+++ b/.github/workflows/docker-build-upload.yml
@@ -213,7 +213,8 @@ jobs:
                     ${{ needs.build-amd.outputs.base_tags_ghcr }}-arm
 
             - name: Create and push manifest for DockerHub latest
-              if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'a') && !contains(github.ref, 'b') && !contains(github.ref, 'rc')
+              if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, 'a') && !contains(github.ref_name, 'b') && !contains(github.ref_name,
+                  'rc')
               run: |
                   docker buildx imagetools create -t docker.io/${{ env.IMAGE_NAME }}:latest \
                     ${{ needs.build-amd.outputs.base_tags_dockerhub }}-amd \


### PR DESCRIPTION
Use `github.ref_name` instead of `github.ref` to avoid matching unwanted characters from the static 'refs/tags/' prefix when filtering out pre-releases (a, b, rc).