### PR TITLE
Update pseudopotentials panel

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -403,5 +403,3 @@ class PseudosConfigurationSettingsModel(
         if self.spin_orbit == "soc":
             if relativistic_set != {"full"}:
                 yield "For spin-orbit coupling (SOC) calculations, all pseudopotentials must be fully relativistic."
-        elif "full" in relativistic_set:
-            yield "For non-spin-orbit coupling (non-SOC) calculations, no pseudopotential should be fully relativistic."

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -61,8 +61,10 @@ class PseudosConfigurationSettingsModel(
         default_value=[
             "SSSP efficiency",
             "SSSP precision",
-            "PseudoDojo standard",
-            "PseudoDojo stringent",
+            "PseudoDojo standard (SR)",
+            "PseudoDojo stringent (SR)",
+            "PseudoDojo standard (FR)",
+            "PseudoDojo stringent (FR)",
         ],
     )
     family = tl.Unicode(allow_none=True)
@@ -88,15 +90,15 @@ class PseudosConfigurationSettingsModel(
 
     PSEUDO_HELP_WO_SOC = """
         <div class="pseudo-text">
+            SSSP provides standard solid-state pseudopotentials, while PseudoDojo
+            provides both scalar (SR) and full (FR) relativistic types.
+            <br>
             If you are unsure, select 'SSSP efficiency', which for most calculations
             will produce sufficiently accurate results at comparatively small
             computational costs.
             <br>
-            If your calculations require a higher accuracy, select 'SSSP accuracy' or
-            'PseudoDojo stringent', which will be computationally more expensive.
-            <br>
-            SSSP is the standard solid-state pseudopotentials.
-            The PseudoDojo version used here is the SR relativistic type.
+            For higher accuracy, select 'SSSP precision' or 'PseudoDojo stringent'
+            (computationally more expensive).
         </div>
     """
 
@@ -131,8 +133,14 @@ class PseudosConfigurationSettingsModel(
             ]
 
         pseudo_family = PseudoFamily.from_string(pseudo_family_string)
+        library = f"{pseudo_family.library} {pseudo_family.accuracy}"
 
-        self._defaults["library"] = f"{pseudo_family.library} {pseudo_family.accuracy}"
+        if "FR" in pseudo_family_string:
+            library += " (FR)"
+        elif "SR" in pseudo_family_string:
+            library += " (SR)"
+
+        self._defaults["library"] = library
         self._defaults["functional"] = pseudo_family.functional
 
         with self.hold_trait_notifications():
@@ -152,19 +160,15 @@ class PseudosConfigurationSettingsModel(
         if self.loaded_from_process or not (self.library and self.functional):
             return
 
-        library, accuracy = self.library.split()
+        parts = self.library.split()
+        library, accuracy = parts[:2]
+        if len(parts) == 3:
+            relativistic = parts[2].strip("()")
         functional = self.functional
         # XXX (jusong.yu): a validator is needed to check the family string is
         # consistent with the list of pseudo families defined in the setup_pseudos.py
         if library == "PseudoDojo":
-            if self.spin_orbit == "soc":
-                pseudo_family_string = (
-                    f"PseudoDojo/{PSEUDODOJO_VERSION}/{functional}/FR/{accuracy}/upf"
-                )
-            else:
-                pseudo_family_string = (
-                    f"PseudoDojo/{PSEUDODOJO_VERSION}/{functional}/SR/{accuracy}/upf"
-                )
+            pseudo_family_string = f"PseudoDojo/{PSEUDODOJO_VERSION}/{functional}/{relativistic}/{accuracy}/upf"
         elif library == "SSSP":
             pseudo_family_string = f"SSSP/{SSSP_VERSION}/{functional}/{accuracy}"
         else:
@@ -180,7 +184,7 @@ class PseudosConfigurationSettingsModel(
             self.family_header = "<h4>Pseudopotential family</h4>"
             return
 
-        library, accuracy = self.library.split()
+        library, accuracy = self.library.split()[:2]
         if library == "SSSP":
             pseudo_family_link = (
                 f"https://www.materialscloud.org/discover/sssp/table/{accuracy}"
@@ -310,18 +314,20 @@ class PseudosConfigurationSettingsModel(
         if self.loaded_from_process or not self.has_structure:
             return
 
+        relativistic_options = [
+            "PseudoDojo standard (FR)",
+            "PseudoDojo stringent (FR)",
+        ]
         if self.spin_orbit == "soc":
-            library_options = [
-                "PseudoDojo standard",
-                "PseudoDojo stringent",
-            ]
+            library_options = relativistic_options
             self.family_help_message = self.PSEUDO_HELP_SOC
         else:
             library_options = [
                 "SSSP efficiency",
                 "SSSP precision",
-                "PseudoDojo standard",
-                "PseudoDojo stringent",
+                "PseudoDojo standard (SR)",
+                "PseudoDojo stringent (SR)",
+                *relativistic_options,
             ]
             self.family_help_message = self.PSEUDO_HELP_WO_SOC
 
@@ -363,8 +369,10 @@ class PseudosConfigurationSettingsModel(
                 [
                     "SSSP efficiency",
                     "SSSP precision",
-                    "PseudoDojo standard",
-                    "PseudoDojo stringent",
+                    "PseudoDojo standard (SR)",
+                    "PseudoDojo stringent (SR)",
+                    "PseudoDojo standard (FR)",
+                    "PseudoDojo stringent (FR)",
                 ],
             )
         return super()._get_default(trait)

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -90,8 +90,8 @@ class PseudosConfigurationSettingsModel(
 
     PSEUDO_HELP_WO_SOC = """
         <div class="pseudo-text">
-            SSSP provides standard solid-state pseudopotentials, while PseudoDojo
-            provides both scalar (SR) and full (FR) relativistic types.
+            SSSP (v1.3) provides standard solid-state pseudopotentials, while PseudoDojo
+            (v0.4) provides both scalar (SR) and full (FR) relativistic types.
             <br>
             If you are unsure, select 'SSSP efficiency', which for most calculations
             will produce sufficiently accurate results at comparatively small
@@ -124,13 +124,16 @@ class PseudosConfigurationSettingsModel(
 
         if self.spin_orbit == "soc":
             if self.protocol in ["fast", "balanced"]:
-                pseudo_family_string = "PseudoDojo/0.4/PBEsol/FR/standard/upf"
+                pseudo_family_string = (
+                    f"PseudoDojo/{PSEUDODOJO_VERSION}/PBEsol/FR/standard/upf"
+                )
             else:
-                pseudo_family_string = "PseudoDojo/0.4/PBEsol/FR/stringent/upf"
+                pseudo_family_string = (
+                    f"PseudoDojo/{PSEUDODOJO_VERSION}/PBEsol/FR/stringent/upf"
+                )
         else:
-            pseudo_family_string = PwBaseWorkChain.get_protocol_inputs(self.protocol)[
-                "pseudo_family"
-            ]
+            protocol_inputs = PwBaseWorkChain.get_protocol_inputs(self.protocol)
+            pseudo_family_string = protocol_inputs["pseudo_family"]
 
         pseudo_family = PseudoFamily.from_string(pseudo_family_string)
         library = f"{pseudo_family.library} {pseudo_family.accuracy}"

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -73,15 +73,6 @@ class PseudosConfigurationSettingsPanel(
             (self.family_help, "value"),
         )
 
-        self.functional_help = ipw.HTML("""
-            <div class="pseudo-text">
-                The exchange-correlation energy is calculated using this functional.
-                <br>
-                We currently provide support for two well-established generalized
-                gradient approximation (GGA) functionals: PBE and PBEsol.
-            </div>
-        """)
-
         self.functional = ipw.ToggleButtons()
         ipw.dlink(
             (self._model, "functional_options"),
@@ -92,7 +83,7 @@ class PseudosConfigurationSettingsPanel(
             (self.functional, "value"),
         )
 
-        self.library = ipw.ToggleButtons()
+        self.library = ipw.ToggleButtons(style={"button_width": "fit-content"})
         ipw.dlink(
             (self._model, "library_options"),
             (self.library, "options"),
@@ -134,11 +125,11 @@ class PseudosConfigurationSettingsPanel(
                     <h4><b>⚠️ Pseudopotential upload detected ⚠️</b></h4>
                     Adjust plane-wave cutoff energies below to ensure convergence
                     <br>
-                    To reset to protocol-derived pseudopotentials, select both an
-                    exchange-correlation functional and a pseudopotential family above
+                    To reset to protocol defaults, select both an exchange-correlation
+                    functional and a pseudopotential family above.
                     <br>
                     Switching the protocol in <b>Basic settings</b> will also reset the
-                    pseudopotentials to the defaults for the selected protocol
+                    pseudopotentials to the defaults of the selected protocol.
                 """,
                 class_="text-center",
                 style_="line-height: 2;",
@@ -151,27 +142,27 @@ class PseudosConfigurationSettingsPanel(
         self.children = [
             ipw.HTML("""
                 <div class="pseudo-text">
-                    The exchange-correlation functional and pseudopotential library is
+                    The exchange-correlation functional and pseudopotential library are
                     set by the <b>protocol</b> configured in the <b>Basic settings</b>
                     tab.
                     <br>
                     Here you can override the defaults if desired.
                 </div>
             """),
-            ipw.VBox(
-                children=[
-                    ipw.HTML("<h4>Exchange-correlation functional</h4>"),
-                    self.functional,
-                    self.functional_help,
-                ],
-            ),
-            ipw.VBox(
-                children=[
-                    self.family_header,
-                    self.library,
-                    self.family_help,
-                ],
-            ),
+            ipw.HTML("<h4>Exchange-correlation functional</h4>"),
+            ipw.HTML("""
+                <div class="pseudo-text">
+                    The exchange-correlation energy is described using the selected
+                    functional.
+                    <br>
+                    We currently provide support for two well-established generalized
+                    gradient approximation (GGA) functionals: PBE and PBEsol.
+                </div>
+            """),
+            self.functional,
+            self.family_header,
+            self.family_help,
+            self.library,
             ipw.HTML("<h4>Pseudopotentials</h4>"),
             self._warning_message,
             ipw.HTML("""

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -136,6 +136,9 @@ class PseudosConfigurationSettingsPanel(
                     <br>
                     To reset to protocol-derived pseudopotentials, select both an
                     exchange-correlation functional and a pseudopotential family above
+                    <br>
+                    Switching the protocol in <b>Basic settings</b> will also reset the
+                    pseudopotentials to the defaults for the selected protocol
                 """,
                 class_="text-center",
                 style_="line-height: 2;",

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/uploader/uploader.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/uploader/uploader.py
@@ -8,11 +8,7 @@ from aiidalab_qe.utils import generate_alert
 from aiidalab_widgets_base import LoadingWidget
 from aiidalab_widgets_base.utils import StatusHTML
 
-from ..utils import (
-    UpfData,
-    get_pseudo_by_filename,
-    get_pseudo_by_md5,
-)
+from ..utils import UpfData, get_pseudo_by_md5
 from .model import PseudoPotentialUploaderModel
 
 
@@ -133,19 +129,6 @@ class PseudoPotentialUploader(ipw.VBox):
                 alert_type="info",
                 message=f"Identical pseudo detected. Loading pseudo (UUID={uploaded_pseudo.uuid})",
             )
-
-        # New pseudo but existing filename
-        elif get_pseudo_by_filename(filename):
-            self._model.message = generate_alert(
-                alert_type="warning",
-                message=f"""
-                    {filename} found in database with different content.
-                    <br>
-                    Please rename your file before uploading.
-                """,
-            )
-            self._reset_uploader()
-            return
 
         # Valid new pseudo
         else:

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -317,27 +317,6 @@ def test_pseudo_upload_widget(generate_upf_data):
     assert model.pseudo.filename == "O.upf"
     assert "Identical pseudo" in model.message
 
-    # Check different content but same filename is rejected
-    different_content_same_filename = generate_upf_data(
-        "O",
-        "O.upf",
-        params={"accuracy": "low"},
-    )
-    uploader._on_file_upload(
-        {
-            "new": {
-                "O.upf": {
-                    "content": bytes(
-                        different_content_same_filename.get_content(),
-                        encoding="utf-8",
-                    ),
-                },
-            },
-        }
-    )
-    assert model.pseudo.filename == "O.upf"
-    assert "rename your file" in model.message
-
     # Check invalid pseudo content is rejected
     uploader._on_file_upload(
         {

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -171,7 +171,7 @@ def test_pseudos_settings(generate_structure_data, generate_upf_data):
     assert model.family == f"SSSP/{SSSP_VERSION}/PBE/precision"
 
     # Test library-dependent family change
-    model.library = "PseudoDojo stringent"
+    model.library = "PseudoDojo stringent (SR)"
     assert model.family == f"PseudoDojo/{PSEUDODOJO_VERSION}/PBE/SR/stringent/upf"
 
     # Test spin-orbit-dependent family change
@@ -357,7 +357,7 @@ def test_missing_pseudos(generate_structure_data):
     _ = PseudosConfigurationSettingsPanel(model=model)
     model.input_structure = generate_structure_data("CeO")
     model.functional = "PBEsol"
-    model.library = "PseudoDojo standard"
+    model.library = "PseudoDojo standard (SR)"
     assert model.family == "PseudoDojo/0.4/PBEsol/SR/standard/upf"
     assert model.dictionary["Ce"] is None
     assert model.dictionary["O"] is not None
@@ -377,13 +377,11 @@ def test_functional_mismatch_blocker(generate_structure_data):
 
 def test_relativistic_mismatch_blocker(generate_structure_data):
     """Test blocker for inconsistent relativistic treatment across selected
-    pseudopotentials with and without SOC.
+    pseudopotentials with SOC.
     """
     model = PseudosConfigurationSettingsModel()
     _ = PseudosConfigurationSettingsPanel(model=model)
     model.input_structure = generate_structure_data("silica")
-
-    # Check with SOC
     model.spin_orbit = "soc"
     model.family = "SSSP/1.3/PBEsol/efficiency"
     assert len(model.blockers) == 1

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -409,16 +409,3 @@ def test_relativistic_mismatch_blocker(generate_structure_data):
     model.family = "SSSP/1.3/PBEsol/efficiency"
     assert len(model.blockers) == 1
     assert "pseudopotentials must be fully relativistic" in model.blockers[0]
-
-    # Check without SOC
-    # This would only happen if the user loads a fully relativistic pseudopotential.
-    # Here we simulate it by setting the relativistic extra and triggering the blocker
-    # check manually
-    model.spin_orbit = "wo_soc"
-    pseudo = orm.load_node(model.dictionary["Si"])
-    pseudo.base.extras.set("relativistic", "full")
-    model.update_blockers()
-    assert len(model.blockers) == 1
-    assert "no pseudopotential should be fully relativistic" in model.blockers[0]
-    # Restore extras entry to correct value
-    pseudo.base.extras.set("relativistic", "N/A")


### PR DESCRIPTION
Per team discussion, this PR does the following:

- [x] Allow full relativistic pseudopotentials for non-SOC calculations
- [x] Mark PseudoDojo family selectors with SR/FR
- ~~Add checkbox to include FR families when in non-SOC state~~
- [x] Allow uploading unique-md5 pseudos of existing filenames
- [x] Notify user post-pseudo-upload that switching the protocol will also reset all pseudos (undo upload)

### Comment regarding FR checkbox

~~Unfortunately, `ipywidgets.ToggleButtons` is designed to auto-select the first option on change of options. Hence, updating the family options on checkbox state change results in a reset of the current selected family to the first available option. There is no apparent public API (or hacking path) for blocking this. One can save the previous library and reset it after, but the UX is not great, as the user sees the bounce between current to first and back to current (if available). Not great, but doable if team requests it. Pinging @giovannipizzi.~~

#### Update

The checkbox has been removed in favor of always showing the FR families. The text has been adjusted. @AndresOrtegaGuerrero if you find issues with this, we can consider restoring the full relativistic checkbox. But great if you can provide a reason for not including them by default.