### PR TITLE
Display custom NSCF kpoint distance 

### DIFF
--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -43,8 +43,8 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
         }
 
     def set_model_state(self, parameters: dict):
-        self.kpoints_distance = parameters.get("nscf", {}).get(
-            "kpoints_distance",
+        self.kpoints_distance = parameters.get(
+            "nscf_kpoints_distance",
             self.traits()["kpoints_distance"].default_value,
         )
         self.use_pdos_degauss = parameters.get("use_pdos_degauss", False)

--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -20,7 +20,7 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
 
     protocol = tl.Unicode(allow_none=True)
 
-    kpoints_distance = tl.Float(0.1)
+    nscf_kpoints_distance = tl.Float(0.1)
     mesh_grid = tl.Unicode("")
     use_pdos_degauss = tl.Bool(False)
     pdos_degauss = tl.Float(0.005)
@@ -36,16 +36,16 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
 
     def get_model_state(self):
         return {
-            "nscf_kpoints_distance": self.kpoints_distance,
+            "nscf_kpoints_distance": self.nscf_kpoints_distance,
             "use_pdos_degauss": self.use_pdos_degauss,
             "pdos_degauss": self.pdos_degauss,
             "energy_grid_step": self.energy_grid_step,
         }
 
     def set_model_state(self, parameters: dict):
-        self.kpoints_distance = parameters.get(
+        self.nscf_kpoints_distance = parameters.get(
             "nscf_kpoints_distance",
-            self.traits()["kpoints_distance"].default_value,
+            self.traits()["nscf_kpoints_distance"].default_value,
         )
         self.use_pdos_degauss = parameters.get("use_pdos_degauss", False)
         self.pdos_degauss = parameters.get("pdos_degauss", 0.005)
@@ -53,7 +53,7 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
 
     def reset(self):
         with self.hold_trait_notifications():
-            self.kpoints_distance = self._get_default("kpoints_distance")
+            self.nscf_kpoints_distance = self._get_default("nscf_kpoints_distance")
             self.use_pdos_degauss = self._get_default("use_pdos_degauss")
             self.pdos_degauss = self._get_default("pdos_degauss")
             self.energy_grid_step = self._get_default("energy_grid_step")
@@ -64,10 +64,10 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
     def _update_kpoints_mesh(self, _=None):
         if not self.has_structure:
             mesh_grid = ""
-        elif self.kpoints_distance > 0:
+        elif self.nscf_kpoints_distance > 0:
             mesh = create_kpoints_from_distance.process_class._func(
                 self.input_structure,
-                orm.Float(self.kpoints_distance),
+                orm.Float(self.nscf_kpoints_distance),
                 orm.Bool(False),
             )
             mesh_grid = f"Mesh {mesh.get_kpoints_mesh()[0]!s}"
@@ -78,9 +78,9 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
 
     def _update_kpoints_distance(self, parameters):
         if self.has_pbc:
-            kpoints_distance = parameters["nscf"]["kpoints_distance"]
+            nscf_kpoints_distance = parameters["nscf"]["kpoints_distance"]
         else:
-            kpoints_distance = 100.0
+            nscf_kpoints_distance = 100.0
             self.use_pdos_degauss = True
-        self._defaults["kpoints_distance"] = kpoints_distance
-        self.kpoints_distance = self._defaults["kpoints_distance"]
+        self._defaults["nscf_kpoints_distance"] = nscf_kpoints_distance
+        self.nscf_kpoints_distance = self._defaults["nscf_kpoints_distance"]

--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -43,8 +43,8 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
         }
 
     def set_model_state(self, parameters: dict):
-        self.nscf_kpoints_distance = parameters.get(
-            "nscf_kpoints_distance",
+        self.kpoints_distance = parameters.get("nscf", {}).get(
+            "kpoints_distance",
             self.traits()["kpoints_distance"].default_value,
         )
         self.use_pdos_degauss = parameters.get("use_pdos_degauss", False)

--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -30,7 +30,7 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
         with self.hold_trait_notifications():
             if not specific or specific != "mesh":
                 parameters = PdosWorkChain.get_protocol_inputs(self.protocol)
-                self._update_kpoints_distance(parameters)
+                self._update_nscf_kpoints_distance(parameters)
 
             self._update_kpoints_mesh()
 
@@ -76,7 +76,7 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
         self._defaults["mesh_grid"] = mesh_grid
         self.mesh_grid = mesh_grid
 
-    def _update_kpoints_distance(self, parameters):
+    def _update_nscf_kpoints_distance(self, parameters):
         if self.has_pbc:
             nscf_kpoints_distance = parameters["nscf"]["kpoints_distance"]
         else:

--- a/src/aiidalab_qe/plugins/pdos/setting.py
+++ b/src/aiidalab_qe/plugins/pdos/setting.py
@@ -25,8 +25,8 @@ class PdosConfigurationSettingPanel(
             "protocol",
         )
         self._model.observe(
-            self._on_kpoints_distance_change,
-            "kpoints_distance",
+            self._on_nscf_kpoints_distance_change,
+            "nscf_kpoints_distance",
         )
 
     def render(self):
@@ -40,7 +40,7 @@ class PdosConfigurationSettingPanel(
             style={"description_width": "initial"},
         )
         ipw.link(
-            (self._model, "kpoints_distance"),
+            (self._model, "nscf_kpoints_distance"),
             (self.nscf_kpoints_distance, "value"),
         )
         ipw.dlink(
@@ -147,5 +147,5 @@ class PdosConfigurationSettingPanel(
     def _on_protocol_change(self, _):
         self.refresh(specific="protocol")
 
-    def _on_kpoints_distance_change(self, _):
+    def _on_nscf_kpoints_distance_change(self, _):
         self.refresh(specific="mesh")


### PR DESCRIPTION
This allows the PDOS plugin to use the custom NSCF k-point distance for display.