### PR TITLE
Feature Mixing mode controls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.12.0
+    aiida-quantumespresso~=4.12.1
     aiidalab-widgets-base[optimade] @ git+https://github.com/aiidalab/aiidalab-widgets-base@master
     aiida-pseudo~=1.4
     filelock~=3.8

--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -235,6 +235,31 @@ class AdvancedConfigurationSettingsPanel(
             (self._model, "optimization_maxsteps"),
             (self.optimization_maxsteps, "value"),
         )
+
+        self.mixing_mode = ipw.Dropdown(
+            description="Mixing mode:",
+            style={"description_width": "150px"},
+        )
+        ipw.dlink(
+            (self._model, "mixing_mode_options"),
+            (self.mixing_mode, "options"),
+        )
+        ipw.link(
+            (self._model, "mixing_mode"),
+            (self.mixing_mode, "value"),
+        )
+
+        self.mixing_beta = ipw.BoundedFloatText(
+            min=0.1,
+            max=1.0,
+            step=0.01,
+            description="Mixing beta:",
+            style={"description_width": "150px"},
+        )
+        ipw.link(
+            (self._model, "mixing_beta"),
+            (self.mixing_beta, "value"),
+        )
         self.pseudos.render()
 
         num_atoms = len(self._model.input_structure.sites)
@@ -291,6 +316,15 @@ class AdvancedConfigurationSettingsPanel(
             """),
             self.electron_maxstep,
             self.optimization_maxsteps,
+            ipw.HTML("<h4>Mixing mode</h4>"),
+            ipw.HTML("""
+                <div style="line-height: 1.4; margin-bottom: 5px;">
+                    The mixing mode determines how the charge density is updated during
+                    the SCF cycles.
+                </div>
+            """),
+            self.mixing_mode,
+            self.mixing_beta,
             self.smearing,
             ipw.HTML("<h2>K-points</h2>"),
             ipw.HTML("""

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -130,7 +130,9 @@ class AdvancedConfigurationSettingsModel(
 
         # Only modify if mixing mode is different than default
         if self.mixing_mode != "plain":
-            parameters["pw"]["parameters"]["SYSTEM"]["mixing_mode"] = self.mixing_mode
+            parameters["pw"]["parameters"]["ELECTRONS"]["mixing_mode"] = (
+                self.mixing_mode
+            )
         hubbard: HubbardConfigurationSettingsModel = self.get_model("hubbard")  # type: ignore
         if hubbard.is_active:
             parameters["hubbard_parameters"] = {
@@ -337,7 +339,7 @@ class AdvancedConfigurationSettingsModel(
         self.scf_conv_thr = electron_params.get("conv_thr", 0.0) / num_atoms
         self.electron_maxstep = electron_params.get("electron_maxstep", 80)
 
-        self.mixing_mode = system_params.get("mixing_mode", "plain")
+        self.mixing_mode = electron_params.get("mixing_mode", "plain")
         self.mixing_beta = electron_params.get("mixing_beta", 0.4)
 
         self.total_charge = system_params.get("tot_charge", 0)

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -83,6 +83,17 @@ class AdvancedConfigurationSettingsModel(
         "dft-d3mbj": 6,
     }
 
+    mixing_mode_options = tl.List(
+        trait=tl.Unicode(),
+        default_value=[
+            "plain",
+            "TF",
+            "local-TF",
+        ],
+    )
+    mixing_mode = tl.Unicode("plain")
+    mixing_beta = tl.Float(0.4)
+
     def update(self, specific=""):
         with self.hold_trait_notifications():
             if not specific or specific != "mesh":
@@ -108,6 +119,7 @@ class AdvancedConfigurationSettingsModel(
                     "ELECTRONS": {
                         "conv_thr": self.scf_conv_thr * num_atoms,
                         "electron_maxstep": self.electron_maxstep,
+                        "mixing_beta": self.mixing_beta,
                     },
                 }
             },
@@ -116,6 +128,9 @@ class AdvancedConfigurationSettingsModel(
             "optimization_maxsteps": self.optimization_maxsteps,
         }
 
+        # Only modify if mixing mode is different than default
+        if self.mixing_mode != "plain":
+            parameters["pw"]["parameters"]["SYSTEM"]["mixing_mode"] = self.mixing_mode
         hubbard: HubbardConfigurationSettingsModel = self.get_model("hubbard")  # type: ignore
         if hubbard.is_active:
             parameters["hubbard_parameters"] = {
@@ -248,6 +263,8 @@ class AdvancedConfigurationSettingsModel(
             self.electron_maxstep = self._get_default("electron_maxstep")
             self.kpoints_distance = self._get_default("kpoints_distance")
             self.optimization_maxsteps = self._get_default("optimization_maxsteps")
+            self.mixing_mode = self._get_default("mixing_mode")
+            self.mixing_beta = self._get_default("mixing_beta")
 
     def _get_default(self, trait):
         return self._defaults.get(trait, self.traits()[trait].default_value)
@@ -319,6 +336,9 @@ class AdvancedConfigurationSettingsModel(
         self.etot_conv_thr = control_params.get("etot_conv_thr", 0.0) / num_atoms
         self.scf_conv_thr = electron_params.get("conv_thr", 0.0) / num_atoms
         self.electron_maxstep = electron_params.get("electron_maxstep", 80)
+
+        self.mixing_mode = system_params.get("mixing_mode", "plain")
+        self.mixing_beta = electron_params.get("mixing_beta", 0.4)
 
         self.total_charge = system_params.get("tot_charge", 0)
         self.spin_orbit = "soc" if "lspinorb" in system_params else "wo_soc"

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -12,6 +12,7 @@ advanced:
       ELECTRONS:
         conv_thr: 4.0e-10
         electron_maxstep: 80
+        mixing_beta: 0.4
       SYSTEM:
         degauss: 0.015
         ecutrho: 240.0


### PR DESCRIPTION
Some inhomogeneous systems may fail to converge with the default Broyden mixing scheme. In such cases, adjusting the mixing_beta parameter or selecting an alternative mixing mode can be essential. Expert users who tune these settings appropriately can often achieve significantly faster and more reliable convergence.

Closes #1357 

Where the user was not able to converge its system.


The PR includes two controls in the advanced settings for the mixing beta and the mixing mode: 

<img width="1134" height="306" alt="image" src="https://github.com/user-attachments/assets/897916c6-cd39-453f-84a3-20c8f224568f" />


Mixing beta is by default 0.4 in aiida-quantumespresso , and if failure it starts reducing it 
Mixing mode is plain by default as well as in aiida-quantumespresso 
