### PR TITLE
Addign editor  to fix atomic positions in x,y,z and to add constraints

### DIFF
--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -193,13 +193,17 @@ class WorkChainSummaryModel(ResultsComponentModel):
             "cell_lengths": "{:.3f} {:.3f} {:.3f}".format(*structure.cell_lengths),
             "cell_angles": "{:.0f} {:.0f} {:.0f}".format(*structure.cell_angles),
         }
+        
 
         relax_value_mapping = {
             "none": "off",
             "positions": "atomic positions",
             "positions_cell": "full geometry",
         }
-
+        constraints = 'None'
+        if 'fixed_atoms' in structure.base.attributes.all:
+            constraints = 'There are fixed atoms'
+        
         report |= {
             "basic_settings": {
                 "relaxed": relax_value_mapping.get(basic["relax_type"], "off"),
@@ -207,6 +211,7 @@ class WorkChainSummaryModel(ResultsComponentModel):
                 "spin_type": "off" if basic["spin_type"] == "none" else "on",
                 "electronic_type": basic["electronic_type"],
                 "periodicity": PERIODICITY_MAPPING.get(structure.pbc, "xyz"),
+                "constraints": constraints
             },
             "advanced_settings": {},
         }

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -200,10 +200,19 @@ class WorkChainSummaryModel(ResultsComponentModel):
             "positions": "atomic positions",
             "positions_cell": "full geometry",
         }
-        constraints = 'None'
-        if 'fixed_atoms' in structure.base.attributes.all:
-            constraints = 'There are fixed atoms'
         
+        # check for fixed atoms
+        constraints = 'None'
+        fixed_atoms = structure.base.attributes.all.get('fixed_atoms', None)
+        if fixed_atoms is not None:
+            has_fixed = any(
+                any((int(v) == 0) for v in row if v is not None)
+                for row in fixed_atoms
+            )
+            # True if any element equals 0 (works for (N,3), (N,), or nested lists)
+            if has_fixed:
+                constraints = "There are fixed atoms"        
+                
         report |= {
             "basic_settings": {
                 "relaxed": relax_value_mapping.get(basic["relax_type"], "off"),

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -202,8 +202,10 @@ class WorkChainSummaryModel(ResultsComponentModel):
         }
         
         # check for fixed atoms
-        constraints = 'None'
+        constraints = ''
         fixed_atoms = structure.base.attributes.all.get('fixed_atoms', None)
+        other_constraints = structure.base.attributes.all.get('CONSTRAINTS', None)
+        
         if fixed_atoms is not None:
             has_fixed = any(
                 any((int(v) == 0) for v in row if v is not None)
@@ -211,8 +213,13 @@ class WorkChainSummaryModel(ResultsComponentModel):
             )
             # True if any element equals 0 (works for (N,3), (N,), or nested lists)
             if has_fixed:
-                constraints = "There are fixed atoms"        
-                
+                constraints += "There are fixed atoms."
+
+        if other_constraints is not None:
+            constraints += '; '.join(other_constraints['list'])
+        if not constraints:
+            constraints = "None"
+            
         report |= {
             "basic_settings": {
                 "relaxed": relax_value_mapping.get(basic["relax_type"], "off"),

--- a/src/aiidalab_qe/app/result/components/summary/schema.json
+++ b/src/aiidalab_qe/app/result/components/summary/schema.json
@@ -94,6 +94,11 @@
     "type": "text",
     "description": "The periodicity of the structure"
   },
+  "constraints": {
+    "title": "Constraints",
+    "type": "text",
+    "description": "The constraints applied to the structure"
+  },
   "functional": {
     "title": "Functional",
     "type": "link",

--- a/src/aiidalab_qe/app/result/components/viewer/structure/model.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/model.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+from pydoc import html
 
+from aiida_quantumespresso.tools import data
+from matplotlib import legend
 import traitlets as tl
 from ase.formula import Formula
 
@@ -74,41 +77,150 @@ class StructureResultsModel(ResultsModel):
             </div>
         """
 
+    # def _get_atom_table_data(self):
+    #     """Build table data; if 'fixed_atoms' is present in structure attributes,
+    #     add a 'Free x,y,z' column showing '✓' for free (1) and 'x' for fixed (0)."""
+    #     # Try to get fixed_atoms from AiiDA StructureData attributes
+    #     fixed_atoms = self.structure.base.attributes.all.get('fixed_atoms', None) 
+
+    #     ase_atoms = self.structure.get_ase()
+
+    #     # Header
+    #     data = [["Atom index", "Chemical symbol", "Tag", "x (Å)", "y (Å)", "z (Å)"]]
+    #     if fixed_atoms is not None:
+    #         data[0].append("Free x,y,z")
+
+    #     positions = ase_atoms.positions
+    #     chemical_symbols = ase_atoms.get_chemical_symbols()
+    #     tags = ase_atoms.get_tags()
+
+    #     def fmt_free(mask):
+    #         """mask: tuple/list of three 0/1; 0=free -> 'X', 1=fixed -> ' '."""
+    #         try:
+    #             x, y, z = mask
+    #         except Exception:
+    #             x = y = z = 0
+    #         # If your UI collapses spaces, replace ' ' with '·' or '\u00A0' (NBSP).
+    #         return f"({'x' if x == 0 else '✓'} {'x' if y == 0 else '✓'} {'x' if z == 0 else '✓'})"
+
+    #     for idx, (symbol, tag, pos) in enumerate(zip(chemical_symbols, tags, positions), start=1):
+    #         formatted_position = [f"{coord:.2f}" for coord in pos]
+    #         row = [idx, symbol, tag, *formatted_position]
+
+    #         if fixed_atoms is not None:
+    #             mask = fixed_atoms[idx - 1] if idx - 1 < len(fixed_atoms) else (0, 0, 0)
+    #             row.append(fmt_free(mask))
+
+    #         data.append(row)
+
+    #     return data
     def _get_atom_table_data(self):
-        """Build table data; if 'fixed_atoms' is present in structure attributes,
-        add a 'Free x,y,z' column showing '✓' for free (1) and 'x' for fixed (0)."""
-        # Try to get fixed_atoms from AiiDA StructureData attributes
-        fixed_atoms = self.structure.base.attributes.all.get('fixed_atoms', None) 
+        """Build table data.
+
+        - If 'fixed_atoms' is present in AiiDA StructureData attributes (or ASE arrays),
+        add a 'Free x,y,z' column showing '✓' for free (1) and 'x' for fixed (0).
+        - If constraints exist (CONSTRAINTS block), add a 'Constr.' column with
+        star labels (*1, *2, …) for atoms involved in each constraint.
+        """
+        # --- source data ---
+        attrs_all = getattr(getattr(getattr(self.structure, "base", None), "attributes", None), "all", {}) or {}
+        fixed_atoms = attrs_all.get("fixed_atoms", None)
 
         ase_atoms = self.structure.get_ase()
 
-        # Header
+        # Try also to read fixed mask from ASE arrays if attributes missing
+        if fixed_atoms is None and "fixed_atoms" in getattr(ase_atoms, "arrays", {}):
+            fixed_atoms = ase_atoms.arrays["fixed_atoms"].tolist()
+
+        # constraints: prefer attributes, else ASE info
+        constraints_info = attrs_all.get("CONSTRAINTS")
+        if constraints_info is None:
+            constraints_info = ase_atoms.info.get("CONSTRAINTS", None) if hasattr(ase_atoms, "info") else None
+        # normalize constraints_info
+        if not isinstance(constraints_info, dict):
+            constraints_info = {"number": 0, "tolerance": "1e-6", "list": []}
+        constraints_list = constraints_info.get("list", []) or []
+
+        # Build star marks per atom and a legend (legend not returned here)
+        def build_marks(n_atoms, entries):
+            marks = {i: [] for i in range(n_atoms)}
+            legend = []
+            for k, entry in enumerate(entries, start=1):
+                legend.append(f"*{k} {entry}")
+                parts = str(entry).strip().split()
+                if len(parts) >= 4 and parts[0] == "distance":
+                    try:
+                        i1 = int(parts[1]) - 1
+                        i2 = int(parts[2]) - 1
+                    except Exception:
+                        continue
+                    label = f"*{k}"
+                    if 0 <= i1 < n_atoms:
+                        marks[i1].append(label)
+                    if 0 <= i2 < n_atoms:
+                        marks[i2].append(label)
+            return marks, legend
+
+        marks_map, legend = build_marks(len(ase_atoms), constraints_list)
+
+        # --- header ---
         data = [["Atom index", "Chemical symbol", "Tag", "x (Å)", "y (Å)", "z (Å)"]]
         if fixed_atoms is not None:
             data[0].append("Free x,y,z")
+        # add constraints column if any constraints exist
+        if constraints_list:
+            data[0].append("Constr.")
 
         positions = ase_atoms.positions
         chemical_symbols = ase_atoms.get_chemical_symbols()
         tags = ase_atoms.get_tags()
 
         def fmt_free(mask):
-            """mask: tuple/list of three 0/1; 0=free -> 'X', 1=fixed -> ' '."""
+            """mask: 3-tuple/list of 0/1; 1=free → '✓', 0=fixed → 'x'."""
             try:
                 x, y, z = mask
             except Exception:
-                x = y = z = 0
-            # If your UI collapses spaces, replace ' ' with '·' or '\u00A0' (NBSP).
-            return f"({'x' if x == 0 else '✓'} {'x' if y == 0 else '✓'} {'x' if z == 0 else '✓'})"
+                x = y = z = 1  # default free if malformed
+            return f"({'✓' if int(x)==1 else 'x'} {'✓' if int(y)==1 else 'x'} {'✓' if int(z)==1 else 'x'})"
 
         for idx, (symbol, tag, pos) in enumerate(zip(chemical_symbols, tags, positions), start=1):
             formatted_position = [f"{coord:.2f}" for coord in pos]
             row = [idx, symbol, tag, *formatted_position]
 
             if fixed_atoms is not None:
-                mask = fixed_atoms[idx - 1] if idx - 1 < len(fixed_atoms) else (0, 0, 0)
+                # robustly fetch mask; default to all free if missing
+                mask = (1, 1, 1)
+                try:
+                    if 0 <= (idx - 1) < len(fixed_atoms):
+                        mask = fixed_atoms[idx - 1]
+                except Exception:
+                    pass
                 row.append(fmt_free(mask))
 
+            if constraints_list:
+                stars = " ".join(marks_map.get(idx - 1, []))
+                row.append(stars)
+
             data.append(row)
+        # temporary quick fix to show teh legend of constraints
+        if legend:
+            ncols = len(data[0])
+            legend_text = "; ".join(legend)
+
+            injected = (
+                # close the last normal row
+                f'</td></tr>'
+                # add a non-interactive full-width legend row
+                f'<tr class="constraints-legend-row" '
+                f'style="pointer-events:none; user-select:none;">'
+                f'<td colspan="{ncols}" style="text-align:right;">{html.escape(legend_text)}</td>'
+                f'</tr>'
+                # open a dummy row/cell so the renderer’s trailing </td></tr> stays balanced
+                f'<tr><td>'
+            )
+            data.append([injected])
+
+
 
         return data
 

--- a/src/aiidalab_qe/app/result/components/viewer/structure/model.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/model.py
@@ -78,11 +78,7 @@ class StructureResultsModel(ResultsModel):
         """Build table data; if 'fixed_atoms' is present in structure attributes,
         add a 'Free x,y,z' column showing '✓' for free (1) and 'x' for fixed (0)."""
         # Try to get fixed_atoms from AiiDA StructureData attributes
-        fixed_atoms = None
-        try:
-            fixed_atoms = self.structure.base.attributes.all['fixed_atoms']
-        except KeyError:
-            fixed_atoms = None
+        fixed_atoms = self.structure.base.attributes.all.get('fixed_atoms', None) 
 
         ase_atoms = self.structure.get_ase()
 

--- a/src/aiidalab_qe/app/structure/__init__.py
+++ b/src/aiidalab_qe/app/structure/__init__.py
@@ -10,6 +10,7 @@ import ipywidgets as ipw
 from aiidalab_qe.app.structure.model import StructureStepModel
 from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_qe.common import (
+    AddingFixedAtomsEditor,
     AddingTagsEditor,
     LazyLoadedOptimade,
     LazyLoadedStructureBrowser,
@@ -105,6 +106,7 @@ class StructureSelectionStep(QeConfirmableWizardStep[StructureStepModel]):
             BasicCellEditor(title="Edit cell"),
             BasicStructureEditor(title="Edit structure"),
             AddingTagsEditor(title="Edit atom tags"),
+            AddingFixedAtomsEditor(title="Edit fixed atoms"),
             PeriodicityEditor(title="Edit periodicity"),
             ShakeNBreakEditor(title="ShakeNBreak"),
         ]

--- a/src/aiidalab_qe/app/structure/__init__.py
+++ b/src/aiidalab_qe/app/structure/__init__.py
@@ -10,7 +10,7 @@ import ipywidgets as ipw
 from aiidalab_qe.app.structure.model import StructureStepModel
 from aiidalab_qe.app.utils import get_entry_items
 from aiidalab_qe.common import (
-    AddingFixedAtomsEditor,
+    AddingConstraintsEditor,
     AddingTagsEditor,
     LazyLoadedOptimade,
     LazyLoadedStructureBrowser,
@@ -106,7 +106,7 @@ class StructureSelectionStep(QeConfirmableWizardStep[StructureStepModel]):
             BasicCellEditor(title="Edit cell"),
             BasicStructureEditor(title="Edit structure"),
             AddingTagsEditor(title="Edit atom tags"),
-            AddingFixedAtomsEditor(title="Edit fixed atoms"),
+            AddingConstraintsEditor(title="Edit constraints"),
             PeriodicityEditor(title="Edit periodicity"),
             ShakeNBreakEditor(title="ShakeNBreak"),
         ]

--- a/src/aiidalab_qe/common/__init__.py
+++ b/src/aiidalab_qe/common/__init__.py
@@ -2,6 +2,7 @@
 from .node_view import CalcJobNodeViewerWidget  # noqa: F401
 from .process import QeAppWorkChainSelector, WorkChainSelector
 from .widgets import (
+    AddingFixedAtomsEditor,
     AddingTagsEditor,
     LazyLoadedOptimade,
     LazyLoadedStructureBrowser,
@@ -10,6 +11,7 @@ from .widgets import (
 )
 
 __all__ = [
+    "AddingFixedAtomsEditor",
     "AddingTagsEditor",
     "LazyLoadedOptimade",
     "LazyLoadedStructureBrowser",

--- a/src/aiidalab_qe/common/__init__.py
+++ b/src/aiidalab_qe/common/__init__.py
@@ -2,7 +2,7 @@
 from .node_view import CalcJobNodeViewerWidget  # noqa: F401
 from .process import QeAppWorkChainSelector, WorkChainSelector
 from .widgets import (
-    AddingFixedAtomsEditor,
+    AddingConstraintsEditor,
     AddingTagsEditor,
     LazyLoadedOptimade,
     LazyLoadedStructureBrowser,
@@ -11,7 +11,7 @@ from .widgets import (
 )
 
 __all__ = [
-    "AddingFixedAtomsEditor",
+    "AddingConstraintsEditor",
     "AddingTagsEditor",
     "LazyLoadedOptimade",
     "LazyLoadedStructureBrowser",

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -627,14 +627,12 @@ class AddingTagsEditor(ipw.VBox):
         self.input_selection = None
         self.input_selection = deepcopy(self.selection)
 
-
-import re, html
-import numpy as np
-from copy import deepcopy
-
-###ASA
 class AddingConstraintsEditor(ipw.VBox):
-    """Editor for per-atom constraints; supports 'fixed <axes>' → free-mask (1=free, 0=fixed)."""
+    """Editor for per-atom constraints; supports:
+       - 'fixed <axes>' / 'free <axes>' -> free-mask (1=free, 0=fixed)
+       - 'distance <float>' -> pair distance constraint stored in atoms.info['CONSTRAINTS']
+       - 'none' -> remove constraints involving selected atoms
+    """
 
     structure = traitlets.Instance(ase.Atoms, allow_none=True)
     selection = traitlets.List(traitlets.Int(), allow_none=True)
@@ -642,6 +640,7 @@ class AddingConstraintsEditor(ipw.VBox):
     structure_node = traitlets.Instance(orm_Data, allow_none=True, read_only=True)
 
     _ARRAY_NAME = "fixed_atoms"  # Nx3 int array, 1=free, 0=fixed
+    _INFO_KEY = "CONSTRAINTS"    # dict with {'number', 'tolerance', 'list'}
 
     def __init__(self, title="", **kwargs):
         self.title = title
@@ -657,10 +656,9 @@ class AddingConstraintsEditor(ipw.VBox):
         self.from_selection = ipw.Button(description="From selection")
         self.from_selection.on_click(self._from_selection)
 
-        # Renamed: general 'constraint' field. No numeric masks allowed.
         self.constraint = ipw.Text(
             description="Constraint",
-            placeholder="fixed x y   |   free x,y",
+            placeholder="fixed x y   |   free x,y   |   distance 2.0   |   none",
             value="free x y z",
             layout={"width": "initial"},
             style={"description_width": "100px"},
@@ -701,25 +699,15 @@ class AddingConstraintsEditor(ipw.VBox):
                     """
                     <p>
                     Constrain movement per atom with <code>fixed &lt;axes&gt;</code> or <code>free &lt;axes&gt;</code>, where axes are any of x, y, z.<br>
-                    Examples:<br>
-                    &nbsp;&nbsp;• <code>fixed x</code> → (0 1 1)&nbsp;&nbsp;&nbsp;&nbsp;• <code>fixed x y</code> → (0 0 1)<br>
-                    &nbsp;&nbsp;• <code>free x</code> → (1 0 0)&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• <code>free x y</code> → (1 1 0)<br>
-                    <b>Numeric masks like '0 1 0' are not accepted.</b>
+                    Also supported: <code>distance &lt;value&gt;</code> (requires exactly two atoms selected), and <code>none</code> to remove constraints for the selected atoms.
                     </p>
-                    <p style="font-weight: bold; color: #1f77b4;">NOTE:</p>
                     <ul style="padding-left: 2em; list-style-type: disc;">
-                        <li>Atom indices in the UI start from 1.</li>
+                        <li>Indices shown are 1-based in the legend (e.g. "distance 1 2 2.0").</li>
                         <li>Unmodified atoms keep the default <code>(1, 1, 1)</code> (all free).</li>
                     </ul>
                     """
                 ),
-                ipw.HBox(
-                    [
-                        self.atom_selection,
-                        self.from_selection,
-                        self.constraint,
-                    ]
-                ),
+                ipw.HBox([self.atom_selection, self.from_selection, self.constraint]),
                 self.fixed_display,
                 self.scroll_note,
                 ipw.HBox([self.apply_constraint, self.reset_fixed, self.reset_all_fixed]),
@@ -731,53 +719,96 @@ class AddingConstraintsEditor(ipw.VBox):
     # ---------- helpers ----------
 
     def _ensure_mask_array(self, atoms):
-        """Ensure atoms has an Nx3 int mask array named _ARRAY_NAME (default ones)."""
         if atoms is None:
             return
         if self._ARRAY_NAME not in atoms.arrays:
             atoms.set_array(self._ARRAY_NAME, np.ones((len(atoms), 3), dtype=int))
 
+    def _get_constraints_info(self, atoms):
+        """Return a normalized constraints dict from atoms.info[_INFO_KEY]."""
+        info = atoms.info.get(self._INFO_KEY, None)
+        if not isinstance(info, dict):
+            info = {}
+        number = int(info.get("number", 0))
+        tol = str(info.get("tolerance", "1e-6"))
+        items = info.get("list", [])
+        if not isinstance(items, list):
+            items = []
+        return {"number": number, "tolerance": tol, "list": list(items)}
+
+    def _set_constraints_info(self, atoms, cdict):
+        """Persist constraints dict back to atoms.info[_INFO_KEY]."""
+        atoms.info[self._INFO_KEY] = {
+            "number": int(cdict.get("number", 0)),
+            "tolerance": str(cdict.get("tolerance", "1e-6")),
+            "list": list(cdict.get("list", [])),
+        }
+
     def _parse_constraint_text(self, text):
         """
-        Parse 'fixed <axes>' or 'free <axes>' into a (3,) mask (1=free, 0=fixed).
-        Examples:
-        fixed x y -> [0, 0, 1]
-        free  x y -> [1, 1, 0]
+        Returns a tuple (mode, payload):
+          - ('mask', np.array([x,y,z])) for fixed/free
+          - ('distance', float_value) for 'distance <float>'
+          - ('none', None) for 'none'
         """
         if not text or not text.strip():
             raise ValueError("Constraint string is empty.")
-
         s = text.strip().lower()
 
-        # reject any digits (we no longer accept numeric masks)
-        if re.search(r"\d", s):
-            raise ValueError("Numeric masks are not accepted; use 'fixed x y' or 'free x y'.")
+        # 'none' removes constraints involving selected atoms
+        if s == "none":
+            return ("none", None)
 
+        # distance <float>
+        m = re.match(r"^distance\s+([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)\s*$", s)
+        if m:
+            return ("distance", float(m.group(1)))
+
+        # reject digits for fixed/free (we don't accept numeric masks)
+        if re.search(r"\d", s):
+            raise ValueError("Numeric masks are not accepted; use 'fixed x y', 'free x', 'distance 2.0', or 'none'.")
+
+        # fixed/free axes
         m = re.match(r"^(fix(?:ed)?|free)\b\s*(.*)$", s)
         if not m:
-            raise ValueError("Constraint must start with 'fixed' or 'free' (e.g. 'fixed x', 'free y z').")
-
+            raise ValueError("Constraint must be 'fixed ...', 'free ...', 'distance <float>', or 'none'.")
         mode = "fixed" if m.group(1).startswith("fix") else "free"
         tail = m.group(2) or ""
-
-        # only parse axes from the tail (after the keyword), commas/spaces allowed, order-insensitive
         axes = re.findall(r"[xyz]", tail)
         if not axes:
             raise ValueError("Specify at least one axis after the keyword (x, y, z).")
-
         idx_map = {"x": 0, "y": 1, "z": 2}
         if mode == "fixed":
-            mask = np.ones(3, dtype=int)   # default free
+            mask = np.ones(3, dtype=int)
             for ax in axes:
-                mask[idx_map[ax]] = 0      # listed axes become fixed
-        else:  # mode == "free"
-            mask = np.zeros(3, dtype=int)  # default fixed
+                mask[idx_map[ax]] = 0
+        else:
+            mask = np.zeros(3, dtype=int)
             for ax in axes:
-                mask[idx_map[ax]] = 1      # listed axes become free
+                mask[idx_map[ax]] = 1
+        return ("mask", mask)
 
-        return mask
-
-
+    def _constraints_index_map(self, atoms_len, cdict):
+        """Return mapping atom_index -> list of constraint labels ['*1','*3',...] and legend lines."""
+        marks = {i: [] for i in range(atoms_len)}
+        legend = []
+        for i, entry in enumerate(cdict.get("list", []), start=1):
+            # expected format: "distance i j value"
+            parts = entry.strip().split()
+            if len(parts) >= 4 and parts[0] == "distance":
+                try:
+                    i1 = int(parts[1]) - 1
+                    i2 = int(parts[2]) - 1
+                except Exception:
+                    continue
+                label = f"*{i}"
+                if 0 <= i1 < atoms_len:
+                    marks[i1].append(label)
+                if 0 <= i2 < atoms_len:
+                    marks[i2].append(label)
+            # legend shows with star
+            legend.append(f"*{i} {entry}")
+        return marks, legend
 
     # ---------- UI logic ----------
 
@@ -791,20 +822,34 @@ class AddingConstraintsEditor(ipw.VBox):
         chemichal_symbols = self.structure.get_chemical_symbols()
         current_mask = self.structure.get_array(self._ARRAY_NAME)
 
+        # constraints marks & legend
+        cdict = self._get_constraints_info(self.structure)
+        marks_map, legend = self._constraints_index_map(len(self.structure), cdict)
+
         if selection and (min(selection) >= 0):
             rows = []
             for index in selection:
                 symbol = chemichal_symbols[index]
                 m = current_mask[index]
-                rows.append([f"{index + 1}", f"{symbol}", f"{int(m[0])} {int(m[1])} {int(m[2])}"])
+                mask_str = f"{int(m[0])} {int(m[1])} {int(m[2])}"
+                stars = " ".join(marks_map.get(index, []))
+                rows.append([f"{index + 1}", f"{symbol}", mask_str, stars])
 
             table_html = "<table>"
-            table_html += "<tr><th>Index</th><th>Element</th><th>Free (x y z)</th></tr>"
+            table_html += "<tr><th>Index</th><th>Element</th><th>Free (x y z)</th><th>Constr.</th></tr>"
             for row in rows:
                 table_html += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>"
             table_html += "</table>"
 
-            self.fixed_display.layout = {"overflow": "auto", "height": "120px", "width": "260px"}
+            # Append legend below the table
+            if legend:
+                table_html += "<div style='margin-top:6px; font-size: 90%;'>"
+                table_html += "<div><b>Constraints:</b></div>"
+                for line in legend:
+                    table_html += f"<div>{line}</div>"
+                table_html += "</div>"
+
+            self.fixed_display.layout = {"overflow": "auto", "height": "150px", "width": "320px"}
             with self.fixed_display:
                 clear_output()
                 display(HTML(table_html))
@@ -819,7 +864,7 @@ class AddingConstraintsEditor(ipw.VBox):
         self.atom_selection.value = list_to_string_range(self.selection)
 
     def _add_fixed(self, _=None):
-        """Apply parsed 'fixed …' constraint to the selected atoms (updates free-mask)."""
+        """Apply parsed constraint to the selected atoms."""
         if not self.atom_selection.value:
             self._status_message.message = """
             <div class="alert alert-info"><strong>Please select atoms first.</strong></div>
@@ -827,7 +872,7 @@ class AddingConstraintsEditor(ipw.VBox):
             return
 
         try:
-            new_mask_row = self._parse_constraint_text(self.constraint.value)  # (3,)
+            mode, payload = self._parse_constraint_text(self.constraint.value)
         except Exception as exc:
             self._status_message.message = f"""
             <div class="alert alert-danger"><strong>Invalid constraint:</strong> {html.escape(str(exc))}</div>
@@ -836,27 +881,85 @@ class AddingConstraintsEditor(ipw.VBox):
 
         selection = string_range_to_list(self.atom_selection.value)[0]
         selection = [s for s in selection if 0 <= s < len(self.structure)]
-
-        new_structure = deepcopy(self.structure)
-        self._ensure_mask_array(new_structure)
-
         if len(selection) == 0:
             self._status_message.message = """
             <div class="alert alert-warning"><strong>No valid atom indices selected.</strong></div>
             """
             return
 
-        mask = new_structure.get_array(self._ARRAY_NAME).copy()
-        mask[selection, :] = new_mask_row  # broadcast
-        new_structure.set_array(self._ARRAY_NAME, mask)
+        new_structure = deepcopy(self.structure)
+        self._ensure_mask_array(new_structure)
 
+        if mode == "mask":
+            # fixed/free axes → update per-atom mask
+            mask = new_structure.get_array(self._ARRAY_NAME).copy()
+            mask[selection, :] = payload  # payload is (3,) array
+            new_structure.set_array(self._ARRAY_NAME, mask)
+            msg = "Constraint applied to selected atoms."
+
+        elif mode == "distance":
+            # must select exactly two distinct atoms
+            uniq = sorted(set(selection))
+            if len(uniq) != 2:
+                self._status_message.message = """
+                <div class="alert alert-danger"><strong>distance</strong> requires exactly two selected atoms.</div>
+                """
+                return
+            i1, i2 = uniq[0] + 1, uniq[1] + 1  # 1-based
+            value = payload
+            cdict = self._get_constraints_info(new_structure)
+            # append new entry
+            entry = f"distance {i1} {i2} {value:g}"
+            cdict["list"].append(entry)
+            cdict["number"] = len(cdict["list"])
+            # keep tolerance if already set; otherwise default
+            if "tolerance" not in cdict or not cdict["tolerance"]:
+                cdict["tolerance"] = "1e-6"
+            self._set_constraints_info(new_structure, cdict)
+            msg = f"Added constraint: {entry}"
+
+        elif mode == "none":
+            # remove any constraints that involve any selected atom
+            sel_set = set(selection)
+            cdict = self._get_constraints_info(new_structure)
+            kept = []
+            for entry in cdict["list"]:
+                parts = entry.strip().split()
+                if len(parts) >= 4 and parts[0] == "distance":
+                    try:
+                        a = int(parts[1]) - 1
+                        b = int(parts[2]) - 1
+                    except Exception:
+                        kept.append(entry)
+                        continue
+                    if {a, b} & sel_set:
+                        # drop this constraint
+                        continue
+                else:
+                    # unknown format → keep
+                    kept.append(entry)
+            cdict["list"] = kept
+            cdict["number"] = len(kept)
+            if cdict["number"] == 0:
+                # keep the block but empty; you could also del info[_INFO_KEY]
+                cdict["tolerance"] = cdict.get("tolerance", "1e-6")
+            self._set_constraints_info(new_structure, cdict)
+            msg = "Removed constraints involving selected atoms."
+
+        else:
+            self._status_message.message = """
+            <div class="alert alert-danger"><strong>Unsupported constraint mode.</strong></div>
+            """
+            return
+
+        # trigger traitlet updates
         self.structure = None
         self.structure = deepcopy(new_structure)
         self.input_selection = None
         self.input_selection = deepcopy(self.selection)
 
-        self._status_message.message = """
-        <div class="alert alert-success"><strong>Constraint applied to selected atoms.</strong></div>
+        self._status_message.message = f"""
+        <div class="alert alert-success"><strong>{html.escape(msg)}</strong></div>
         """
 
     def _reset_fixed(self, _=None):
@@ -893,7 +996,7 @@ class AddingConstraintsEditor(ipw.VBox):
         """
 
     def _reset_all_fixed(self, _=None):
-        """Reset all atoms to (1,1,1) free movement."""
+        """Reset all atoms to (1,1,1) free movement (does not touch distance constraints)."""
         new_structure = deepcopy(self.structure)
         self._ensure_mask_array(new_structure)
 
@@ -909,7 +1012,6 @@ class AddingConstraintsEditor(ipw.VBox):
         <div class="alert alert-success"><strong>All atoms reset to (1,1,1).</strong></div>
         """
 
-###ASA
 class PeriodicityEditor(ipw.VBox):
     """Editor for changing periodicity of structures."""
 

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -206,7 +206,10 @@ class QeAppWorkChain(WorkChain):
             relax_builder.pop("structure", None)
             relax_builder.pop("clean_workdir", None)
             relax_builder.pop("base_final_scf", None)  # never run a final scf
-            builder.relax = relax_builder
+            if 'fixed_atoms' in structure.base.attributes.all:
+                
+                relax_builder.base.pw.settings = orm.Dict({'FIXED_COORDS':[[v == 0 for v in row] for row in structure.base.attributes.all['fixed_atoms']]})
+            builder.relax = relax_builder            
         else:
             builder.pop("relax")
 

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -206,9 +206,13 @@ class QeAppWorkChain(WorkChain):
             relax_builder.pop("structure", None)
             relax_builder.pop("clean_workdir", None)
             relax_builder.pop("base_final_scf", None)  # never run a final scf
+            settings = {}
             if 'fixed_atoms' in structure.base.attributes.all:
-                
-                relax_builder.base.pw.settings = orm.Dict({'FIXED_COORDS':[[v == 0 for v in row] for row in structure.base.attributes.all['fixed_atoms']]})
+                settings['FIXED_COORDS'] = [[v == 0 for v in row] for row in structure.base.attributes.all['fixed_atoms']]
+            if 'CONSTRAINTS' in structure.base.attributes.all:
+                settings['CONSTRAINTS'] = structure.base.attributes.all['CONSTRAINTS']
+            if settings:
+                relax_builder.base.pw.settings = orm.Dict(dict=settings)
             builder.relax = relax_builder            
         else:
             builder.pop("relax")


### PR DESCRIPTION
connected to https://github.com/aiidalab/aiidalab-widgets-base/pull/706
Constraints on x,y,z for each atom are stored in the ASE array 'fixed_atoms' .
<img width="638" height="564" alt="image" src="https://github.com/user-attachments/assets/26889e58-dfc4-44a6-9e74-4c3523cbf7ce" />
<img width="540" height="324" alt="image" src="https://github.com/user-attachments/assets/1e1d2b17-463b-4893-a3d4-6a700d0f5391" />
The additional column is not present in case no constraints were specified

I need help (I would prefer in a separate PR), e.g. @edan-bainglass @superstar54, to add some warning logics:
If I load a structure that has constraints and I try to do phonons-related properties, I should get a warning. The warning can disappear only if 1)I remove the constraints, and 2) I do an additional geo-opt.

We should think about how to make this editor more general, including other [types of constraints](https://www.quantum-espresso.org/Doc/INPUT_PW.html#idm1633)