### PR TITLE
Discard `traitlets` typing hack

### DIFF
--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -8,10 +8,9 @@ from aiida import orm
 from aiida.common.exceptions import NotExistent
 from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
 from aiidalab_qe.common.mvc import Model
-from aiidalab_qe.utils import HasTraits
 
 
-class HasInputStructure(HasTraits):
+class HasInputStructure(tl.HasTraits):
     input_structure = tl.Union(
         [
             tl.Instance(orm.StructureData),
@@ -92,7 +91,7 @@ class HasModels(t.Generic[M]):
             )
 
 
-class HasProcess(HasTraits):
+class HasProcess(tl.HasTraits):
     process_uuid = tl.Unicode(None, allow_none=True)
     monitor_counter = tl.Int(0)  # used for continuous updates
 
@@ -128,7 +127,7 @@ class HasProcess(HasTraits):
             return None
 
 
-class Confirmable(HasTraits):
+class Confirmable(tl.HasTraits):
     confirmed = tl.Bool(False)
 
     confirmation_exceptions = [
@@ -147,7 +146,7 @@ class Confirmable(HasTraits):
         self.confirmed = False
 
 
-class HasBlockers(HasTraits):
+class HasBlockers(tl.HasTraits):
     blockers = tl.List(tl.Unicode())
     blocker_messages = tl.Unicode("")
 

--- a/src/aiidalab_qe/common/mvc.py
+++ b/src/aiidalab_qe/common/mvc.py
@@ -1,7 +1,5 @@
 import traitlets as tl
 
-from aiidalab_qe.utils import HasTraits
-
 
 class MetaHasTraitsLast(tl.MetaHasTraits):
     """A metaclass that ensures that `HasTraits` is pushed to the end of the MRO.
@@ -16,7 +14,7 @@ class MetaHasTraitsLast(tl.MetaHasTraits):
         return super().__new__(cls, name, bases, classdict)
 
 
-class Model(HasTraits, metaclass=MetaHasTraitsLast):
+class Model(tl.HasTraits, metaclass=MetaHasTraitsLast):
     """A parent class for all MVC models.
 
     The class extends `traitlet`'s `HasTraits` and uses a metaclass to

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -8,7 +8,6 @@ Authors:
 from __future__ import annotations
 
 import os
-import sys
 import typing as t
 
 import ipywidgets as ipw
@@ -26,11 +25,6 @@ from aiidalab_qe.common.widgets import (
     QEAppComputationalResourcesWidget,
 )
 from aiidalab_widgets_base import LoadingWidget
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
 
 DEFAULT: dict = DEFAULT_PARAMETERS  # type: ignore
 
@@ -58,12 +52,6 @@ class Panel(ipw.VBox, t.Generic[PM]):
 
     rendered = False
     loading_message = "Loading {identifier} panel"
-
-    # For IDE type checking
-    # Type checking struggles with `traitlets.HasTraits`, which inherits
-    # `traitlets.HasDescriptors`, which in turn defines `__new__(...) -> t.Any`
-    def __new__(cls, *args: t.Any, **kwargs: t.Any) -> Self:
-        return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, model: PM, **kwargs):
         loading_message = self.loading_message.format(identifier=model.identifier)

--- a/src/aiidalab_qe/utils.py
+++ b/src/aiidalab_qe/utils.py
@@ -1,25 +1,7 @@
-import sys
 import typing as t
-
-import traitlets as tl
 
 from aiida import orm
 from aiida.common.exceptions import NotExistent
-
-if sys.version_info >= (3, 11):
-    from typing import Self
-else:
-    from typing_extensions import Self
-
-
-class HasTraits(tl.HasTraits):
-    """Wrapper on `tl.HasTraits` for improved static type checking."""
-
-    # For IDE type checking
-    # Type checking struggles with `traitlets.HasTraits`, which inherits
-    # `traitlets.HasDescriptors`, which in turn defines `__new__(...) -> t.Any`
-    def __new__(cls, *args: t.Any, **kwargs: t.Any) -> Self:
-        return super().__new__(cls, *args, **kwargs)
 
 
 def generate_alert(alert_type: str, message: str, class_: str = "", style_: str = ""):


### PR DESCRIPTION
This PR manually reverts #1375.

#1375 introduced a hack to recover static analysis for ipywidgets/traitlets classes. Further research suggests that this was an issue due to a "recent" release of the `pyright` package (used by `pylance`). This is addressed by https://github.com/ipython/traitlets/pull/918. For the time being, downgrading `pylance` to `2024.12.1` restores static typing. Once `traitlets` releases a new version, we should consider upgrading, for the fix, but also to stay up-to-date if possible. If and when we upgrade, `pylance` may be updated as well.