### PR TITLE
Don't fetch codes in AWB

### DIFF
--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -696,7 +696,7 @@ class QEAppComputationalResourcesWidget(ipw.VBox):
             description=kwargs.pop("description", None),
             default_calc_job_plugin=kwargs.pop("default_calc_job_plugin", None),
             include_setup_widget=False,
-            fetch_codes=True,  # TODO resolve testing issues when set to `False`
+            fetch_codes=False,
             **kwargs,
         )
         self.code_selection.layout.width = "80%"


### PR DESCRIPTION
The MVC redesign introduced code models corresponding to individual code resources selector widgets. The code models handle code fetching. However, the automatic code fetching done in the AWB widget was not yet disabled due to failures in testing. This has sense been fixed. This PR disables AWB's auto code fetching, leaving the work for the code models.