### PR TITLE
Fix width in `fat bands`

### DIFF
--- a/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
@@ -414,13 +414,13 @@ class BandsPdosPlotly:
                 mode="markers",
                 line={"width": 0, "color": data["color"]},
                 name=data["label"],
-                marker=dict(
-                    size=np.array(data["marker_sizes"]) * projections_width,
-                    sizemode="diameter",
-                    color=data["color"],
-                    opacity=0.7,
-                    line=dict(width=0),
-                ),
+                marker={
+                    "size": np.array(data["marker_sizes"]) * projections_width,
+                    "sizemode": "diameter",
+                    "color": data["color"],
+                    "opacity": 0.7,
+                    "line": {"width": 0},
+                },
                 showlegend=True if self.plot_type == "bands" else False,
             )
             for data in prepared_data

--- a/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
@@ -397,7 +397,7 @@ class BandsPdosPlotly:
                     "y": np.array(proj_bands["y"]) - fermi_energy,
                     "color": proj_bands["color"],
                     "label": proj_bands["label"],
-                    "marker_sizes": proj_bands['marker_sizes'],
+                    "marker_sizes": proj_bands["marker_sizes"],
                 }
             )
         return prepared_data
@@ -411,15 +411,15 @@ class BandsPdosPlotly:
                 x=data["x"],
                 y=data["y"],
                 legendgroup=data["label"],
-                mode='markers',
+                mode="markers",
                 line={"width": 0, "color": data["color"]},
                 name=data["label"],
                 marker=dict(
-                    size=np.array(data['marker_sizes']) * projections_width,
-                    sizemode='diameter',
+                    size=np.array(data["marker_sizes"]) * projections_width,
+                    sizemode="diameter",
                     color=data["color"],
                     opacity=0.7,
-                    line=dict(width=0)  
+                    line=dict(width=0),
                 ),
                 showlegend=True if self.plot_type == "bands" else False,
             )
@@ -431,7 +431,10 @@ class BandsPdosPlotly:
     def update_projected_bands_thickness(self, fig, width):
         """Update the projected bands thickness."""
         # Create a mapping from labels to y-data for efficient updates
-        marker_sizes_by_label = {data["label"]: np.array(data["marker_sizes"]) * width  for data in self.project_bands}
+        marker_sizes_by_label = {
+            data["label"]: np.array(data["marker_sizes"]) * width
+            for data in self.project_bands
+        }
 
         with fig.batch_update():
             for trace in fig.data:

--- a/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdosplotly.py
@@ -234,9 +234,9 @@ class BandsPdosPlotly:
                     },
                 )
 
-    def adding_projected_bands(self, fig):
+    def adding_projected_bands(self, fig, projections_width=None):
         if self.project_bands:
-            self._add_projection_traces(fig)
+            self._add_projection_traces(fig, projections_width)
 
     def _create_fig(self):
         """Create a plotly figure.
@@ -397,11 +397,12 @@ class BandsPdosPlotly:
                     "y": np.array(proj_bands["y"]) - fermi_energy,
                     "color": proj_bands["color"],
                     "label": proj_bands["label"],
+                    "marker_sizes": proj_bands['marker_sizes'],
                 }
             )
         return prepared_data
 
-    def _add_projection_traces(self, fig):
+    def _add_projection_traces(self, fig, projections_width):
         """Function to add the projected bands traces to the bands plot."""
         prepared_data = self._prepare_bands_projection_traces_data(self.project_bands)
 
@@ -409,12 +410,17 @@ class BandsPdosPlotly:
             go.Scattergl(
                 x=data["x"],
                 y=data["y"],
-                fill="toself",
                 legendgroup=data["label"],
-                mode="lines",
+                mode='markers',
                 line={"width": 0, "color": data["color"]},
                 name=data["label"],
-                # If PDOS is present, use those legend entries
+                marker=dict(
+                    size=np.array(data['marker_sizes']) * projections_width,
+                    sizemode='diameter',
+                    color=data["color"],
+                    opacity=0.7,
+                    line=dict(width=0)  
+                ),
                 showlegend=True if self.plot_type == "bands" else False,
             )
             for data in prepared_data
@@ -422,17 +428,15 @@ class BandsPdosPlotly:
 
         self._add_traces_to_fig(fig, scatter_objects, 1)
 
-    def update_projected_bands_thickness(self, fig):
+    def update_projected_bands_thickness(self, fig, width):
         """Update the projected bands thickness."""
-        prepared_data = self._prepare_bands_projection_traces_data(self.project_bands)
-
         # Create a mapping from labels to y-data for efficient updates
-        y_data_by_label = {data["label"]: data["y"] for data in prepared_data}
+        marker_sizes_by_label = {data["label"]: np.array(data["marker_sizes"]) * width  for data in self.project_bands}
 
         with fig.batch_update():
             for trace in fig.data:
-                if trace.xaxis == "x" and trace.legendgroup in y_data_by_label:
-                    trace.y = y_data_by_label[trace.legendgroup]
+                if trace.xaxis == "x" and trace.legendgroup in marker_sizes_by_label:
+                    trace.marker.size = marker_sizes_by_label[trace.legendgroup]
 
     def _customize_combined_layout(self, fig):
         self._customize_layout(fig, self._bands_xaxis, self._bands_yaxis)

--- a/src/aiidalab_qe/common/bands_pdos/model.py
+++ b/src/aiidalab_qe/common/bands_pdos/model.py
@@ -176,7 +176,7 @@ class BandsPdosModel(Model):
                 self._remove_bands_traces()
             self.bands_projections_data = self._get_bands_projections_data()
             self.helper.project_bands = self.bands_projections_data
-            self.helper.adding_projected_bands(self.plot)
+            self.helper.adding_projected_bands(self.plot, self.proj_bands_width)
         else:
             self._remove_bands_traces()
         self._get_traces_selector_options()
@@ -184,9 +184,7 @@ class BandsPdosModel(Model):
     def update_bands_projections_thickness(self):
         """Update the bands projections thickness."""
         if self.project_bands_box:
-            self.bands_projections_data = self._get_bands_projections_data()
-            self.helper.project_bands = self.bands_projections_data
-            self.helper.update_projected_bands_thickness(self.plot)
+            self.helper.update_projected_bands_thickness(self.plot, self.proj_bands_width)
 
     def _remove_bands_traces(self):
         """Remove the bands traces."""
@@ -265,7 +263,6 @@ class BandsPdosModel(Model):
                 group_tag=self.dos_atoms_group,
                 plot_tag=self.dos_plot_group,
                 selected_atoms=expanded_selection,
-                bands_width=self.proj_bands_width,
             )
             return bands_projections
         return None

--- a/src/aiidalab_qe/common/bands_pdos/model.py
+++ b/src/aiidalab_qe/common/bands_pdos/model.py
@@ -184,7 +184,9 @@ class BandsPdosModel(Model):
     def update_bands_projections_thickness(self):
         """Update the bands projections thickness."""
         if self.project_bands_box:
-            self.helper.update_projected_bands_thickness(self.plot, self.proj_bands_width)
+            self.helper.update_projected_bands_thickness(
+                self.plot, self.proj_bands_width
+            )
 
     def _remove_bands_traces(self):
         """Remove the bands traces."""

--- a/src/aiidalab_qe/common/bands_pdos/utils.py
+++ b/src/aiidalab_qe/common/bands_pdos/utils.py
@@ -404,7 +404,9 @@ def _prepare_projections_to_plot(bands_data, projections):
                     "y": y_bands.flatten().tolist(),
                     "label": proj["label"],
                     "color": proj["color"],
-                    "marker_sizes": (np.array(proj["projections"]).T * 10).flatten().tolist()
+                    "marker_sizes": (np.array(proj["projections"]).T * 10)
+                    .flatten()
+                    .tolist(),
                 }
             )
 


### PR DESCRIPTION
Currently, we determine the line width to display the projectability in a `fat bands` plot simply by shifting the bands up and down by `+- band_width / 2`. 
However, this is not correct as one would need to perform the shift perpendicular to the band. As an example, a vertical band would have 0 width in the current version, independent of the projectability.

I discussed with @edan-bainglass @eimrek at some point that it might be possible to use the gradients to plot the correct `fat bands`. While the general idea would work, I realized during the last days that this approach doesn't work that smoothly and produces visual artefacts, e.g., in areas with a strong curvature. Hence, I move to a simple scatter plot in this version to visualize the projections, which is also used in other tools and much simpler than the actual filled line plots with varying width, as outlined above. Moreover, it avoids recalculating the projections and so may improve performance. 

Also pinging @AndresOrtegaGuerrero 

Happy to discuss this further, just wanted to open it already so that it can be used for the paper.

### new version

<img width="903" alt="image" src="https://github.com/user-attachments/assets/e2fa9301-3d65-429b-8d18-e1490805dc60" />


### old version

<img width="906" alt="image" src="https://github.com/user-attachments/assets/d1b0fc9f-cf50-4836-ad41-9ec39b5cb244" />





