### PR TITLE
Reduce the number of decimal points to displayed

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -152,7 +152,7 @@ class AdvancedConfigurationSettingsPanel(
 
         # Convergence Threshold settings
         self.scf_conv_thr = ipw.BoundedFloatText(
-            min=1e-15,
+            min=1e-18,
             max=1.0,
             description="Energy:",
             style={"description_width": "150px"},
@@ -174,7 +174,7 @@ class AdvancedConfigurationSettingsPanel(
         ipw.dlink(
             (self._model, "scf_conv_thr"),
             (scf_conv_thr_abs, "value"),
-            lambda value: str(value * len(self._model.input_structure.sites)),
+            lambda value: f"{value * len(self._model.input_structure.sites):.5e}",
         )
         scf_conv_thr_abs.add_class("convergence-label")
         self.etot_conv_thr = ipw.BoundedFloatText(
@@ -195,7 +195,7 @@ class AdvancedConfigurationSettingsPanel(
         ipw.dlink(
             (self._model, "etot_conv_thr"),
             (etot_conv_thr_abs, "value"),
-            lambda value: str(value * len(self._model.input_structure.sites)),
+            lambda value: f"{value * len(self._model.input_structure.sites):.5e}",
         )
         etot_conv_thr_abs.add_class("convergence-label")
         self.forc_conv_thr = ipw.BoundedFloatText(


### PR DESCRIPTION
Here we reduce the number of decimals points to be displayed ,

<img width="1142" height="587" alt="image" src="https://github.com/user-attachments/assets/3c6882c7-ba21-49ea-bba9-27382933fe3e" />


This way, we avoid displaying numbers like 1.9999999999999 without exponential notation.
For example , 

<img width="1142" height="268" alt="image" src="https://github.com/user-attachments/assets/0f7ba529-1b40-410b-8bd6-d7b679febdd5" />


I also lowered the minimum allowed SCF threshold to 1e-18. For systems with more than 120 atoms, we sometimes need thresholds around 1e-14 for vibrational calculations, so this small adjustment makes that possible.