### PR TITLE
Split advanced settings into tabs

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -7,7 +7,6 @@ import ipywidgets as ipw
 
 from aiidalab_qe.common.infobox import InAppGuide
 from aiidalab_qe.common.panel import ConfigurationSettingsPanel
-from aiidalab_qe.common.widgets import HBoxWithUnits
 
 from .convergence import (
     ConvergenceConfigurationSettingsModel,
@@ -43,20 +42,8 @@ class AdvancedConfigurationSettingsPanel(
         )
 
         self._model.observe(
-            self._on_input_structure_change,
-            "input_structure",
-        )
-        self._model.observe(
-            self._on_protocol_change,
-            "protocol",
-        )
-        self._model.observe(
             self._on_spin_type_change,
             "spin_type",
-        )
-        self._model.observe(
-            self._on_kpoints_distance_change,
-            "kpoints_distance",
         )
 
         convergence_model = ConvergenceConfigurationSettingsModel()
@@ -140,35 +127,6 @@ class AdvancedConfigurationSettingsPanel(
             (self.van_der_waals, "value"),
         )
 
-        # Kpoints setting
-        self.kpoints_distance = ipw.BoundedFloatText(
-            min=0.0,
-            step=0.05,
-            description="K-points distance:",
-            style={"description_width": "150px"},
-        )
-        ipw.link(
-            (self._model, "kpoints_distance"),
-            (self.kpoints_distance, "value"),
-        )
-        ipw.dlink(
-            (self._model, "input_structure"),
-            (self.kpoints_distance, "disabled"),
-            lambda _: not self._model.has_pbc,
-        )
-        self.mesh_grid = ipw.HTML(layout=ipw.Layout(margin="0 0 0 10px"))
-        ipw.dlink(
-            (self._model, "mesh_grid"),
-            (self.mesh_grid, "value"),
-        )
-        kpoint_row = ipw.HBox(
-            children=[
-                HBoxWithUnits(self.kpoints_distance, "Å<sup>-1</sup>"),
-                self.mesh_grid,
-            ],
-            layout=ipw.Layout(align_items="center"),
-        )
-
         self.advanced_tabs = ipw.Tab()
         self.advanced_tabs.observe(
             self._on_advanced_tab_change,
@@ -181,18 +139,7 @@ class AdvancedConfigurationSettingsPanel(
             self.clean_workdir,
             self.total_charge,
             self.van_der_waals,
-            kpoint_row,
-            ipw.HTML("""
-                <div style="line-height: 1.4; margin-bottom: 5px;">
-                    The k-points mesh density of the SCF calculation is set by the
-                    <b>protocol</b>.
-                    <br>
-                    The value below represents the maximum distance between k-points
-                    in each direction of reciprocal space.
-                    <br>
-                    Smaller is more accurate and costly.
-                </div>
-            """),
+            ipw.HTML("<hr>"),
             self.advanced_tabs,
         ]
 
@@ -201,12 +148,6 @@ class AdvancedConfigurationSettingsPanel(
         self.refresh()
 
         self._update_tabs()
-
-    def _on_input_structure_change(self, _):
-        self.refresh(specific="structure")
-
-    def _on_protocol_change(self, _):
-        self.refresh(specific="protocol")
 
     def _on_spin_type_change(self, _):
         self._update_tabs()
@@ -229,9 +170,6 @@ class AdvancedConfigurationSettingsPanel(
         self.advanced_tabs.children = children
         for i, title in enumerate(titles):
             self.advanced_tabs.set_title(i, title)
-
-    def _on_kpoints_distance_change(self, _):
-        self.refresh(specific="mesh")
 
     def _on_advanced_tab_change(self, change):
         self.advanced_tabs.children[change["new"]].render()

--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -51,14 +51,13 @@ class AdvancedConfigurationSettingsPanel(
             "protocol",
         )
         self._model.observe(
+            self._on_spin_type_change,
+            "spin_type",
+        )
+        self._model.observe(
             self._on_kpoints_distance_change,
             "kpoints_distance",
         )
-
-        # NOTE connect pseudos first, as some settings depend on it
-        pseudos_model = PseudosConfigurationSettingsModel()
-        self.pseudos = PseudosConfigurationSettingsPanel(model=pseudos_model)
-        model.add_model("pseudos", pseudos_model)
 
         convergence_model = ConvergenceConfigurationSettingsModel()
         self.convergence = ConvergenceConfigurationSettingsPanel(
@@ -70,6 +69,10 @@ class AdvancedConfigurationSettingsPanel(
         self.smearing = SmearingConfigurationSettingsPanel(model=smearing_model)
         model.add_model("smearing", smearing_model)
 
+        pseudos_model = PseudosConfigurationSettingsModel()
+        self.pseudos = PseudosConfigurationSettingsPanel(model=pseudos_model)
+        model.add_model("pseudos", pseudos_model)
+
         magnetization_model = MagnetizationConfigurationSettingsModel()
         self.magnetization = MagnetizationConfigurationSettingsPanel(
             model=magnetization_model,
@@ -79,6 +82,14 @@ class AdvancedConfigurationSettingsPanel(
         hubbard_model = HubbardConfigurationSettingsModel()
         self.hubbard = HubbardConfigurationSettingsPanel(model=hubbard_model)
         model.add_model("hubbard", hubbard_model)
+
+        self.sub_settings = {
+            "convergence": self.convergence,
+            "smearing": self.smearing,
+            "magnetization": self.magnetization,
+            "hubbard": self.hubbard,
+            "pseudos": self.pseudos,
+        }
 
     def render(self):
         if self.rendered:
@@ -150,12 +161,19 @@ class AdvancedConfigurationSettingsPanel(
             (self._model, "mesh_grid"),
             (self.mesh_grid, "value"),
         )
+        kpoint_row = ipw.HBox(
+            children=[
+                HBoxWithUnits(self.kpoints_distance, "Å<sup>-1</sup>"),
+                self.mesh_grid,
+            ],
+            layout=ipw.Layout(align_items="center"),
+        )
 
-        self.convergence.render()
-        self.smearing.render()
-        self.hubbard.render()
-        self.magnetization.render()
-        self.pseudos.render()
+        self.advanced_tabs = ipw.Tab()
+        self.advanced_tabs.observe(
+            self._on_advanced_tab_change,
+            "selected_index",
+        )
 
         self.children = [
             InAppGuide(identifier="advanced-settings"),
@@ -163,9 +181,7 @@ class AdvancedConfigurationSettingsPanel(
             self.clean_workdir,
             self.total_charge,
             self.van_der_waals,
-            self.convergence,
-            self.smearing,
-            ipw.HTML("<h2>K-points</h2>"),
+            kpoint_row,
             ipw.HTML("""
                 <div style="line-height: 1.4; margin-bottom: 5px;">
                     The k-points mesh density of the SCF calculation is set by the
@@ -177,21 +193,14 @@ class AdvancedConfigurationSettingsPanel(
                     Smaller is more accurate and costly.
                 </div>
             """),
-            ipw.HBox(
-                children=[
-                    HBoxWithUnits(self.kpoints_distance, "Å<sup>-1</sup>"),
-                    self.mesh_grid,
-                ],
-                layout=ipw.Layout(align_items="center"),
-            ),
-            self.magnetization,
-            self.hubbard,
-            self.pseudos,
+            self.advanced_tabs,
         ]
 
         self.rendered = True
 
         self.refresh()
+
+        self._update_tabs()
 
     def _on_input_structure_change(self, _):
         self.refresh(specific="structure")
@@ -199,8 +208,33 @@ class AdvancedConfigurationSettingsPanel(
     def _on_protocol_change(self, _):
         self.refresh(specific="protocol")
 
+    def _on_spin_type_change(self, _):
+        self._update_tabs()
+
+    def _update_tabs(self):
+        if not self.rendered:
+            return
+        children = []
+        titles = []
+        for identifier, model in self._model.get_models():
+            subsetting = self.sub_settings[identifier]
+            if identifier == "convergence":
+                subsetting.render()
+            if identifier == "magnetization":
+                if self._model.spin_type != "collinear":
+                    continue
+                subsetting.render()
+            titles.append(model.title)
+            children.append(subsetting)
+        self.advanced_tabs.children = children
+        for i, title in enumerate(titles):
+            self.advanced_tabs.set_title(i, title)
+
     def _on_kpoints_distance_change(self, _):
         self.refresh(specific="mesh")
+
+    def _on_advanced_tab_change(self, change):
+        self.advanced_tabs.children[change["new"]].render()
 
     def _on_reset_to_defaults_button_click(self, _):
         self._reset()

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
@@ -147,7 +147,6 @@ class ConvergenceConfigurationSettingsPanel(
         )
 
         self.children = [
-            ipw.HTML("<h2>Convergence</h2>"),
             self.help_message,
             ipw.HTML("<h4>Threshold for SCF cycles</h4>"),
             ipw.VBox(

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
@@ -13,6 +13,7 @@ class ConvergenceConfigurationSettingsModel(
     AdvancedCalculationSubSettingsModel,
     HasInputStructure,
 ):
+    title = "Convergence"
     identifier = "convergence"
 
     dependencies = [

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
@@ -139,6 +139,3 @@ class ConvergenceConfigurationSettingsModel(
             mesh_grid = "Please select a number higher than 0.0"
         self._defaults["mesh_grid"] = mesh_grid
         self.mesh_grid = self._get_default("mesh_grid")
-
-    def _get_default(self, trait):
-        return self._defaults.get(trait, self.traits()[trait].default_value)

--- a/src/aiidalab_qe/app/configuration/advanced/general/__init__.py
+++ b/src/aiidalab_qe/app/configuration/advanced/general/__init__.py
@@ -1,0 +1,7 @@
+from .general import GeneralConfigurationSettingsPanel
+from .model import GeneralConfigurationSettingsModel
+
+__all__ = [
+    "GeneralConfigurationSettingsModel",
+    "GeneralConfigurationSettingsPanel",
+]

--- a/src/aiidalab_qe/app/configuration/advanced/general/general.py
+++ b/src/aiidalab_qe/app/configuration/advanced/general/general.py
@@ -1,0 +1,57 @@
+import ipywidgets as ipw
+
+from ..subsettings import AdvancedConfigurationSubSettingsPanel
+from .model import GeneralConfigurationSettingsModel
+
+
+class GeneralConfigurationSettingsPanel(
+    AdvancedConfigurationSubSettingsPanel[GeneralConfigurationSettingsModel],
+):
+    def render(self):
+        if self.rendered:
+            return
+
+        self.clean_workdir = ipw.Checkbox(
+            description="Delete the work directory after the calculation",
+            indent=False,
+            layout=ipw.Layout(width="fit-content", margin="5px 2px"),
+        )
+        ipw.link(
+            (self._model, "clean_workdir"),
+            (self.clean_workdir, "value"),
+        )
+
+        # Total change setting
+        self.total_charge = ipw.BoundedFloatText(
+            min=-3,
+            max=3,
+            step=0.01,
+            description="Total charge:",
+            style={"description_width": "150px"},
+        )
+        ipw.link(
+            (self._model, "total_charge"),
+            (self.total_charge, "value"),
+        )
+
+        # Van der Waals setting
+        self.van_der_waals = ipw.Dropdown(
+            description="Van der Waals correction:",
+            style={"description_width": "150px"},
+        )
+        ipw.dlink(
+            (self._model, "van_der_waals_options"),
+            (self.van_der_waals, "options"),
+        )
+        ipw.link(
+            (self._model, "van_der_waals"),
+            (self.van_der_waals, "value"),
+        )
+
+        self.children = [
+            self.clean_workdir,
+            self.total_charge,
+            self.van_der_waals,
+        ]
+
+        self.rendered = True

--- a/src/aiidalab_qe/app/configuration/advanced/general/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/general/model.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import typing as t
+
+import traitlets as tl
+
+from aiidalab_qe.app.parameters import DEFAULT_PARAMETERS
+
+from ..subsettings import AdvancedCalculationSubSettingsModel
+
+DEFAULT = t.cast(dict, DEFAULT_PARAMETERS)
+
+
+class GeneralConfigurationSettingsModel(AdvancedCalculationSubSettingsModel):
+    title = "General"
+    identifier = "general"
+
+    clean_workdir = tl.Bool(DEFAULT["advanced"]["clean_workdir"])
+    total_charge = tl.Float(DEFAULT["advanced"]["tot_charge"])
+    van_der_waals_options = tl.List(
+        trait=tl.List(tl.Unicode()),
+        default_value=[
+            ["None", "none"],
+            ["Grimme-D3", "dft-d3"],
+            ["Grimme-D3BJ", "dft-d3bj"],
+            ["Grimme-D3M", "dft-d3m"],
+            ["Grimme-D3MBJ", "dft-d3mbj"],
+            ["Tkatchenko-Scheffler", "ts-vdw"],
+        ],
+    )
+    van_der_waals = tl.Unicode(DEFAULT["advanced"]["vdw_corr"])
+
+    dftd3_version = {
+        "dft-d3": 3,
+        "dft-d3bj": 4,
+        "dft-d3m": 5,
+        "dft-d3mbj": 6,
+    }
+
+    def reset(self):
+        with self.hold_trait_notifications():
+            self.total_charge = self._get_default("total_charge")
+            self.van_der_waals = self._get_default("van_der_waals")

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
@@ -69,7 +69,6 @@ class HubbardConfigurationSettingsPanel(
         self.container = ipw.VBox()
 
         self.children = [
-            ipw.HTML("<h2>Hubbard (DFT+U)</h2>"),
             self.activate_hubbard_checkbox,
             self.container,
         ]

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/model.py
@@ -16,6 +16,7 @@ class HubbardConfigurationSettingsModel(
     AdvancedCalculationSubSettingsModel,
     HasInputStructure,
 ):
+    title = "Hubbard (DFT+U)"
     identifier = "hubbard"
 
     dependencies = [

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -50,8 +50,6 @@ class MagnetizationConfigurationSettingsPanel(
         if self.rendered:
             return
 
-        self.header = ipw.HTML("<h2>Magnetization</h2>")
-
         self.unit = "µ<sub>B</sub>"
 
         self.insulator_help = ipw.HTML("""
@@ -187,23 +185,19 @@ class MagnetizationConfigurationSettingsPanel(
         if self._model.spin_type == "none":
             children = []
         else:
-            children = [self.header]
             if self._model.electronic_type == "metal":
-                children.extend(
-                    [
-                        self.magnetization_type,
-                        self.magnetization_type_help,
-                        self.container,
-                    ]
-                )
+                children = [
+                    self.magnetization_type,
+                    self.magnetization_type_help,
+                    self.container,
+                ]
+
             else:
-                children.extend(
-                    [
-                        self.insulator_help,
-                        self.magnetization_type_help,
-                        self.tot_magnetization_with_unit,
-                    ],
-                )
+                children = [
+                    self.insulator_help,
+                    self.magnetization_type_help,
+                    self.tot_magnetization_with_unit,
+                ]
         self.children = children
 
     def _toggle_widgets(self):

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -15,6 +15,7 @@ class MagnetizationConfigurationSettingsModel(
     AdvancedCalculationSubSettingsModel,
     HasInputStructure,
 ):
+    title = "Magnetization"
     identifier = "magnetization"
 
     dependencies = [

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -367,7 +367,7 @@ class PseudosConfigurationSettingsModel(
                     "PseudoDojo stringent",
                 ],
             )
-        return self._defaults.get(trait, self.traits()[trait].default_value)
+        return super()._get_default(trait)
 
     def _get_default_dictionary(self):
         return deepcopy(self._defaults["dictionary"])

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -27,6 +27,7 @@ class PseudosConfigurationSettingsModel(
     AdvancedCalculationSubSettingsModel,
     HasInputStructure,
 ):
+    title = "Accuracy/presicion"
     identifier = "pseudos"
 
     dependencies = [

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -27,7 +27,7 @@ class PseudosConfigurationSettingsModel(
     AdvancedCalculationSubSettingsModel,
     HasInputStructure,
 ):
-    title = "Accuracy/presicion"
+    title = "Pseudopotentials"
     identifier = "pseudos"
 
     dependencies = [

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -146,7 +146,6 @@ class PseudosConfigurationSettingsPanel(
         )
 
         self.children = [
-            ipw.HTML("<h2>Accuracy and precision</h2>"),
             ipw.HTML("""
                 <div class="pseudo-text">
                     The exchange-correlation functional and pseudopotential library is

--- a/src/aiidalab_qe/app/configuration/advanced/smearing/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/smearing/model.py
@@ -48,6 +48,3 @@ class SmearingConfigurationSettingsModel(AdvancedCalculationSubSettingsModel):
         with self.hold_trait_notifications():
             self.type = self._get_default("type")
             self.degauss = self._get_default("degauss")
-
-    def _get_default(self, trait):
-        return self._defaults.get(trait, self.traits()[trait].default_value)

--- a/src/aiidalab_qe/app/configuration/advanced/smearing/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/smearing/model.py
@@ -8,6 +8,7 @@ from ..subsettings import AdvancedCalculationSubSettingsModel
 
 
 class SmearingConfigurationSettingsModel(AdvancedCalculationSubSettingsModel):
+    title = "Smearing"
     identifier = "smearing"
 
     dependencies = [

--- a/src/aiidalab_qe/app/configuration/advanced/smearing/smearing.py
+++ b/src/aiidalab_qe/app/configuration/advanced/smearing/smearing.py
@@ -46,7 +46,6 @@ class SmearingConfigurationSettingsPanel(
         )
 
         self.children = [
-            ipw.HTML("<h2>Smearing</h2>"),
             ipw.HTML("""
                 <div style="line-height: 1.4; margin-bottom: 5px;">
                     Smear electronic state occupations near the Fermi level to

--- a/src/aiidalab_qe/app/configuration/advanced/subsettings.py
+++ b/src/aiidalab_qe/app/configuration/advanced/subsettings.py
@@ -36,6 +36,9 @@ class AdvancedCalculationSubSettingsModel(
         """Resets the model to present defaults."""
         raise NotImplementedError()
 
+    def _get_default(self, trait):
+        return self._defaults.get(trait, self.traits()[trait].default_value)
+
 
 M = t.TypeVar("M", bound=AdvancedCalculationSubSettingsModel)
 

--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -58,9 +58,6 @@ class PdosConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructu
             self.pdos_degauss = self._get_default("pdos_degauss")
             self.energy_grid_step = self._get_default("energy_grid_step")
 
-    def _get_default(self, trait):
-        return self._defaults.get(trait, self.traits()[trait].default_value)
-
     def _update_kpoints_mesh(self, _=None):
         if not self.has_structure:
             mesh_grid = ""

--- a/tests/configuration/test_advanced.py
+++ b/tests/configuration/test_advanced.py
@@ -6,6 +6,10 @@ from aiidalab_qe.app.configuration.advanced.convergence import (
     ConvergenceConfigurationSettingsModel,
     ConvergenceConfigurationSettingsPanel,
 )
+from aiidalab_qe.app.configuration.advanced.general import (
+    GeneralConfigurationSettingsModel,
+    GeneralConfigurationSettingsPanel,
+)
 
 
 def test_advanced_default():
@@ -29,6 +33,24 @@ def test_advanced_default():
     assert smearing_model.type == "cold"
     assert smearing_model.degauss == 0.0275
     assert convergence_model.kpoints_distance == 0.3
+
+
+def test_advanced_general_settings():
+    """Test General settings."""
+    model = GeneralConfigurationSettingsModel()
+    _ = GeneralConfigurationSettingsPanel(model=model)
+
+    assert model.total_charge == 0.0
+    assert model.van_der_waals == "none"
+
+    # Check reset
+    model.total_charge = 1.0
+    model.van_der_waals = "dft-d3"
+
+    model.reset()
+
+    assert model.total_charge == 0.0
+    assert model.van_der_waals == "none"
 
 
 def test_advanced_convergence_settings(generate_structure_data):
@@ -139,20 +161,6 @@ def test_advanced_smearing_settings():
 
     assert smearing_model.type == "cold"
     assert smearing_model.degauss == 0.0275
-
-
-def test_advanced_tot_charge_settings():
-    """Test TotCharge widget."""
-    model = AdvancedConfigurationSettingsModel()
-    _ = AdvancedConfigurationSettingsPanel(model=model)
-
-    assert model.total_charge == 0.0
-
-    # Check reset
-    model.total_charge = 1.0
-    model.reset()
-
-    assert model.total_charge == 0.0
 
 
 def test_advanced_hubbard_settings(generate_structure_data):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -476,8 +476,9 @@ def submit_app_generator(
         # Advanced settings
         advanced_model = app.configure_model.get_model("advanced")
 
-        advanced_model.total_charge = tot_charge
-        advanced_model.van_der_waals = vdw_corr
+        general_model = advanced_model.get_model("general")
+        general_model.total_charge = tot_charge
+        general_model.van_der_waals = vdw_corr
 
         convergence_model = advanced_model.get_model("convergence")
         convergence_model.electron_maxstep = electron_maxstep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -478,10 +478,10 @@ def submit_app_generator(
 
         advanced_model.total_charge = tot_charge
         advanced_model.van_der_waals = vdw_corr
-        advanced_model.kpoints_distance = kpoints_distance
 
         convergence_model = advanced_model.get_model("convergence")
         convergence_model.electron_maxstep = electron_maxstep
+        convergence_model.kpoints_distance = kpoints_distance
 
         if isinstance(initial_magnetic_moments, (int, float)):
             initial_magnetic_moments = [initial_magnetic_moments]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -3,16 +3,6 @@ from aiidalab_qe.app.configuration.model import ConfigurationStepModel
 from aiidalab_qe.setup.pseudos import PSEUDODOJO_VERSION, SSSP_VERSION
 
 
-def test_protocol():
-    model = ConfigurationStepModel()
-    _ = ConfigureQeAppWorkChainStep(model=model)
-    workchain_model = model.get_model("workchain")
-    advanced_model = model.get_model("advanced")
-    workchain_model.protocol = "fast"
-    assert advanced_model.protocol == "fast"
-    assert advanced_model.kpoints_distance == 0.3
-
-
 def test_get_configuration_parameters():
     model = ConfigurationStepModel()
     _ = ConfigureQeAppWorkChainStep(model=model)


### PR DESCRIPTION
Based on #1361

Recent work updating/extending the advanced settings (e.g., #1355, #1358) has motivated switching from a vertical scroll to a horizontal one (i.e. tabs).

<img width="720" height="187" alt="image" src="https://github.com/user-attachments/assets/f839b62f-797b-42bf-aa1a-2990f42a573d" />
