### PR TITLE
Image cleanup

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -70,10 +70,6 @@ jobs:
                   push: ${{ ! (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
                   context: .
                   platforms: linux/amd64
-                  cache-to: |
-                      type=gha,scope=${{ github.workflow }},mode=min
-                  cache-from: |
-                      type=gha,scope=${{ github.workflow }}
 
             - name: Set Up Python 🐍
               uses: actions/setup-python@v5

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -61,7 +61,7 @@ jobs:
 
             - name: Build and push images (GHCR)
               id: build-upload
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v6
               with:
                   # Provide multiple comma/line-separated tags:
                   tags: >


### PR DESCRIPTION
This PR attempts to add some cleanup prior to image build and reduce cache explosion to reduce image size, which is currently failing all tests due to size limit exceeding.