### PR TITLE
Lift default user email caching to submission model

### DIFF
--- a/src/aiidalab_qe/app/submission/__init__.py
+++ b/src/aiidalab_qe/app/submission/__init__.py
@@ -41,7 +41,8 @@ class SubmitQeAppWorkChainStep(QeConfirmableDependentWizardStep[SubmissionStepMo
         )
 
         global_resources_model = GlobalResourceSettingsModel(
-            default_codes=DEFAULT["codes"]
+            default_codes=DEFAULT["codes"],
+            default_user_email=self._model.default_user_email,
         )
         self.global_resources = GlobalResourceSettingsPanel(
             model=global_resources_model
@@ -275,7 +276,8 @@ class SubmitQeAppWorkChainStep(QeConfirmableDependentWizardStep[SubmissionStepMo
                     raise ValueError(f"Entry {identifier} is missing the '{key}' key")
 
             model: PluginResourceSettingsModel = resources["model"](
-                default_codes=DEFAULT["codes"]
+                default_codes=DEFAULT["codes"],
+                default_user_email=self._model.default_user_email,
             )
             model.observe(
                 self._on_plugin_overrides_change,

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -45,6 +45,8 @@ class SubmissionStepModel(
             "qe_installed",
         ]
 
+        self.default_user_email = orm.User.collection.get_default().email
+
         self._default_models = {
             "global",
         }

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -62,7 +62,7 @@ class CodeModel(Model):
     def deactivate(self):
         self.is_active = False
 
-    def update(self, user_email="", default_code=None, refresh=False):
+    def update(self, user_email: str, default_code=None, refresh=False):
         if not self.options or refresh:
             self.options = self._get_codes(user_email)
             if default_code:
@@ -109,7 +109,7 @@ class CodeModel(Model):
         # in the app and thus will not be considered as an option!
         return uuid if uuid in [opt[1] for opt in self.options] else None
 
-    def _get_codes(self, user_email: str = ""):
+    def _get_codes(self, user_email: str):
         user = orm.User.collection.get(email=user_email)
 
         filters = (

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -174,19 +174,16 @@ class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):
 
     warning_messages = tl.Unicode("")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, default_user_email: str, *args, **kwargs):
         self.default_codes: dict[str, dict] = kwargs.pop("default_codes", {})
-
+        self.default_user_email = default_user_email
         super().__init__(*args, **kwargs)
-
-        # Used by the code-setup thread to fetch code options
-        self.DEFAULT_USER_EMAIL = orm.User.collection.get_default().email
 
     def add_model(self, identifier, model):
         super().add_model(identifier, model)
         code_key = model.default_calc_job_plugin.split(".")[-1]
         model.update(
-            self.DEFAULT_USER_EMAIL,
+            user_email=self.default_user_email,
             default_code=self.default_codes.get(code_key, {}).get("code"),
         )
 
@@ -194,7 +191,7 @@ class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):
         for _, code_model in self.get_models():
             code_key = code_model.default_calc_job_plugin.split(".")[-1]
             code_model.update(
-                self.DEFAULT_USER_EMAIL,
+                user_email=self.default_user_email,
                 default_code=self.default_codes.get(code_key, {}).get("code"),
                 refresh=True,
             )


### PR DESCRIPTION
#1356 triggers randomly. It is tracked to the local storing of the default user email used to load the default user when fetching codes. This PR lifts this caching to the submission model, prior to any thread triggering that could possibly result in issues.

Resolves #1356
Resolves #1215