### PR TITLE
Discard redundant `get_selected_codes` and `set_selected_codes` methods

### DIFF
--- a/src/aiidalab_qe/app/submission/global_settings/setting.py
+++ b/src/aiidalab_qe/app/submission/global_settings/setting.py
@@ -89,7 +89,7 @@ class GlobalResourceSettingsPanel(ResourceSettingsPanel[GlobalResourceSettingsMo
         self._model.update_global_codes()
 
     def reset(self):
-        self._model.set_selected_codes()
+        self._model.set_model_state({})
 
     def _on_input_parameters_change(self, _):
         self._model.update_active_codes()

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -168,13 +168,6 @@ class SubmissionStepModel(
             self.process_description = self.process_node.description
             self.loaded_from_process = True
 
-    def get_selected_codes(self) -> dict[str, dict]:
-        return {
-            identifier: code_model.get_model_state()
-            for identifier, code_model in self.get_model("global").get_models()
-            if code_model.is_ready
-        }
-
     def reset(self):
         with self.hold_trait_notifications():
             self.input_structure = None

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -247,18 +247,9 @@ class ResourceSettingsModel(SettingsModel, HasModels[CodeModel]):
         }
 
     def set_model_state(self, parameters: dict):
-        self.set_selected_codes(parameters.get("codes", {}))
-
-    def get_selected_codes(self) -> dict[str, dict]:
-        return {
-            identifier: code_model.get_model_state()
-            for identifier, code_model in self.get_models()
-            if code_model.is_ready
-        }
-
-    def set_selected_codes(self, code_data=None):
+        code_data = parameters.get("codes", {}) or self.default_codes
         for identifier, code_model in self.get_models():
-            if identifier in (code_data or self.default_codes):
+            if identifier in code_data:
                 code_model.set_model_state(code_data[identifier])
 
     def _check_blockers(self):

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -13,8 +13,8 @@ def test_code_not_selected(submit_app_generator):
     model._create_builder(parameters)
 
 
-def test_set_selected_codes(submit_app_generator):
-    """Test set_selected_codes method."""
+def test_set_codes(submit_app_generator):
+    """Test setting codes (in practice, from a loaded process)."""
     app: WizardApp = submit_app_generator()
     parameters = app.submit_model.get_model_state()
     model = SubmissionStepModel()
@@ -22,8 +22,10 @@ def test_set_selected_codes(submit_app_generator):
     for identifier, code_model in app.submit_model.get_model("global").get_models():
         model.get_model("global").get_model(identifier).is_active = code_model.is_active
     model.qe_installed = True
-    model.get_model("global").set_selected_codes(parameters["codes"]["global"]["codes"])
-    assert model.get_selected_codes() == app.submit_model.get_selected_codes()
+    model.get_model("global").set_model_state(parameters["codes"]["global"])
+    assert (
+        model.get_model_state()["codes"] == app.submit_model.get_model_state()["codes"]
+    )
 
 
 def test_global_code_toggle(app: WizardApp):


### PR DESCRIPTION
No need for these methods. 99% accomplished by `get_model_state` and `set_model_state` of the `ResourceSettingsModel`.