### PR TITLE
Restore advanced panel `refresh` on structure change

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -50,6 +50,10 @@ class AdvancedConfigurationSettingsPanel(
         )
 
         self._model.observe(
+            self._on_input_structure_change,
+            "input_structure",
+        )
+        self._model.observe(
             self._on_spin_type_change,
             "spin_type",
         )
@@ -118,6 +122,9 @@ class AdvancedConfigurationSettingsPanel(
         self.rendered = True
 
         self._update_tabs()
+
+    def _on_input_structure_change(self, _):
+        self.refresh(specific="structure")
 
     def _on_spin_type_change(self, _):
         self._update_tabs()


### PR DESCRIPTION
Without this, changing a structure leads in certain cases to an inconsistent state, raising an error (trait removed while being changed). The `refresh` method ensures any links are first detached and a proper reset is triggered.

Resolves https://github.com/aiidalab/aiidalab-qe/issues/1378