### PR TITLE
Pin `aiida-hyperqueue` version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ ARG HQ_URL_AMD64="https://github.com/It4innovations/hyperqueue/releases/download
 ARG HQ_URL_ARM64="https://github.com/It4innovations/hyperqueue/releases/download/v${HQ_VER}/hq-v${HQ_VER}-linux-arm64-linux.tar.gz"
 ARG VIBROSCOPY_PKG="aiidalab-qe-vibroscopy@git+https://github.com/mikibonacci/aiidalab-qe-vibroscopy@v1.2.0"
 ARG MUON_PKG="aiidalab-qe-muon@git+https://github.com/mikibonacci/aiidalab-qe-muon@v1.0.0"
-ARG AIIDA_HQ_PKG="aiida-hyperqueue@git+https://github.com/aiidateam/aiida-hyperqueue"
+# aiida-hyperqueue 0.3.0 need aiida-core >=2.7, so we pin it to 0.2.1
+ARG AIIDA_HQ_PKG="aiida-hyperqueue==0.2.1"
 
 ###############################################################################
 # 2) uv stage (unchanged)
@@ -110,7 +111,6 @@ RUN mkdir -p ${PSEUDO_FOLDER} && \
 
 ENV UV_CONSTRAINT=${PIP_CONSTRAINT}
 # Install the aiida-hyperqueue
-# XXX: fix me after release aiida-hyperqueue
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \
     uv pip install --system --strict --cache-dir=${UV_CACHE_DIR} ${AIIDA_HQ_PKG}
@@ -170,7 +170,6 @@ WORKDIR /tmp
 # Install python dependencies
 # Use uv cache from the previous build step
 # # Install the aiida-hyperqueue
-# # XXX: fix me after release aiida-hyperqueue
 ENV UV_CONSTRAINT=${PIP_CONSTRAINT}
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=from=build_deps,source=${UV_CACHE_DIR},target=${UV_CACHE_DIR},rw \


### PR DESCRIPTION
`aiida-hyperqueue` 0.3.0 is released, but it needs aiida-core >=2.7, so we pin it to 0.2.1 in the current Dockerfile.

This fixes the failed tests `build-test` as shown here: https://github.com/aiidalab/aiidalab-qe/actions/runs/16493448398/job/46634450814?pr=1343
