### PR TITLE
Fix PP upload widget

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     shakenbreak~=3.3.1
     plotly~=5.24
     kaleido~=0.2.1
+    upf_tools~=0.1.9
 
 python_requires = >=3.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.10.0
+    aiida-quantumespresso~=4.12.0
     aiidalab-widgets-base[optimade] @ git+https://github.com/aiidalab/aiidalab-widgets-base@master
     aiida-pseudo~=1.4
     filelock~=3.8

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -42,8 +42,8 @@ class MagnetizationConfigurationSettingsPanel(
             "type",
         )
         self._model.observe(
-            self._on_family_change,
-            "family",
+            self._on_pseudos_dictionary_change,
+            "dictionary",
         )
 
     def render(self):
@@ -127,7 +127,7 @@ class MagnetizationConfigurationSettingsPanel(
         self._toggle_widgets()
         self._model.update_type_help()
 
-    def _on_family_change(self, _):
+    def _on_pseudos_dictionary_change(self, _):
         self._model._update_default_moments()
 
     def _update(self, specific=""):

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -38,12 +38,12 @@ class MagnetizationConfigurationSettingsPanel(
             "spin_type",
         )
         self._model.observe(
-            self._on_magnetization_type_change,
-            "type",
-        )
-        self._model.observe(
             self._on_pseudos_dictionary_change,
             "dictionary",
+        )
+        self._model.observe(
+            self._on_magnetization_type_change,
+            "type",
         )
 
     def render(self):
@@ -123,12 +123,12 @@ class MagnetizationConfigurationSettingsPanel(
     def _on_spin_type_change(self, _):
         self.refresh(specific="spin")
 
+    def _on_pseudos_dictionary_change(self, _):
+        self.refresh(specific="dictionary")
+
     def _on_magnetization_type_change(self, _):
         self._toggle_widgets()
         self._model.update_type_help()
-
-    def _on_pseudos_dictionary_change(self, _):
-        self._model._update_default_moments()
 
     def _update(self, specific=""):
         if self.updated:

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -1,13 +1,12 @@
 from copy import deepcopy
 
 import traitlets as tl
-from aiida_pseudo.groups.family import PseudoPotentialFamily
 
+from aiida import orm
 from aiida_quantumespresso.workflows.protocols.utils import (
     get_magnetization_parameters,
 )
 from aiidalab_qe.common.mixins import HasInputStructure
-from aiidalab_qe.utils import fetch_pseudo_family_by_label
 
 from ..subsettings import AdvancedCalculationSubSettingsModel
 
@@ -22,12 +21,16 @@ class MagnetizationConfigurationSettingsModel(
         "input_structure",
         "electronic_type",
         "spin_type",
-        "pseudos.family",
+        "pseudos.dictionary",
     ]
 
     electronic_type = tl.Unicode()
     spin_type = tl.Unicode()
-    family = tl.Unicode("", allow_none=True)
+    dictionary = tl.Dict(
+        key_trait=tl.Unicode(),  # kind name
+        value_trait=tl.Unicode(),  # pseudopotential node uuid
+        default_value={},
+    )
 
     type_options = tl.List(
         trait=tl.List(tl.Unicode()),
@@ -103,26 +106,25 @@ class MagnetizationConfigurationSettingsModel(
             # and should be carefully checked!
             return
 
-        if not self.family:
-            # If no family is selected, we cannot determine the default moments.
-            self._defaults["moments"] = {}
-            return
-
-        family = fetch_pseudo_family_by_label(self.family)
         self._defaults["moments"] = {
-            kind.name: self._get_moment(kind.symbol, family)
-            for kind in self.input_structure.kinds
+            kind.name: self._get_moment(kind) for kind in self.input_structure.kinds
         }
 
-    def _get_moment(self, symbol: str, family: PseudoPotentialFamily) -> float:
+    def _get_moment(self, kind) -> float:
         """Convert the default magnetization to an initial magnetic moment."""
-        moment = self._DEFAULT_MOMENTS.get(symbol, {}).get("magmom", 0)
+        moment = self._DEFAULT_MOMENTS.get(kind.symbol, {}).get("magmom", 0)
         if moment != 0:
             return moment
 
+        try:
+            pseudo_uuid = self.dictionary.get(kind.name)
+            z_valence = orm.load_node(pseudo_uuid).z_valence
+        except Exception:
+            z_valence = 0
+
         # If no default moment is defined, or if it's 0, use 0.1 as default magnetization
         # and convert it to moments.
-        return round(0.1 * family.get_pseudo(symbol).z_valence, 3)
+        return round(0.1 * z_valence, 3)
 
     def _get_default_moments(self):
         return deepcopy(self._defaults.get("moments", {}))

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -27,7 +27,7 @@ class MagnetizationConfigurationSettingsModel(
 
     electronic_type = tl.Unicode()
     spin_type = tl.Unicode()
-    family = tl.Unicode()
+    family = tl.Unicode("", allow_none=True)
 
     type_options = tl.List(
         trait=tl.List(tl.Unicode()),
@@ -101,6 +101,11 @@ class MagnetizationConfigurationSettingsModel(
             # TODO this guard shouldn't be here! It IS here only because in the present
             # implementation, an update is called on app start. This breaks lazy loading
             # and should be carefully checked!
+            return
+
+        if not self.family:
+            # If no family is selected, we cannot determine the default moments.
+            self._defaults["moments"] = {}
             return
 
         family = fetch_pseudo_family_by_label(self.family)

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -183,13 +183,18 @@ class AdvancedConfigurationSettingsModel(
 
     def set_model_state(self, parameters):
         pseudos: PseudosConfigurationSettingsModel = self.get_model("pseudos")  # type: ignore
-        if "pseudo_family" in parameters:
-            pseudo_family = PseudoFamily.from_string(parameters["pseudo_family"])
+        if pseudo_family_string := parameters.get("pseudo_family"):
+            pseudo_family = PseudoFamily.from_string(pseudo_family_string)
             library = pseudo_family.library
             accuracy = pseudo_family.accuracy
             pseudos.library = f"{library} {accuracy}"
             pseudos.functional = pseudo_family.functional
-            pseudos.family = parameters["pseudo_family"]
+            pseudos.family = pseudo_family_string
+        else:
+            pseudos.library = None
+            pseudos.functional = None
+            pseudos.family = None
+            pseudos.show_upload_warning = True
 
         if "pseudos" in parameters["pw"]:
             pseudos.dictionary = parameters["pw"]["pseudos"]

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -50,9 +50,13 @@ class PseudosConfigurationSettingsModel(
                 DEFAULT["advanced"]["pseudo_family"]["functional"],
                 DEFAULT["advanced"]["pseudo_family"]["accuracy"],
             ]
-        )
+        ),
+        allow_none=True,
     )
-    functional = tl.Unicode(DEFAULT["advanced"]["pseudo_family"]["functional"])
+    functional = tl.Unicode(
+        DEFAULT["advanced"]["pseudo_family"]["functional"],
+        allow_none=True,
+    )
     functional_options = tl.List(
         trait=tl.Unicode(),
         default_value=[
@@ -66,7 +70,8 @@ class PseudosConfigurationSettingsModel(
                 DEFAULT["advanced"]["pseudo_family"]["library"],
                 DEFAULT["advanced"]["pseudo_family"]["accuracy"],
             ]
-        )
+        ),
+        allow_none=True,
     )
     library_options = tl.List(
         trait=tl.Unicode(),
@@ -83,7 +88,8 @@ class PseudosConfigurationSettingsModel(
     )
     ecutwfc = tl.Float()
     ecutrho = tl.Float()
-    status_message = tl.Unicode("")
+    status_message = tl.Unicode("", allow_none=True)
+    show_upload_warning = tl.Bool(False)
 
     PSEUDO_HELP_SOC = """
         <div class="pseudo-text">

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -111,8 +111,6 @@ class PseudosConfigurationSettingsModel(
 
     family_help_message = tl.Unicode(PSEUDO_HELP_WO_SOC)
 
-    pseudo_filename_reset_trigger = tl.Int(0)
-
     def update(self, specific=""):  # noqa: ARG002
         with self.hold_trait_notifications():
             if not self.has_structure:
@@ -276,7 +274,6 @@ class PseudosConfigurationSettingsModel(
             self.family = self._get_default("family")
             self.family_help_message = self._get_default("family_help_message")
             self.status_message = self._get_default("status_message")
-            self.pseudo_filename_reset_trigger += 1
 
     def _get_default(self, trait):
         if trait == "dictionary":

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -45,16 +45,9 @@ class PseudosConfigurationSettingsPanel(
             self._on_family_change,
             "family",
         )
-
-        ipw.dlink(
-            (self._model, "cutoffs"),
-            (self._model, "ecutwfc"),
-            lambda cutoffs: max(cutoffs[0]),
-        )
-        ipw.dlink(
-            (self._model, "cutoffs"),
-            (self._model, "ecutrho"),
-            lambda cutoffs: max(cutoffs[1]),
+        self._model.observe(
+            self._on_cutoffs_change,
+            "cutoffs",
         )
 
     def render(self):
@@ -202,6 +195,11 @@ class PseudosConfigurationSettingsPanel(
         self._update_family_link()
         self._model.update_default_pseudos()
         self._model.update_default_cutoffs()
+
+    def _on_cutoffs_change(self, change):
+        cutoffs = change["new"]  # [[ecutwfc...], [ecutrho...]]
+        self._model.ecutwfc = max(cutoffs[0])
+        self._model.ecutrho = max(cutoffs[1])
 
     def _update(self, specific=""):
         if self.updated:

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -141,7 +141,9 @@ class PseudosConfigurationSettingsPanel(
                         To reset to the protocol-derived pseudopotentials, please select a functional and a family.
                     """,
             ),
-            layout=ipw.Layout(display="none"),
+            layout=ipw.Layout(
+                display="block" if self._model.show_upload_warning else "none",
+            ),
         )
 
         self.children = [

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -291,7 +291,7 @@ class PseudosConfigurationSettingsPanel(
         kinds = self._model.input_structure.kinds if self._model.input_structure else []
 
         for index, kind in enumerate(kinds):
-            upload_widget = PseudoUploadWidget(kind)
+            upload_widget = PseudoUploadWidget(kind.name, kind.symbol)
 
             def on_default_pseudo(
                 _=None,
@@ -370,13 +370,14 @@ class PseudoUploadWidget(ipw.VBox):
     cutoffs = tl.List(tl.Float(), [])
     uploaded = tl.Bool(False)
 
-    def __init__(self, kind, **kwargs):
+    def __init__(self, kind_name, kind_symbol, **kwargs):
         super().__init__(
             children=[LoadingWidget("Loading pseudopotential uploader")],
             **kwargs,
         )
 
-        self.kind = kind
+        self.kind_name = kind_name
+        self.kind_symbol = kind_symbol
 
         self.rendered = False
 
@@ -385,7 +386,7 @@ class PseudoUploadWidget(ipw.VBox):
             return
 
         self.pseudo_text = ipw.Text(
-            description=self.kind.name,
+            description=self.kind_name,
             style={"description_width": "50px"},
         )
         pseudo_link = ipw.dlink(
@@ -458,10 +459,10 @@ class PseudoUploadWidget(ipw.VBox):
             return
 
         # Wrong element
-        if uploaded_pseudo.element != self.kind.symbol:
+        if uploaded_pseudo.element != self.kind_symbol:
             self.message_box.message = _PSEUDO_ALERT_TEMPLATE.format(
                 alert_type="danger",
-                message=f"Pseudo element {uploaded_pseudo.element} does not match {self.kind.symbol}",
+                message=f"Pseudo element {uploaded_pseudo.element} does not match {self.kind_symbol}",
             )
             self._reset_uploader()
             return
@@ -514,7 +515,7 @@ class PseudoUploadWidget(ipw.VBox):
             cutoff_dict = pseudo_family.get_cutoffs()
             cutoff = {
                 key: U.Quantity(v, current_unit).to("Ry").to_tuple()[0]
-                for key, v in cutoff_dict.get(self.kind.symbol, {}).items()
+                for key, v in cutoff_dict.get(self.kind_symbol, {}).items()
             }
             cutoffs = [
                 cutoff.get("cutoff_wfc", 0.0),

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -134,12 +134,22 @@ class PseudosConfigurationSettingsPanel(
             value=_PSEUDO_ALERT_TEMPLATE.format(
                 alert_type="warning",
                 message="""
-                        You have uploaded a custom pseudopotential.
-                        <br>
-                        <b>Please make sure to use the same functional for all pseudopotentials.</b>
-                        <br>
-                        To reset to the protocol-derived pseudopotentials, please select a functional and a family.
-                    """,
+                    ⚠️ You have uploaded a pseudopotential ⚠️
+                    <br>
+                    <br>
+                    <b>Please make sure to use the same Quantum ESPRESSO supported
+                    exchange-correlation functional for all pseudopotentials.</b>
+                    <br>
+                    <b>If including spin-orbit coupling (SOC) effects, make sure to
+                    upload a fully relativistic pseudopotential.</b>
+                    <br>
+                    <b>Finally, remember to adjust the plane-wave cutoff energy to
+                    ensure convergence.</b>
+                    <br>
+                    <br>
+                    To reset to the protocol-derived pseudopotentials, please select
+                    an exchange-correlation functional and a pseudopotential family.
+                """,
             ),
             layout=ipw.Layout(
                 display="block" if self._model.show_upload_warning else "none",

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -45,10 +45,6 @@ class PseudosConfigurationSettingsPanel(
             self._on_family_change,
             "family",
         )
-        self._model.observe(
-            self._on_reset_trigger_change,
-            "pseudo_filename_reset_trigger",
-        )
 
         ipw.dlink(
             (self._model, "cutoffs"),
@@ -207,13 +203,6 @@ class PseudosConfigurationSettingsPanel(
         self._model.update_default_pseudos()
         self._model.update_default_cutoffs()
 
-    def _on_reset_trigger_change(self, _):
-        if not self.rendered:
-            return
-        upload_widget: PseudoUploadWidget
-        for upload_widget in self.setter_widget.children:
-            upload_widget.reset_pseudo_filename_widget()
-
     def _update(self, specific=""):
         if self.updated:
             return
@@ -365,9 +354,6 @@ class PseudoUploadWidget(ipw.HBox):
         ]
 
         self.rendered = True
-
-    def reset_pseudo_filename_widget(self):
-        self.pseudo_text.value = self.pseudo.filename if self.pseudo else ""
 
     def _on_file_upload(self, change=None):
         """When file upload button is pressed."""

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -528,17 +528,31 @@ class PseudoUploadWidget(ipw.VBox):
                 cutoff.get("cutoff_rho", 0.0),
             ]
         else:
-            with uploaded_pseudo.as_path() as pseudo_path:
-                upf_dict = UPFDict.from_upf(pseudo_path.as_posix())
-            cutoffs = [
-                float(int(upf_dict["header"].get("wfc_cutoff", 0))),
-                float(int(upf_dict["header"].get("rho_cutoff", 0))),
-            ]
+            try:
+                with uploaded_pseudo.as_path() as pseudo_path:
+                    upf_dict = UPFDict.from_upf(pseudo_path.as_posix())
+                cutoffs = [
+                    float(int(upf_dict.get("header", {}).get("wfc_cutoff", 0))),
+                    float(int(upf_dict.get("header", {}).get("rho_cutoff", 0))),
+                ]
+            except ValueError:
+                self.message = _PSEUDO_ALERT_TEMPLATE.format(
+                    alert_type="danger",
+                    message="Failed to parse cutoffs from UPF file",
+                )
+                self._reset_uploader()
+                return
+            except Exception:
+                self.message = _PSEUDO_ALERT_TEMPLATE.format(
+                    alert_type="danger",
+                    message="Failed to read/parse UPF file",
+                )
+                self._reset_uploader()
+                return
 
         self.cutoffs = cutoffs
-
-        self.message = message
         self.pseudo = uploaded_pseudo
+        self.message = message
         self.uploaded = True
         self._reset_uploader()
 

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -369,6 +369,7 @@ class PseudoUploadWidget(ipw.VBox):
     pseudo = tl.Instance(UpfData, allow_none=True)
     cutoffs = tl.List(tl.Float(), [])
     uploaded = tl.Bool(False)
+    message = tl.Unicode(allow_none=True)
 
     def __init__(self, kind_name, kind_symbol, **kwargs):
         super().__init__(
@@ -426,6 +427,10 @@ class PseudoUploadWidget(ipw.VBox):
         ]
 
         self.message_box = StatusHTML(clear_after=5)
+        ipw.link(
+            (self, "message"),
+            (self.message_box, "message"),
+        )
 
         self.pseudo_row = ipw.HBox(
             children=[
@@ -452,15 +457,16 @@ class PseudoUploadWidget(ipw.VBox):
         try:
             uploaded_pseudo = UpfData(io.BytesIO(content), filename=filename)
         except Exception:
-            self.message_box.message = _PSEUDO_ALERT_TEMPLATE.format(
+            self.message = _PSEUDO_ALERT_TEMPLATE.format(
                 alert_type="danger",
                 message=f"{filename} is not a valid UPF file",
             )
+            self._reset_uploader()
             return
 
         # Wrong element
         if uploaded_pseudo.element != self.kind_symbol:
-            self.message_box.message = _PSEUDO_ALERT_TEMPLATE.format(
+            self.message = _PSEUDO_ALERT_TEMPLATE.format(
                 alert_type="danger",
                 message=f"Pseudo element {uploaded_pseudo.element} does not match {self.kind_symbol}",
             )
@@ -491,7 +497,7 @@ class PseudoUploadWidget(ipw.VBox):
             )
             .count()
         ):
-            self.message_box.message = _PSEUDO_ALERT_TEMPLATE.format(
+            self.message = _PSEUDO_ALERT_TEMPLATE.format(
                 alert_type="warning",
                 message=f"""
                     {filename} found in database with different content.
@@ -531,7 +537,7 @@ class PseudoUploadWidget(ipw.VBox):
 
         self.cutoffs = cutoffs
 
-        self.message_box.message = message
+        self.message = message
         self.pseudo = uploaded_pseudo
         self.uploaded = True
         self._reset_uploader()

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -238,10 +238,10 @@ class WorkChainSummaryModel(ResultsComponentModel):
                 "url": None,
                 "value": "custom",
             }
-        report["advanced_settings"]["pseudos"] = "<br>".join(
+        report["advanced_settings"]["pseudos"] = [
             f"<b>{kind}:</b> {(pp := orm.load_node(pp_uuid)).filename} (PK={pp.pk})"
             for kind, pp_uuid in advanced.get("pw", {}).get("pseudos", {}).items()
-        )
+        ]
 
         # Extract the pw calculation parameters from the ui_parameters
         pw_parameters = ui_parameters["advanced"].get("pw", {}).get("parameters", {})

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -87,17 +87,17 @@ class WorkChainSummaryModel(ResultsComponentModel):
             "All calculations are performed within the density-functional "
             "theory formalism as implemented in the Quantum ESPRESSO code. "
             "The pseudopotential for each element is extracted from the "
-            f'{report_dict["Pseudopotential library"][0]} '
+            f"{report_dict['Pseudopotential library'][0]} "
             "library. The wave functions "
             "of the valence electrons are expanded in a plane wave basis set, using an "
             "energy cutoff equal to "
-            f'{round(report_dict["Plane wave energy cutoff (wave functions)"][0])} Ry '
+            f"{round(report_dict['Plane wave energy cutoff (wave functions)'][0])} Ry "
             "for the wave functions and "
-            f'{round(report_dict["Plane wave energy cutoff (charge density)"][0])} Ry '
+            f"{round(report_dict['Plane wave energy cutoff (charge density)'][0])} Ry "
             "for the charge density and potential. "
             "The exchange-correlation energy is "
             "calculated using the "
-            f'{FUNCTIONAL_REPORT_MAP[report_dict["Functional"][0]]}. '
+            f"{FUNCTIONAL_REPORT_MAP[report_dict['Functional'][0]]}. "
             "A Monkhorst-Pack mesh is used for sampling the Brillouin zone, where the "
             "distance between the k-points is set to "
         )
@@ -210,25 +210,34 @@ class WorkChainSummaryModel(ResultsComponentModel):
             "advanced_settings": {},
         }
 
-        pseudo_family = advanced.get("pseudo_family")
-        pseudo_family_info = pseudo_family.split("/")
-        pseudo_library = pseudo_family_info[0]
-        pseudo_version = pseudo_family_info[1]
-        functional = pseudo_family_info[2]
-        if pseudo_library == "SSSP":
-            pseudo_protocol = pseudo_family_info[3]
-        elif pseudo_library == "PseudoDojo":
-            pseudo_protocol = pseudo_family_info[4]
-        report["advanced_settings"] |= {
-            "functional": {
-                "url": FUNCTIONAL_LINK_MAP[functional],
-                "value": functional,
-            },
-            "pseudo_library": {
-                "url": PSEUDO_LINK_MAP[pseudo_library],
-                "value": f"{pseudo_library} {pseudo_protocol} v{pseudo_version}",
-            },
-        }
+        if pseudo_family := advanced.get("pseudo_family"):
+            pseudo_family_info = pseudo_family.split("/")
+            pseudo_library = pseudo_family_info[0]
+            pseudo_version = pseudo_family_info[1]
+            functional = pseudo_family_info[2]
+            if pseudo_library == "SSSP":
+                pseudo_protocol = pseudo_family_info[3]
+            elif pseudo_library == "PseudoDojo":
+                pseudo_protocol = pseudo_family_info[4]
+            report["advanced_settings"] |= {
+                "functional": {
+                    "url": FUNCTIONAL_LINK_MAP[functional],
+                    "value": functional,
+                },
+                "pseudo_library": {
+                    "url": PSEUDO_LINK_MAP[pseudo_library],
+                    "value": f"{pseudo_library} {pseudo_protocol} v{pseudo_version}",
+                },
+            }
+        else:
+            report["advanced_settings"]["functional"] = {
+                "url": None,
+                "value": "custom",
+            }
+            report["advanced_settings"]["pseudo_library"] = {
+                "url": None,
+                "value": "custom",
+            }
         report["advanced_settings"]["pseudos"] = "<br>".join(
             f"<b>{kind}:</b> {(pp := orm.load_node(pp_uuid)).filename} (PK={pp.pk})"
             for kind, pp_uuid in advanced.get("pw", {}).get("pseudos", {}).items()

--- a/src/aiidalab_qe/app/result/components/summary/schema.json
+++ b/src/aiidalab_qe/app/result/components/summary/schema.json
@@ -106,7 +106,7 @@
   },
   "pseudos": {
     "title": "Pseudopotentials",
-    "type": "text",
+    "type": "list",
     "description": "The pseudopotentials used for the calculation"
   },
   "energy_cutoff_wfc": {

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -156,3 +156,22 @@ footer {
   margin-bottom: 0;
   padding: 10px;
 }
+
+.list-no-bullets {
+  margin-bottom: 0;
+  line-height: 1.8;
+}
+
+.list-no-bullets.list-format {
+  padding-left: 16px;
+}
+
+.list-no-bullets.table-format {
+  padding: 2px 0;
+}
+
+.list-no-bullets li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -107,6 +107,11 @@
   padding: 5px 0;
 }
 
+.pseudo-warning {
+  margin-bottom: 0;
+  line-height: 140%;
+}
+
 .convergence-label {
   width: 150px;
   text-align: right;

--- a/src/aiidalab_qe/app/static/templates/workflow_summary.jinja
+++ b/src/aiidalab_qe/app/static/templates/workflow_summary.jinja
@@ -11,7 +11,13 @@
             {{ schema[key].title }}
           </td>
           <td class="value">
-            {% if schema[key].type == "link" %}
+            {% if schema[key].type == "list" %}
+            <ul class="list-no-bullets {{format}}-format">
+              {% for item in value %}
+                <li>{{ item }}</li>
+              {% endfor %}
+            </ul>
+            {% elif schema[key].type == "link" %}
               {% if value.url %}
               <a class="link" href="{{ value.url }}" target="_blank">
                 {{ value.value }}

--- a/src/aiidalab_qe/app/static/templates/workflow_summary.jinja
+++ b/src/aiidalab_qe/app/static/templates/workflow_summary.jinja
@@ -12,9 +12,13 @@
           </td>
           <td class="value">
             {% if schema[key].type == "link" %}
-            <a class="link" href="{{ value.url }}" target="_blank">
+              {% if value.url %}
+              <a class="link" href="{{ value.url }}" target="_blank">
+                {{ value.value }}
+              </a>
+              {% else %}
               {{ value.value }}
-            </a>
+              {% endif %}
             {% else %}
             {{ value }}
             {% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ ELEMENTS = [
     "Si",
     "Co",
     "Mo",
+    "Ni",
 ]
 
 
@@ -308,11 +309,11 @@ def pseudodojo(generate_upf_data_for_session):
 def generate_upf_data():
     """Return a `UpfData` instance for the given element a file for which should exist in `tests/fixtures/pseudos`."""
 
-    def _generate_upf_data(element, filename=None, perturb=False):
+    def _generate_upf_data(element, filename=None, z_valence=4):
         """Return `UpfData` node."""
         from aiida_pseudo.data.pseudo import UpfData
 
-        z_valence = 5.0 if perturb else 4.0
+        z_valence = str(float(z_valence))
         content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="{z_valence}"\n/></UPF>\n'
         stream = io.BytesIO(content.encode("utf-8"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,11 +308,12 @@ def pseudodojo(generate_upf_data_for_session):
 def generate_upf_data():
     """Return a `UpfData` instance for the given element a file for which should exist in `tests/fixtures/pseudos`."""
 
-    def _generate_upf_data(element, filename=None):
+    def _generate_upf_data(element, filename=None, perturb=False):
         """Return `UpfData` node."""
         from aiida_pseudo.data.pseudo import UpfData
 
-        content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="4.0"\n/></UPF>\n'
+        z_valence = 5.0 if perturb else 4.0
+        content = f'<UPF version="2.0.1"><PP_HEADER\nelement="{element}"\nz_valence="{z_valence}"\n/></UPF>\n'
         stream = io.BytesIO(content.encode("utf-8"))
 
         if filename is None:

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -211,7 +211,7 @@ def test_pseudos_settings(generate_structure_data, generate_upf_data):
 
     # Test reset from uploaded state
     uploader: PseudoUploadWidget = pseudos.setter_widget.children[1]
-    new_O_pseudo = generate_upf_data("O", "O_new.upf", perturb=True)
+    new_O_pseudo = generate_upf_data("O", "O_new.upf", z_valence=5)
     uploader._on_file_upload(
         {
             "new": {
@@ -290,7 +290,7 @@ def test_pseudo_upload_widget(generate_upf_data):
     assert "Identical pseudo" in w.message
 
     # Check different content but same filename is rejected
-    different_content_same_filename = generate_upf_data("O", "O.upf", perturb=True)
+    different_content_same_filename = generate_upf_data("O", "O.upf", z_valence=6)
     w._on_file_upload(
         {
             "new": {
@@ -319,11 +319,11 @@ def test_pseudo_upload_widget(generate_upf_data):
     assert "not a valid UPF file" in w.message
 
     # Check valid pseudo is accepted
-    valid = generate_upf_data("O", "O_new.upf", perturb=True)
+    valid = generate_upf_data("O", "O_valid.upf", z_valence=7)
     w._on_file_upload(
         {
             "new": {
-                "O_new.upf": {
+                "O_valid.upf": {
                     "content": bytes(
                         valid.get_content(),
                         encoding="utf-8",
@@ -332,5 +332,5 @@ def test_pseudo_upload_widget(generate_upf_data):
             },
         }
     )
-    assert w.pseudo.filename == "O_new.upf"
+    assert w.pseudo.filename == "O_valid.upf"
     assert "uploaded successfully" in w.message

--- a/tests/test_result/test_summary_report.yml
+++ b/tests/test_result/test_summary_report.yml
@@ -11,7 +11,8 @@ advanced_settings:
   pseudo_library:
     url: https://www.materialscloud.org/discover/sssp/table/efficiency
     value: SSSP efficiency v1.3
-  pseudos: <b>Si:</b> Si.upf (PK=4)
+  pseudos:
+  - <b>Si:</b> Si.upf (PK=4)
   scf_kpoints_distance: 0.3 Å<sup>-1</sup>
   smearing: cold
   spin_orbit: 'off'

--- a/tests/test_result/test_summary_report.yml
+++ b/tests/test_result/test_summary_report.yml
@@ -11,7 +11,7 @@ advanced_settings:
   pseudo_library:
     url: https://www.materialscloud.org/discover/sssp/table/efficiency
     value: SSSP efficiency v1.3
-  pseudos: <b>Si:</b> Si.upf (PK=3)
+  pseudos: <b>Si:</b> Si.upf (PK=4)
   scf_kpoints_distance: 0.3 Å<sup>-1</sup>
   smearing: cold
   spin_orbit: 'off'


### PR DESCRIPTION
Motivated by #1299

This PR aims to make the pseudopotential uploaders compatible with the various changes that came after its initial implementation.

### Logic
- **Rejected uploads** (accompanied by a dedicated notification for each)
  - Cases 
    - Invalid UPF
    - Wrong element
    - Valid upload that shares a filename with an existing one (in the DB)
  - Behavior
    - No change to the UI/model
- **Accepted uploads** (again, with clear notifications)
  - Cases
    - Identical md5 (replaces upload with existing entry from DB)
    - Valid upload
  - Behavior
    - Set functional/library/family to `None`
    - Show permanent warning regarding the custom state, the need for functional consistency, and how to reset to defaults
 
### Comments
- In all cases, cutoffs remain consistent (i.e., max across all pseudos, regardless if custom or default)
- For custom pseudos that do not belong to a family, we use [upf-tools](https://github.com/pseudopotential-tools/upf-tools) to parse the UPF file and extract the relevant info
- As long as uploading was successful, we go into a custom state (even if the upload defaulted to a built-in pseudo - rare!)

### Included changes to magnetization settings
The magnetization panel was dependent on the pseudo family to extract Z values for magnetization-to-moment conversion. To support custom pseudos (family set to `None`), the dependency was replaced by one on the pseudos dictionary. In the conversion process, Z values are now extracted from the `UpfData` node associated with the UUID in the dictionary, which supports successfully uploaded custom pseudos. Pinging @t-reents due to #1252 to particularly have a look at this part 🙏

### Regarding functional consistency
Ideally, we would do better than just inform the user of this need. Unfortunately, functional information is not consistently provided. For example, the functional entry in the built-in `` pseudo is `Functional:  SLA  PW   PSX  PSC`, which is the template, i.e., the pseudopotential author did not bother to change it. For this reason, there is no consistent information we can rely on to determine a given pseudo's functional. Suggestions welcomed 🙏 Pinging @giovannipizzi 

Note that we would ideally want this to prevent calculations from crashing due to the inconsistency. This is also true across plugins, e.g., core-hole potentials for XPS/XAS. We have a system of blockers in place, just no reliable information to act on 🥲 Pinging @superstar54

### Dependencies
- [upf-tools](https://github.com/pseudopotential-tools/upf-tools) for handling custom pseudos
- `aiida-quantumespresso` plugin - to support custom pseudos (no family), the plugin can no longer rely on the presence of a pseudo family. This is done in this [PR](https://github.com/aiidateam/aiida-quantumespresso/pull/1100). Once merged and a new release is made, this PR will be updated with the dependency version bump.