### PR TITLE
Manually handle step advancement

### DIFF
--- a/src/aiidalab_qe/app/wizard_app.py
+++ b/src/aiidalab_qe/app/wizard_app.py
@@ -35,16 +35,13 @@ class WizardApp(ipw.VBox):
         # Create the application steps
         self.structure_step = StructureSelectionStep(
             model=self.structure_model,
-            auto_advance=True,
             auto_setup=auto_setup,
         )
         self.configure_step = ConfigureQeAppWorkChainStep(
             model=self.configure_model,
-            auto_advance=True,
         )
         self.submit_step = SubmitQeAppWorkChainStep(
             model=self.submit_model,
-            auto_advance=True,
             auto_setup=auto_setup,
         )
         self.results_step = ViewQeAppWorkChainStatusAndResultsStep(
@@ -131,12 +128,17 @@ class WizardApp(ipw.VBox):
 
     def _on_structure_confirmation_change(self, _):
         self._update_configuration_step()
+        if not self.process:
+            self._wizard_app_widget.selected_index = 1
 
     def _on_configuration_confirmation_change(self, _):
         self._update_submission_step()
+        if not self.process:
+            self._wizard_app_widget.selected_index = 2
 
     def _on_submission(self, _):
         self._update_results_step()
+        self._wizard_app_widget.selected_index = 3
         self._lock_app()
 
     def _render_step(self, step_index):

--- a/src/aiidalab_qe/app/wizard_app.py
+++ b/src/aiidalab_qe/app/wizard_app.py
@@ -128,22 +128,27 @@ class WizardApp(ipw.VBox):
 
     def _on_structure_confirmation_change(self, _):
         self._update_configuration_step()
-        if not self.process:
-            self._wizard_app_widget.selected_index = 1
+        if self.structure_model.confirmed:
+            self._advance()
 
     def _on_configuration_confirmation_change(self, _):
         self._update_submission_step()
-        if not self.process:
-            self._wizard_app_widget.selected_index = 2
+        if self.configure_model.confirmed:
+            self._advance()
 
     def _on_submission(self, _):
         self._update_results_step()
-        self._wizard_app_widget.selected_index = 3
-        self._lock_app()
+        if self.submit_model.confirmed:
+            self._advance()
+            self._lock_app()
 
     def _render_step(self, step_index):
         step: QeWizardStep = self.steps[step_index][1]
         step.render()
+
+    def _advance(self):
+        if not self.process:
+            self._wizard_app_widget.selected_index += 1
 
     def _update_configuration_step(self):
         if self.structure_model.confirmed:


### PR DESCRIPTION
By relying on the AWB wizard step auto advancement feature, we were hitting inconsistent states, where a given step's `_post_render` method didn't actually have the required state variable (e.g., step 3 rendered prior to having access to the input parameters of step 2). This PR corrects this behavior by disabling auto advance and handling step advancement in `_on_<step>_confirmation` handlers.