### PR TITLE
Decouple build and integration tests

### DIFF
--- a/.github/workflows/chrome-tests.yml
+++ b/.github/workflows/chrome-tests.yml
@@ -1,0 +1,58 @@
+---
+name: Run integration tests
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+        tags:
+            - v*
+    workflow_dispatch:
+
+env:
+    FORCE_COLOR: 1
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    run-integration-tests:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout Repo
+              uses: actions/checkout@v4
+
+            - name: Login to GitHub Container Registry 🔑
+              uses: docker/login-action@v2
+              if: ${{ !github.event.pull_request.head.repo.fork }}
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Set Up Python 🐍
+              uses: actions/setup-python@v5
+              with:
+                  python-version: 3.11
+
+            - name: Install Dev Dependencies 📦
+              run: pip install -r requirements-docker.txt
+
+            - name: Set jupyter token env
+              run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
+
+            - name: Run pytest for Chrome
+              run: pytest -sv --driver Chrome tests_integration/
+
+            - name: Upload screenshots as artifacts
+              if: always()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: Screenshots
+                  path: screenshots/
+                  if-no-files-found: error

--- a/.github/workflows/chrome-tests.yml
+++ b/.github/workflows/chrome-tests.yml
@@ -12,6 +12,7 @@ on:
 
 env:
     FORCE_COLOR: 1
+    RUNNING_INTEGRATION_TESTS: '1'
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -2,12 +2,10 @@
 name: Build Docker image and test
 
 on:
-    pull_request:
-    push:
-        branches:
-            - main
-        tags:
-            - v*
+    workflow_run:
+        workflows: ['Run integration tests']
+        types:
+            - completed
     workflow_dispatch:
 
 env:
@@ -23,6 +21,7 @@ concurrency:
 
 jobs:
     build-test:
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-latest
 
         steps:
@@ -74,38 +73,3 @@ jobs:
                       type=gha,scope=${{ github.workflow }},mode=min
                   cache-from: |
                       type=gha,scope=${{ github.workflow }}
-
-            - name: Set Up Python 🐍
-              uses: actions/setup-python@v5
-              with:
-                  python-version: 3.11
-
-            - name: Install Dev Dependencies 📦
-              run: pip install -r requirements-docker.txt
-
-            - name: Set jupyter token env
-              run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
-
-            - name: Run pytest for Chrome
-              run: pytest -sv --driver Chrome tests_integration/
-              env:
-                  # We'd like to identify the image by its unique digest, i.e ghcr.io/aiidalab/qe@sha256:<digest>
-                  # but that sadly does not work when the image is loaded to Docker locally and not published on ghcr.io
-                  # as is the case for PRs from forks. Hence this super-ugly ternary expression...
-                  # For forks, we take the image as ghcr.io/aiidalab/qe:pr-XXX
-                  # which is stored in the steps.meta_ghcr.outputs.tags variable
-                  QE_IMAGE: >-
-                      ${{
-                          github.event_name == 'pull_request' &&
-                          github.event.pull_request.head.repo.fork &&
-                          steps.meta_ghcr.outputs.tags ||
-                          format('ghcr.io/{0}@{1}', env.IMAGE_NAME, steps.build-upload.outputs.imageid)
-                      }}
-
-            - name: Upload screenshots as artifacts
-              if: always()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: Screenshots
-                  path: screenshots/
-                  if-no-files-found: error

--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -3,6 +3,7 @@
 Authors: AiiDAlab team
 """
 
+import os
 from pathlib import Path
 
 import ipywidgets as ipw
@@ -64,8 +65,10 @@ class QeApp:
                 )
             )
 
+        running_integration_tests = os.getenv("RUNNING_INTEGRATION_TESTS", "0") == "1"
+
         # Set up bug report handling (if a URL is provided)
-        if bug_report_url:
+        if bug_report_url and not running_integration_tests:
             install_create_github_issue_exception_handler(
                 self.log_widget if show_log else self.view.output,
                 url=bug_report_url,

--- a/tests_integration/test_app.py
+++ b/tests_integration/test_app.py
@@ -50,6 +50,8 @@ def test_qe_app_select_silicon_and_confirm(
     except Exception:
         driver.find_element(By.TAG_NAME, "summary").click()
         time.sleep(10)
+    # Scroll to bottom of screen
+    driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
     # Take a screenshot of the selected diamond
     driver.get_screenshot_as_file(
         str(Path.joinpath(screenshot_dir, "qe-app-select-diamond-selected.png"))


### PR DESCRIPTION
This PR aims to separate out Chrome Selenium tests to its own job, making the build process depend on it.