### PR TITLE
Restructure examples importing feature in line with plugin architecture

### DIFF
--- a/examples.ipynb
+++ b/examples.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from aiidalab_qe.common.widgets import ExamplesImporter\n",
+    "from aiidalab_qe.app.utils.examples_importer import ExamplesImporter\n",
     "\n",
     "# Tag rules w.r.t the examples REPO (for devs):\n",
     "# - New examples added - no change here (REPO updates tag to HEAD)\n",

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -46,9 +46,9 @@
    "source": [
     "# AiiDAlab Quantum ESPRESSO - Example calculations\n",
     "\n",
-    "We provide here a set of example calculations performed with the AiiDAlab Quantum ESPRESSO app for you to import into your AiiDA instance. Choose one or more examples to import, then click the **<span style=\"color: #4caf50;\"><i class=\"fa fa-download\"></i> Import</span>** button. A report on each import will be appended to the log below. Once imported, you can click the **<span style=\"color: #2196f3;\"><i class=\"fa fa-list\"></i> Calculation history</span>** button to view details of any given imported calculation and/or launch it in an instance of the app to view its inputs and outputs.\n",
+    "We provide here a set of example calculations performed with the AiiDAlab Quantum ESPRESSO app for you to import into your AiiDA instance. Choose one or more examples to import, then click the **<span style=\"color: #4caf50;\"><i class=\"fa fa-download\"></i> Import</span>** button. A report on each import will be appended to the log below. At any point, you can click the **<span style=\"color: #ff7d17;\"><i class=\"fa fa-list\"></i> Calculation history</span>** button to view details of any calculation and launch it in an instance of the app to view its inputs and outputs.\n",
     "\n",
-    "If you have any questions or issues regarding the examples, please open an issue in the [aiidalab-qe-examples](https://github.com/aiidalab/aiidalab-qe-examples) repository.\n"
+    "Other than the built-in core and electronic structure examples, other examples are provided by each external plugin. To access these examples, you will need to install the corresponding plugin. You can do so by visiting the **<span style=\"color: #0096dd;\"><i class=\"fa fa-cogs\"></i> Plugin manager</span>** page.\n"
    ]
   },
   {
@@ -57,21 +57,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from aiidalab_qe.common.widgets import ArchiveImporter\n",
+    "import ipywidgets as ipw\n",
+    "\n",
+    "from aiidalab_qe.common.widgets import LinkButton\n",
+    "\n",
+    "ipw.HBox(\n",
+    "    children=[\n",
+    "        LinkButton(\n",
+    "            description=\"Calculation history\",\n",
+    "            link=\"./calculation_history.ipynb\",\n",
+    "            style_=\"background-color: var(--color-aiida-orange)\",\n",
+    "            icon=\"list\",\n",
+    "\n",
+    "        ),\n",
+    "        LinkButton(\n",
+    "            description=\"Plugin manager\",\n",
+    "            link=\"./plugin_manager.ipynb\",\n",
+    "            style_=\"background-color: var(--color-aiida-blue)\",\n",
+    "            icon=\"cogs\",\n",
+    "        ),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiidalab_qe.common.widgets import ExamplesImporter\n",
     "\n",
     "# Tag rules w.r.t the examples REPO (for devs):\n",
     "# - New examples added - no change here (REPO updates tag to HEAD)\n",
     "# - Examples rerun due to changes here or in plugin - use new tag (new REPO version)\n",
     "\n",
-    "importer = ArchiveImporter(\n",
+    "importer = ExamplesImporter(\n",
     "    repo=\"aiidalab/aiidalab-qe-examples\",\n",
     "    tag=\"1.0\",  # -> see rules above\n",
-    "    archive_list=\"examples_list.txt\",\n",
-    "    archives_dir=\"examples\",\n",
-    "    logger={\n",
-    "        \"placeholder\": \"Archive import output will be shown here.\",\n",
-    "        \"clear_on_import\": True,\n",
-    "    },\n",
     ")\n",
     "importer"
    ]
@@ -81,9 +104,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "importer.render()"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -93,17 +93,10 @@
     "\n",
     "importer = ExamplesImporter(\n",
     "    repo=\"aiidalab/aiidalab-qe-examples\",\n",
-    "    tag=\"1.0\",  # -> see rules above\n",
+    "    tag=\"2.0\",  # -> see rules above\n",
     ")\n",
     "importer"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -68,7 +68,6 @@
     "            link=\"./calculation_history.ipynb\",\n",
     "            style_=\"background-color: var(--color-aiida-orange)\",\n",
     "            icon=\"list\",\n",
-    "\n",
     "        ),\n",
     "        LinkButton(\n",
     "            description=\"Plugin manager\",\n",

--- a/src/aiidalab_qe/app/utils/examples_importer.py
+++ b/src/aiidalab_qe/app/utils/examples_importer.py
@@ -97,7 +97,7 @@ class ArchiveImporter(ipw.VBox):
         if len(selected) > 1:
             description = self.DESCRIPTION_TEMPLATE.format(
                 header="Multiple examples selected",
-                content="To see example descriptions, select one example at a time.",
+                content="To see a description, select only one example.",
             )
         else:
             archive = selected[0]
@@ -172,19 +172,18 @@ class ExamplesImporter(ipw.Tab):
         self.titles = []
         self._load_tabs()
 
-    def _archive_urls(self, repo: str, tag: str, path: str = "") -> tuple[str, str]:
-        # path = f"refs/tags/{tag}/{path}"
-        path = f"refs/heads/refactor/{path}"
+    def _archive_urls(self, repo: str, tag: str) -> tuple[str, str]:
+        refs = f"refs/tags/{tag}"
+        refs = "refs/heads/refactor"
         return (
-            f"https://raw.githubusercontent.com/{repo}/{path}/metadata.json",
-            f"https://github.com/{repo}/raw/{path}",
+            f"https://raw.githubusercontent.com/{repo}/{refs}/examples.json",
+            f"https://github.com/{repo}/raw/{refs}/examples",
         )
 
     def _load_tabs(self):
         list_url, archives_url = self._archive_urls(
             repo=self.core_repo,
             tag=self.core_tag,
-            path="core",
         )
         core_widget = ArchiveImporter(
             repo=self.core_repo,
@@ -206,7 +205,6 @@ class ExamplesImporter(ipw.Tab):
             list_url, archives_url = self._archive_urls(
                 repo=repo,
                 tag=items.get("tag", ""),
-                path=items.get("path", ""),
             )
 
             plugin_widget = ArchiveImporter(

--- a/src/aiidalab_qe/app/utils/examples_importer.py
+++ b/src/aiidalab_qe/app/utils/examples_importer.py
@@ -174,7 +174,6 @@ class ExamplesImporter(ipw.Tab):
 
     def _archive_urls(self, repo: str, tag: str) -> tuple[str, str]:
         refs = f"refs/tags/{tag}"
-        refs = "refs/heads/refactor"
         return (
             f"https://raw.githubusercontent.com/{repo}/{refs}/examples.json",
             f"https://github.com/{repo}/raw/{refs}/archives",

--- a/src/aiidalab_qe/app/utils/examples_importer.py
+++ b/src/aiidalab_qe/app/utils/examples_importer.py
@@ -112,11 +112,11 @@ class ArchiveImporter(ipw.VBox):
     def _on_import_click(self, _):
         self.import_button.disabled = True
         self.logger.value = ""
-        encountered_an_error = False
+        successful = False
         for filename in self.selector.value:
-            encountered_an_error = self._import_archive(filename)
+            successful = self._import_archive(filename)
         self.import_button.disabled = False
-        if encountered_an_error:
+        if not successful:
             self.info.value = (
                 "ERROR: some archives failed to import. See log for details"
             )
@@ -132,7 +132,7 @@ class ArchiveImporter(ipw.VBox):
         )
         stdout, stderr = process.communicate()
         self._report(filename, stdout, stderr)
-        return bool(stderr)
+        return "Success" in stdout
 
     def _report(self, filename: str, stdout: str, stderr: str):
         if stderr and "Success" not in stdout:
@@ -177,7 +177,7 @@ class ExamplesImporter(ipw.Tab):
         refs = "refs/heads/refactor"
         return (
             f"https://raw.githubusercontent.com/{repo}/{refs}/examples.json",
-            f"https://github.com/{repo}/raw/{refs}/examples",
+            f"https://github.com/{repo}/raw/{refs}/archives",
         )
 
     def _load_tabs(self):

--- a/src/aiidalab_qe/app/utils/examples_importer.py
+++ b/src/aiidalab_qe/app/utils/examples_importer.py
@@ -1,0 +1,219 @@
+import subprocess
+
+import ipywidgets as ipw
+import requests as req
+
+from aiidalab_qe.app.utils import get_entry_items
+from aiidalab_qe.common.widgets import RollingOutput
+from aiidalab_widgets_base import LoadingWidget
+
+
+class ArchiveImporter(ipw.VBox):
+    GITHUB = "https://github.com"
+    INFO_TEMPLATE = "{} <i class='fa fa-spinner fa-spin'></i>"
+    DESCRIPTION_TEMPLATE = """
+        <div class="alert alert-info" style="margin-bottom: 4px;">
+            <h3>{header}</h3>
+            <p>{content}</p>
+        </div>
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        archive_list_url: str,
+        archives_url: str,
+        **kwargs,
+    ):
+        self.repo = repo
+        self.archive_list_url = archive_list_url
+        self.archives_url = archives_url
+        self.archives: dict[str, dict[str, str]] = {}
+
+        self.logger_placeholder = "Archive import output will be shown here."
+        self.logger = RollingOutput()  # TODO use streaming output
+        self.logger.value = self.logger_placeholder
+
+        super().__init__(children=[LoadingWidget()], **kwargs)
+
+    def render(self):
+        self.selector = ipw.SelectMultiple(
+            options=[],
+            description="Examples:",
+            rows=10,
+            style={"description_width": "initial"},
+            layout=ipw.Layout(width="auto"),
+        )
+        self.selector.observe(self._on_examples_selections, names="value")
+
+        self.import_button = ipw.Button(
+            description="Import",
+            button_style="success",
+            layout=ipw.Layout(width="fit-content"),
+            icon="download",
+        )
+        self.import_button.on_click(self._on_import_click)
+
+        self.info = ipw.HTML()
+
+        accordion = None
+        if self.logger:
+            accordion = ipw.Accordion(children=[self.logger])
+            accordion.set_title(0, "Archive import log")
+            accordion.selected_index = None
+
+        self.example_description = ipw.HTML()
+
+        self.children = [
+            ipw.HTML(f"""
+                For questions regarding the examples, please open an issue in the
+                <a href="{self.GITHUB}/{self.repo}" target="_blank">{self.repo}</a>
+                repository.
+            """),
+            self.selector,
+            ipw.HBox(
+                children=[
+                    self.import_button,
+                    self.info,
+                ],
+                layout=ipw.Layout(margin="2px 0 4px 68px", grid_gap="4px"),
+            ),
+            self.example_description,
+            accordion or ipw.Box(),
+        ]
+
+        self.selector.options = self._get_options()
+
+    def _on_examples_selections(self, _) -> None:
+        """Update the description of the selected example."""
+        selected = self.selector.value
+        if not selected:
+            self.example_description.value = ""
+            self.import_button.disabled = True
+            return
+
+        self.import_button.disabled = False
+
+        if len(selected) > 1:
+            description = self.DESCRIPTION_TEMPLATE.format(
+                header="Multiple examples selected",
+                content="To see example descriptions, select one example at a time.",
+            )
+        else:
+            archive = selected[0]
+            metadata = self.archives[archive]
+            description = self.DESCRIPTION_TEMPLATE.format(
+                header=archive,
+                content=metadata["description"] or metadata["label"],
+            )
+
+        self.example_description.value = description
+
+    def _on_import_click(self, _):
+        self.import_button.disabled = True
+        self.logger.value = ""
+        encountered_an_error = False
+        for filename in self.selector.value:
+            encountered_an_error = self._import_archive(filename)
+        self.import_button.disabled = False
+        if encountered_an_error:
+            self.info.value = (
+                "ERROR: some archives failed to import. See log for details"
+            )
+
+    def _import_archive(self, filename: str) -> bool:
+        self.info.value = self.INFO_TEMPLATE.format(f"Importing {filename}")
+        file_url = f"{self.archives_url}/{filename}"
+        process = subprocess.Popen(
+            ["verdi", "archive", "import", "-v", "critical", file_url],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        stdout, stderr = process.communicate()
+        self._report(filename, stdout, stderr)
+        return bool(stderr)
+
+    def _report(self, filename: str, stdout: str, stderr: str):
+        if stderr and "Success" not in stdout:
+            self.logger.value += f"[ERROR] - importing {filename} failed\n\n{stderr}"
+        else:
+            self.info.value = ""
+            self.logger.value += f"{stdout}"
+        self.logger.value += f"\n{'#' * 80}\n\n"
+
+    def _get_options(self) -> list[tuple[str, str]]:
+        try:
+            response: req.Response = req.get(self.archive_list_url)
+            if not response.ok:
+                self.info.value = "Failed to fetch archive list"
+                return []
+            self.archives = response.json()
+            if not self.archives:
+                self.info.value = "NOTE: Plugin does not yet provide examples"
+            return [
+                (
+                    metadata["label"],
+                    archive,
+                )
+                for archive, metadata in self.archives.items()
+            ]
+        except req.RequestException as e:
+            self.info.value = f"Failed to fetch archive list: {e}"
+            return []
+
+
+class ExamplesImporter(ipw.Tab):
+    def __init__(self, repo: str, tag: str):
+        super().__init__()
+        self.core_repo = repo
+        self.core_tag = tag
+        self.children = []
+        self.titles = []
+        self._load_tabs()
+
+    def _archive_urls(self, repo: str, tag: str, path: str = "") -> tuple[str, str]:
+        # path = f"refs/tags/{tag}/{path}"
+        path = f"refs/heads/refactor/{path}"
+        return (
+            f"https://raw.githubusercontent.com/{repo}/{path}/metadata.json",
+            f"https://github.com/{repo}/raw/{path}",
+        )
+
+    def _load_tabs(self):
+        list_url, archives_url = self._archive_urls(
+            repo=self.core_repo,
+            tag=self.core_tag,
+            path="core",
+        )
+        core_widget = ArchiveImporter(
+            repo=self.core_repo,
+            archive_list_url=list_url,
+            archives_url=archives_url,
+        )
+        core_widget.render()
+        self.children = [core_widget]
+        self.set_title(0, "Core")
+
+        entries: dict[str, dict] = get_entry_items(
+            "aiidalab_qe.properties",
+            "examples",
+        )
+        for i, (name, items) in enumerate(entries.items(), start=1):
+            if not items:
+                continue
+            repo = items.get("repo", "")
+            list_url, archives_url = self._archive_urls(
+                repo=repo,
+                tag=items.get("tag", ""),
+                path=items.get("path", ""),
+            )
+
+            plugin_widget = ArchiveImporter(
+                repo=repo,
+                archive_list_url=list_url,
+                archives_url=archives_url,
+            )
+            plugin_widget.render()
+            self.children += (plugin_widget,)
+            self.set_title(i, items.get("title", name.capitalize().replace("_", " ")))

--- a/src/aiidalab_qe/app/wrapper.py
+++ b/src/aiidalab_qe/app/wrapper.py
@@ -187,7 +187,6 @@ class AppWrapperView(ipw.VBox):
             icon="list",
             tooltip="View a list of previous calculations",
             style_="background-color: var(--color-aiida-orange)",
-            disabled=True,
         )
 
         self.setup_resources_link = LinkButton(
@@ -196,7 +195,6 @@ class AppWrapperView(ipw.VBox):
             icon="database",
             tooltip="Setup computational resources for your calculations",
             style_="background-color: var(--color-aiida-blue)",
-            disabled=True,
         )
 
         self.new_workchain_link = LinkButton(
@@ -205,7 +203,6 @@ class AppWrapperView(ipw.VBox):
             icon="plus-circle",
             tooltip="Open a new calculation in a separate tab",
             style_="background-color: var(--color-aiida-green)",
-            disabled=True,
         )
 
         self.external_links = ipw.HBox(

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -5,8 +5,6 @@ Authors: AiiDAlab team
 
 import base64
 import hashlib
-import subprocess
-import typing as t
 from copy import deepcopy
 from queue import Queue
 from tempfile import NamedTemporaryFile
@@ -17,7 +15,6 @@ import anywidget
 import ase
 import ipywidgets as ipw
 import numpy as np
-import requests as req
 import traitlets
 from IPython.display import HTML, Javascript, clear_output, display
 from pymatgen.io.ase import AseAtomsAdaptor
@@ -25,7 +22,6 @@ from shakenbreak.distortions import distort, local_mc_rattle, rattle
 
 from aiida.orm import CalcJobNode, load_code, load_node
 from aiida.orm import Data as orm_Data
-from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_widgets_base import (
     ComputationalResourcesWidget,
     StructureExamplesWidget,
@@ -1298,217 +1294,6 @@ class HBoxWithUnits(ipw.HBox):
             **kwargs,
         )
         self.add_class("hbox-with-units")
-
-
-class ArchiveImporter(ipw.VBox):
-    GITHUB = "https://github.com"
-    INFO_TEMPLATE = "{} <i class='fa fa-spinner fa-spin'></i>"
-    DESCRIPTION_TEMPLATE = """
-        <div class="alert alert-info" style="margin-bottom: 4px;">
-            <h3>{header}</h3>
-            <p>{content}</p>
-        </div>
-    """
-
-    def __init__(
-        self,
-        repo: str,
-        archive_list_url: str,
-        archives_url: str,
-        **kwargs,
-    ):
-        self.repo = repo
-        self.archive_list_url = archive_list_url
-        self.archives_url = archives_url
-        self.archives: dict[str, dict[str, str]] = {}
-
-        self.logger_placeholder = "Archive import output will be shown here."
-        self.logger = RollingOutput()  # TODO use streaming output
-        self.logger.value = self.logger_placeholder
-
-        super().__init__(children=[LoadingWidget()], **kwargs)
-
-    def render(self):
-        self.selector = ipw.SelectMultiple(
-            options=[],
-            description="Examples:",
-            rows=10,
-            style={"description_width": "initial"},
-            layout=ipw.Layout(width="auto"),
-        )
-        self.selector.observe(self._on_examples_selections, names="value")
-
-        self.import_button = ipw.Button(
-            description="Import",
-            button_style="success",
-            layout=ipw.Layout(width="fit-content"),
-            icon="download",
-        )
-        self.import_button.on_click(self._on_import_click)
-
-        self.info = ipw.HTML()
-
-        accordion = None
-        if self.logger:
-            accordion = ipw.Accordion(children=[self.logger])
-            accordion.set_title(0, "Archive import log")
-            accordion.selected_index = None
-
-        self.example_description = ipw.HTML()
-
-        self.children = [
-            ipw.HTML(f"""
-                For questions regarding the examples, please open an issue in the
-                <a href="{self.GITHUB}/{self.repo}" target="_blank">{self.repo}</a>
-                repository.
-            """),
-            self.selector,
-            ipw.HBox(
-                children=[
-                    self.import_button,
-                    self.info,
-                ],
-                layout=ipw.Layout(margin="2px 0 4px 68px", grid_gap="4px"),
-            ),
-            self.example_description,
-            accordion or ipw.Box(),
-        ]
-
-        self.selector.options = self._get_options()
-
-    def _on_examples_selections(self, _) -> None:
-        """Update the description of the selected example."""
-        selected = self.selector.value
-        if not selected:
-            self.example_description.value = ""
-            self.import_button.disabled = True
-            return
-
-        self.import_button.disabled = False
-
-        if len(selected) > 1:
-            description = self.DESCRIPTION_TEMPLATE.format(
-                header="Multiple examples selected",
-                content="To see example descriptions, select one example at a time.",
-            )
-        else:
-            archive = selected[0]
-            metadata = self.archives[archive]
-            description = self.DESCRIPTION_TEMPLATE.format(
-                header=archive,
-                content=metadata["description"] or metadata["label"],
-            )
-
-        self.example_description.value = description
-
-    def _on_import_click(self, _):
-        self.import_button.disabled = True
-        self.logger.value = ""
-        encountered_an_error = False
-        for filename in self.selector.value:
-            encountered_an_error = self._import_archive(filename)
-        self.import_button.disabled = False
-        if encountered_an_error:
-            self.info.value = (
-                "ERROR: some archives failed to import. See log for details"
-            )
-
-    def _import_archive(self, filename: str) -> bool:
-        self.info.value = self.INFO_TEMPLATE.format(f"Importing {filename}")
-        file_url = f"{self.archives_url}/{filename}"
-        process = subprocess.Popen(
-            ["verdi", "archive", "import", "-v", "critical", file_url],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        stdout, stderr = process.communicate()
-        self._report(filename, stdout, stderr)
-        return bool(stderr)
-
-    def _report(self, filename: str, stdout: str, stderr: str):
-        if stderr and "Success" not in stdout:
-            self.logger.value += f"[ERROR] - importing {filename} failed\n\n{stderr}"
-        else:
-            self.info.value = ""
-            self.logger.value += f"{stdout}"
-        self.logger.value += f"\n{'#' * 80}\n\n"
-
-    def _get_options(self) -> list[tuple[str, str]]:
-        try:
-            response: req.Response = req.get(self.archive_list_url)
-            if not response.ok:
-                self.info.value = "Failed to fetch archive list"
-                return []
-            self.archives = response.json()
-            if not self.archives:
-                self.info.value = "NOTE: Plugin does not yet provide examples"
-            return [
-                (
-                    metadata["label"],
-                    archive,
-                )
-                for archive, metadata in self.archives.items()
-            ]
-        except req.RequestException as e:
-            self.info.value = f"Failed to fetch archive list: {e}"
-            return []
-
-
-class ExamplesImporter(ipw.Tab):
-    def __init__(self, repo: str, tag: str):
-        super().__init__()
-        self.core_repo = repo
-        self.core_tag = tag
-        self.children = []
-        self.titles = []
-        self._load_tabs()
-
-    def _archive_urls(self, repo: str, tag: str, path: str = "") -> tuple[str, str]:
-        # path = f"refs/tags/{tag}/{path}"
-        path = f"refs/heads/refactor/{path}"
-        return (
-            f"https://raw.githubusercontent.com/{repo}/{path}/metadata.json",
-            f"https://github.com/{repo}/raw/{path}",
-        )
-
-    def _load_tabs(self):
-        list_url, archives_url = self._archive_urls(
-            repo=self.core_repo,
-            tag=self.core_tag,
-            path="core",
-        )
-        core_widget = ArchiveImporter(
-            repo=self.core_repo,
-            archive_list_url=list_url,
-            archives_url=archives_url,
-        )
-        core_widget.render()
-        self.children = [core_widget]
-        self.set_title(0, "Core")
-
-        entries: dict[str, dict] = get_entry_items(
-            "aiidalab_qe.properties",
-            "examples",
-        )
-        for i, (name, items) in enumerate(entries.items(), start=1):
-            if not items:
-                continue
-            repo = items.get("repo", "")
-            list_url, archives_url = self._archive_urls(
-                repo=repo,
-                tag=items.get("tag", ""),
-                path=items.get("path", ""),
-            )
-
-            plugin_widget = ArchiveImporter(
-                repo=repo,
-                archive_list_url=list_url,
-                archives_url=archives_url,
-            )
-            plugin_widget.render()
-            self.children += (plugin_widget,)
-            self.set_title(i, items.get("title", name.capitalize().replace("_", " ")))
 
 
 class ShakeNBreakEditor(ipw.VBox):

--- a/src/aiidalab_qe/plugins/electronic_structure/__init__.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/__init__.py
@@ -5,4 +5,9 @@ electronic_structure = {
         "panel": ElectronicStructureResultsPanel,
         "model": ElectronicStructureResultsModel,
     },
+    "examples": {
+        "repo": "aiidalab/aiidalab-qe-examples",
+        "tag": "1.0",
+        "path": "electronic_structure",
+    },
 }

--- a/src/aiidalab_qe/plugins/electronic_structure/__init__.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/__init__.py
@@ -4,10 +4,5 @@ electronic_structure = {
     "result": {
         "panel": ElectronicStructureResultsPanel,
         "model": ElectronicStructureResultsModel,
-    },
-    "examples": {
-        "repo": "aiidalab/aiidalab-qe-examples",
-        "tag": "1.0",
-        "path": "electronic_structure",
-    },
+    }
 }


### PR DESCRIPTION
This PR refactors and restructures the examples importing feature to fit with the overall plugin architecture.
Plugin developers can now provide examples in their own examples repo (recommended) by registering in their end point the examples repo as follows:

```
"examples": {
  "repo": <plugin-examples-repo-without-github-prefix>,  -> e.g., aiidalab/aiidalab-qe-examples
  "tag": 1.0,  -> follows rules to be provided in docs
  "path": <archives-path>,  -> optional, defaults to `root/archives`
  "metadata_path": <examples-metadata-file-path>  -> optional, defaults to `root/examples.json`
}
```

A tab will be added in the importer widget for the providing plugin. The plugin examples list is fetched and populates the selector.

### TODO
- Plugin list fetching should trigger on tab switch (lazy fetch)
- Importing log should stream output - we can refactor the streaming utility from the plugin manager for general use
- TBD - how to best handle plugins that have yet to provide examples

### Note
The path to the repo is currently not using the tag but is hardcorded to the refactor branch on the examples repo (see https://github.com/aiidalab/aiidalab-qe-examples/pull/11). Once the PR is set, we update the tag and correct here.

---

![image](https://github.com/user-attachments/assets/9b746ae1-60ac-4e92-a940-7ee90aa740b9)
