### PR TITLE
Add post-install script for the `aiida-qe-xspec` plugin

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -39,6 +39,7 @@ aiida-qe-xspec:
     github: https://github.com/aiidaplugins/aiida-qe-xspec
     documentation: https://aiida-qe-xspec.readthedocs.io/
     pip: aiida-qe-xspec
+    post_install: post-install
     status: beta
     category: calculation
     requires_aiidalab_qe: '>24.04.0'


### PR DESCRIPTION
`aiida-qe-xspec` introduces `post-install` script to download and import the core-hole pseudopotentials.