### PR TITLE
Discard local `LoadingWidget` in favor of AWB

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/subsettings.py
+++ b/src/aiidalab_qe/app/configuration/advanced/subsettings.py
@@ -6,6 +6,7 @@ import traitlets as tl
 
 from aiidalab_qe.common.mixins import HasBlockers
 from aiidalab_qe.common.mvc import Model
+from aiidalab_widgets_base import LoadingWidget
 
 
 class AdvancedCalculationSubSettingsModel(
@@ -41,8 +42,6 @@ M = t.TypeVar("M", bound=AdvancedCalculationSubSettingsModel)
 
 class AdvancedConfigurationSubSettingsPanel(ipw.VBox, t.Generic[M]):
     def __init__(self, model: M, **kwargs):
-        from aiidalab_qe.common.widgets import LoadingWidget
-
         self.loading_message = LoadingWidget(f"Loading {model.identifier} settings")
 
         super().__init__(

--- a/src/aiidalab_qe/app/result/__init__.py
+++ b/src/aiidalab_qe/app/result/__init__.py
@@ -4,9 +4,8 @@ import traitlets as tl
 from aiida.engine import ProcessState
 from aiidalab_qe.common.infobox import InAppGuide
 from aiidalab_qe.common.process import STATE_ICONS
-from aiidalab_qe.common.widgets import LoadingWidget
 from aiidalab_qe.common.wizard import QeDependentWizardStep
-from aiidalab_widgets_base import ProcessMonitor, WizardAppWidgetStep
+from aiidalab_widgets_base import LoadingWidget, ProcessMonitor, WizardAppWidgetStep
 
 from .components import ResultsComponent
 from .components.status import WorkChainStatusModel, WorkChainStatusPanel

--- a/src/aiidalab_qe/app/result/components/__init__.py
+++ b/src/aiidalab_qe/app/result/components/__init__.py
@@ -4,7 +4,7 @@ import ipywidgets as ipw
 
 from aiidalab_qe.common.mixins import HasProcess
 from aiidalab_qe.common.mvc import Model
-from aiidalab_qe.common.widgets import LoadingWidget
+from aiidalab_widgets_base import LoadingWidget
 
 
 class ResultsComponentModel(Model, HasProcess):

--- a/src/aiidalab_qe/app/utils/calculation_history.py
+++ b/src/aiidalab_qe/app/utils/calculation_history.py
@@ -5,7 +5,7 @@ from table_widget import TableWidget
 
 from aiida.orm import QueryBuilder, load_node
 from aiidalab_qe.common.process import STATE_ICONS
-from aiidalab_qe.common.widgets import LoadingWidget
+from aiidalab_widgets_base import LoadingWidget
 
 
 def determine_state_icon(row):

--- a/src/aiidalab_qe/app/wizard_app.py
+++ b/src/aiidalab_qe/app/wizard_app.py
@@ -13,9 +13,8 @@ from aiidalab_qe.app.structure.model import StructureStepModel
 from aiidalab_qe.app.submission import SubmitQeAppWorkChainStep
 from aiidalab_qe.app.submission.model import SubmissionStepModel
 from aiidalab_qe.common.infobox import InAppGuide
-from aiidalab_qe.common.widgets import LoadingWidget
 from aiidalab_qe.common.wizard import QeWizardStep
-from aiidalab_widgets_base import WizardAppWidget
+from aiidalab_widgets_base import LoadingWidget, WizardAppWidget
 
 
 class WizardApp(ipw.VBox):

--- a/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
+++ b/src/aiidalab_qe/common/bands_pdos/bandpdoswidget.py
@@ -1,6 +1,6 @@
 import ipywidgets as ipw
 
-from aiidalab_qe.common.widgets import LoadingWidget
+from aiidalab_widgets_base import LoadingWidget
 from aiidalab_widgets_base.utils import StatusHTML, string_range_to_list
 
 from .model import BandsPdosModel

--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -14,7 +14,7 @@ from aiida.tools.graph.graph_traversers import traverse_graph
 from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_qe.common.mixins import HasProcess
 from aiidalab_qe.common.mvc import Model
-from aiidalab_qe.common.widgets import LoadingWidget
+from aiidalab_widgets_base import LoadingWidget
 
 from .state import STATE_ICONS
 

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -5,6 +5,7 @@ Authors: AiiDAlab team
 
 import base64
 import hashlib
+import warnings
 from copy import deepcopy
 from queue import Queue
 from tempfile import NamedTemporaryFile
@@ -22,10 +23,8 @@ from shakenbreak.distortions import distort, local_mc_rattle, rattle
 
 from aiida.orm import CalcJobNode, load_code, load_node
 from aiida.orm import Data as orm_Data
-from aiidalab_widgets_base import (
-    ComputationalResourcesWidget,
-    StructureExamplesWidget,
-)
+from aiidalab_widgets_base import ComputationalResourcesWidget, StructureExamplesWidget
+from aiidalab_widgets_base import LoadingWidget as _LoadingWidget
 from aiidalab_widgets_base.utils import (
     StatusHTML,
     list_to_string_range,
@@ -967,27 +966,15 @@ class PwCodeResourceSetupWidget(QEAppComputationalResourcesWidget):
             self.set_parallelization(parameters["parallelization"])
 
 
-class LoadingWidget(ipw.HBox):
-    """Widget for displaying a loading spinner."""
-
-    def __init__(self, message="Loading", **kwargs):
-        self.message = ipw.Label(message)
-        super().__init__(
-            children=[
-                ipw.Label(message),
-                ipw.HTML(
-                    value="<i class='fa fa-spinner fa-spin fa-2x fa-fw'/>",
-                    layout=ipw.Layout(margin="12px 0 6px"),
-                ),
-            ],
-            layout=ipw.Layout(
-                justify_content="center",
-                align_items="center",
-                **kwargs.pop("layout", {}),
-            ),
-            **kwargs,
+class LoadingWidget(_LoadingWidget):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "`LoadingWidget` has moved to `aiidalab-widgets-base` and will be "
+            "deprecated here in the next major release. Please update your imports.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        self.add_class("loading")
+        super().__init__(*args, **kwargs)
 
 
 class LazyLoader(ipw.VBox):

--- a/src/aiidalab_qe/plugins/electronic_structure/result/result.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/result/result.py
@@ -4,7 +4,7 @@ import ipywidgets as ipw
 
 from aiidalab_qe.common.bands_pdos import BandsPdosModel, BandsPdosWidget
 from aiidalab_qe.common.panel import ResultsPanel
-from aiidalab_qe.common.widgets import LoadingWidget
+from aiidalab_widgets_base import LoadingWidget
 
 from .model import ElectronicStructureResultsModel
 


### PR DESCRIPTION
Based on #1362 

The `LoadingWidget` moved to AWB in https://github.com/aiidalab/aiidalab-widgets-base/pull/685. This PR discards the widget in this repo and points all imports to AWB.