### PR TITLE
Cleanup

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/__init__.py
+++ b/src/aiidalab_qe/app/configuration/advanced/__init__.py
@@ -1,7 +1,43 @@
 from .advanced import AdvancedConfigurationSettingsPanel
+from .convergence import (
+    ConvergenceConfigurationSettingsModel,
+    ConvergenceConfigurationSettingsPanel,
+)
+from .general import (
+    GeneralConfigurationSettingsModel,
+    GeneralConfigurationSettingsPanel,
+)
+from .hubbard import (
+    HubbardConfigurationSettingsModel,
+    HubbardConfigurationSettingsPanel,
+)
+from .magnetization import (
+    MagnetizationConfigurationSettingsModel,
+    MagnetizationConfigurationSettingsPanel,
+)
 from .model import AdvancedConfigurationSettingsModel
+from .pseudos import (
+    PseudosConfigurationSettingsModel,
+    PseudosConfigurationSettingsPanel,
+)
+from .smearing import (
+    SmearingConfigurationSettingsModel,
+    SmearingConfigurationSettingsPanel,
+)
 
 __all__ = [
     "AdvancedConfigurationSettingsModel",
     "AdvancedConfigurationSettingsPanel",
+    "ConvergenceConfigurationSettingsModel",
+    "ConvergenceConfigurationSettingsPanel",
+    "GeneralConfigurationSettingsModel",
+    "GeneralConfigurationSettingsPanel",
+    "HubbardConfigurationSettingsModel",
+    "HubbardConfigurationSettingsPanel",
+    "MagnetizationConfigurationSettingsModel",
+    "MagnetizationConfigurationSettingsPanel",
+    "PseudosConfigurationSettingsModel",
+    "PseudosConfigurationSettingsPanel",
+    "SmearingConfigurationSettingsModel",
+    "SmearingConfigurationSettingsPanel",
 ]

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
@@ -51,11 +51,22 @@ class ConvergenceConfigurationSettingsPanel(
             )
         )
         ipw.dlink(
-            (self._model, "scf_conv_thr"),
+            (self._model, "scf_conv_thr_abs"),
             (scf_conv_thr_abs, "value"),
-            lambda value: f"{value * len(self._model.input_structure.sites):.5e}",
+            lambda v: f"{v:.5e}",
         )
         scf_conv_thr_abs.add_class("convergence-label")
+
+        scf_conv_thr_with_units = HBoxWithUnits(
+            widget=scf_conv_thr_abs,
+            units="Ry",
+            layout={"margin": "-8px 0 0 150px"},
+        )
+        ipw.dlink(
+            (self._model, "structure_uuid"),
+            (scf_conv_thr_with_units.layout, "display"),
+            lambda _: "flex" if self._model.has_structure else "none",
+        )
 
         self.etot_conv_thr = ipw.BoundedFloatText(
             min=1e-15,
@@ -74,11 +85,22 @@ class ConvergenceConfigurationSettingsPanel(
 
         etot_conv_thr_abs = ipw.Label()
         ipw.dlink(
-            (self._model, "etot_conv_thr"),
+            (self._model, "etot_conv_thr_abs"),
             (etot_conv_thr_abs, "value"),
-            lambda value: f"{value * len(self._model.input_structure.sites):.5e}",
+            lambda v: f"{v:.5e}",
         )
         etot_conv_thr_abs.add_class("convergence-label")
+
+        etot_conv_thr_with_units = HBoxWithUnits(
+            widget=etot_conv_thr_abs,
+            units="Ry",
+            layout={"margin": "-8px 0 0 150px"},
+        )
+        ipw.dlink(
+            (self._model, "structure_uuid"),
+            (etot_conv_thr_with_units.layout, "display"),
+            lambda _: "flex" if self._model.has_structure else "none",
+        )
 
         self.forc_conv_thr = ipw.BoundedFloatText(
             min=1e-15,
@@ -185,22 +207,14 @@ class ConvergenceConfigurationSettingsPanel(
             ipw.VBox(
                 children=[
                     HBoxWithUnits(self.scf_conv_thr, "Ry/atom"),
-                    HBoxWithUnits(
-                        widget=scf_conv_thr_abs,
-                        units="Ry",
-                        layout={"margin": "-8px 0 0 150px"},
-                    ),
+                    scf_conv_thr_with_units,
                 ]
             ),
             ipw.HTML("<h4>Thresholds for ionic convergence</h4>"),
             ipw.VBox(
                 children=[
                     HBoxWithUnits(self.etot_conv_thr, "Ry/atom"),
-                    HBoxWithUnits(
-                        widget=etot_conv_thr_abs,
-                        units="Ry",
-                        layout={"margin": "-8px 0 0 150px"},
-                    ),
+                    etot_conv_thr_with_units,
                 ]
             ),
             HBoxWithUnits(self.forc_conv_thr, "Ry/Bohr"),

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
@@ -86,16 +86,11 @@ class HubbardConfigurationSettingsPanel(
     def _on_eigenvalues_definition(self, _):
         self._toggle_eigenvalues_widget()
 
-    def update(self, specific=""):
-        if self._model.updated:
-            return
+    def _update(self):
         self._show_loading()
-        if not self._model.locked or (specific and specific != "widgets"):
-            self._model.update(specific)
         self._build_hubbard_widget()
         self._toggle_hubbard_widget()
         self._toggle_eigenvalues_widget()
-        self._model.updated = True
 
     def _show_loading(self):
         if self.rendered:

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/model.py
@@ -43,6 +43,10 @@ class HubbardConfigurationSettingsModel(
 
     include = True  # build-in panel
 
+    @property
+    def needs_eigenvalues_widget(self):
+        return len(self.applicable_kind_names) > 0
+
     def update(self, specific=""):  # noqa: ARG002
         if not self.has_structure:
             self.applicable_kind_names = []
@@ -65,7 +69,6 @@ class HubbardConfigurationSettingsModel(
         with self.hold_trait_notifications():
             self.parameters = self._get_default_parameters()
             self.eigenvalues = self._get_default_eigenvalues()
-            self.needs_eigenvalues_widget = len(self.applicable_kind_names) > 0
 
     def get_active_eigenvalues(self):
         if not (

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -97,7 +97,7 @@ class MagnetizationConfigurationSettingsPanel(
             self.unit,
         )
 
-        self.kind_moment_widgets = ipw.VBox()
+        self.moments_list = ipw.VBox()
 
         self.container = ipw.VBox(
             children=[
@@ -128,22 +128,17 @@ class MagnetizationConfigurationSettingsPanel(
         self._toggle_widgets()
         self._model.update_type_help()
 
-    def update(self, specific=""):
-        if self._model.updated:
-            return
+    def _update(self):
         self._show_loading()
-        if not self._model.locked or (specific and specific != "widgets"):
-            self._model.update(specific)
-        self._build_kinds_widget()
+        self._build_moments_list()
         self._switch_widgets()
         self._toggle_widgets()
-        self._model.updated = True
 
     def _show_loading(self):
         if self.rendered:
-            self.kind_moment_widgets.children = [self.loading_message]
+            self.moments_list.children = [self.loading_message]
 
-    def _build_kinds_widget(self):
+    def _build_moments_list(self):
         if not self.rendered:
             return
 
@@ -156,7 +151,7 @@ class MagnetizationConfigurationSettingsPanel(
         )
 
         for kind_name in kind_names:
-            kind_moment_widget = ipw.BoundedFloatText(
+            kind_moment = ipw.BoundedFloatText(
                 description=kind_name,
                 min=-7,
                 max=7,
@@ -165,7 +160,7 @@ class MagnetizationConfigurationSettingsPanel(
             )
             link = ipw.link(
                 (self._model, "moments"),
-                (kind_moment_widget, "value"),
+                (kind_moment, "value"),
                 [
                     lambda moments, kind_name=kind_name: moments.get(kind_name, 0.0),
                     lambda value, kind_name=kind_name: {
@@ -175,9 +170,9 @@ class MagnetizationConfigurationSettingsPanel(
                 ],
             )
             self._links.append(link)
-            children.append(HBoxWithUnits(kind_moment_widget, "µ<sub>B</sub>"))
+            children.append(HBoxWithUnits(kind_moment, "µ<sub>B</sub>"))
 
-        self.kind_moment_widgets.children = children
+        self.moments_list.children = children
 
     def _switch_widgets(self):
         if not self.rendered:
@@ -206,5 +201,5 @@ class MagnetizationConfigurationSettingsPanel(
         self.container.children = [
             self.tot_magnetization_with_unit
             if self._model.type == "tot_magnetization"
-            else self.kind_moment_widgets
+            else self.moments_list
         ]

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -153,7 +153,7 @@ class PseudosConfigurationSettingsModel(
         if self.locked or not (self.functional and self.family):
             return
         self.functionals = (
-            [self.functional for _ in self.input_structure.kinds]
+            [self.functional] * len(self.input_structure.kinds)
             if self.has_structure
             else []
         )

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -82,17 +82,10 @@ class PseudosConfigurationSettingsPanel(
             (self._model, "functional"),
             (self.functional, "value"),
         )
-        ipw.link(
-            (self._model, "functional"),
+        ipw.dlink(
             (self._model, "functionals"),
-            [
-                lambda functional: [functional] * len(self._model.input_structure.kinds)
-                if self._model.has_structure
-                else [],
-                lambda functionals: functionals[0]
-                if len(set(functionals)) == 1
-                else None,
-            ],
+            (self._model, "functional"),
+            lambda functionals: functionals[0] if len(set(functionals)) == 1 else None,
         )
 
         self.library = ipw.ToggleButtons(style={"button_width": "fit-content"})
@@ -243,10 +236,12 @@ class PseudosConfigurationSettingsPanel(
 
     def _on_functional_change(self, _):
         self._model.update_family()
+        self._model.update_functionals()
 
     def _on_library_change(self, _):
         self._model.update_family_header()
         self._model.update_family()
+        self._model.update_blockers()
 
     def _on_functionals_change(self, _):
         self._model.update_blockers()

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -33,8 +33,12 @@ class PseudosConfigurationSettingsPanel(
             "spin_orbit",
         )
         self._model.observe(
-            self._on_family_parameters_change,
-            ["library", "functional"],
+            self._on_functional_change,
+            "functional",
+        )
+        self._model.observe(
+            self._on_library_change,
+            "library",
         )
         self._model.observe(
             self._on_functionals_change,
@@ -51,10 +55,6 @@ class PseudosConfigurationSettingsPanel(
         self._model.observe(
             self._on_cutoffs_change,
             "cutoffs",
-        )
-        self._model.observe(
-            self._on_show_upload_warning_change,
-            "show_upload_warning",
         )
 
     def render(self):
@@ -82,6 +82,18 @@ class PseudosConfigurationSettingsPanel(
             (self._model, "functional"),
             (self.functional, "value"),
         )
+        ipw.link(
+            (self._model, "functional"),
+            (self._model, "functionals"),
+            [
+                lambda functional: [functional] * len(self._model.input_structure.kinds)
+                if self._model.has_structure
+                else [],
+                lambda functionals: functionals[0]
+                if len(set(functionals)) == 1
+                else None,
+            ],
+        )
 
         self.library = ipw.ToggleButtons(style={"button_width": "fit-content"})
         ipw.dlink(
@@ -93,7 +105,7 @@ class PseudosConfigurationSettingsPanel(
             (self.library, "value"),
         )
 
-        self.setter_widget = ipw.VBox()
+        self.pseudos_list = ipw.VBox()
 
         self.ecutwfc = ipw.FloatText(
             description="Wavefunction",
@@ -137,6 +149,11 @@ class PseudosConfigurationSettingsPanel(
             layout=ipw.Layout(
                 display="block" if self._model.show_upload_warning else "none",
             ),
+        )
+        ipw.dlink(
+            (self._model, "show_upload_warning"),
+            (self._warning_message.layout, "display"),
+            lambda show: "block" if show else "none",
         )
 
         self.children = [
@@ -190,7 +207,7 @@ class PseudosConfigurationSettingsPanel(
                     </ul>
                 </div>
             """),
-            self.setter_widget,
+            self.pseudos_list,
             ipw.HTML("<h4>Cutoffs</h4>"),
             ipw.HTML("""
                 <div style="line-height: 1.4;">
@@ -224,18 +241,14 @@ class PseudosConfigurationSettingsPanel(
     def _on_spin_orbit_change(self, _):
         self._model.update_library_options()
 
-    def _on_family_parameters_change(self, _):
+    def _on_functional_change(self, _):
         self._model.update_family()
+
+    def _on_library_change(self, _):
         self._model.update_family_header()
-        self._model.update_functionals()
-        self._model.update_blockers()
+        self._model.update_family()
 
     def _on_functionals_change(self, _):
-        self._model.functional = (
-            self._model.functionals[0]  # type: ignore
-            if len(set(self._model.functionals)) == 1
-            else None
-        )
         self._model.update_blockers()
 
     def _on_family_change(self, _):
@@ -250,29 +263,15 @@ class PseudosConfigurationSettingsPanel(
         self._model.ecutwfc = max(cutoffs[0])
         self._model.ecutrho = max(cutoffs[1])
 
-    def _on_show_upload_warning_change(self, change):
-        if not self.rendered:
-            return
-        self._warning_message.layout.display = "block" if change["new"] else "none"
-
-    def update(self, specific=""):
-        if self._model.updated:
-            return
-        self._show_loading()
-        if not self._model.locked or (specific and specific != "widgets"):
-            self._model.update(specific)
-        self._build_setter_widgets()
-        self._model.update_library_options()
+    def _update(self):
+        self._build_pseudos_list()
         self._model.update_family_header()
-        self._model.updated = True
 
-    def _show_loading(self):
-        if self.rendered:
-            self.setter_widget.children = [self.loading_message]
-
-    def _build_setter_widgets(self):
+    def _build_pseudos_list(self):
         if not self.rendered:
             return
+
+        self.pseudos_list.children = [self.loading_message]
 
         children = []
 
@@ -355,4 +354,4 @@ class PseudosConfigurationSettingsPanel(
 
             children.append(uploader)
 
-        self.setter_widget.children = children
+        self.pseudos_list.children = children

--- a/src/aiidalab_qe/app/configuration/basic/basic.py
+++ b/src/aiidalab_qe/app/configuration/basic/basic.py
@@ -198,6 +198,8 @@ class BasicConfigurationSettingsPanel(
 
         self.rendered = True
 
+        self._update_info_warning_messages()
+
     def _on_input_structure_change(self, _):
         self.refresh(specific="structure")
 

--- a/src/aiidalab_qe/app/result/components/summary/__init__.py
+++ b/src/aiidalab_qe/app/result/components/summary/__init__.py
@@ -1,7 +1,7 @@
-from .model import WorkChainSummaryModel
-from .summary import WorkChainSummary
+from .model import WorkflowSummaryModel
+from .summary import WorkflowSummary
 
 __all__ = [
-    "WorkChainSummary",
-    "WorkChainSummaryModel",
+    "WorkflowSummary",
+    "WorkflowSummaryModel",
 ]

--- a/src/aiidalab_qe/app/result/components/summary/download_data.py
+++ b/src/aiidalab_qe/app/result/components/summary/download_data.py
@@ -98,7 +98,7 @@ class DownloadDataWidget(ipw.VBox):
         self._downloading_message.value = f"""
             <div style="display: flex; align-items: center; margin: 6px 0;">
                 Creating {what} data to download
-                <i class="fa fa-spinner fa-spin fa-2x fa-fw" style="margin-left: 4px;"></i>
+                <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
             </div>
         """
 

--- a/src/aiidalab_qe/app/result/components/summary/model.py
+++ b/src/aiidalab_qe/app/result/components/summary/model.py
@@ -53,7 +53,7 @@ VDW_CORRECTION_VERSION = {
 }
 
 
-class WorkChainSummaryModel(ResultsComponentModel):
+class WorkflowSummaryModel(ResultsComponentModel):
     identifier = "workflow summary"
 
     failed_calculation_report = tl.Unicode("")

--- a/src/aiidalab_qe/app/result/components/summary/summary.py
+++ b/src/aiidalab_qe/app/result/components/summary/summary.py
@@ -3,13 +3,13 @@ import ipywidgets as ipw
 from aiidalab_qe.app.result.components import ResultsComponent
 from aiidalab_qe.parameters import DEFAULT_PARAMETERS
 
-from .model import WorkChainSummaryModel
+from .model import WorkflowSummaryModel
 from .outputs import WorkChainOutputs
 
 DEFAULT: dict = DEFAULT_PARAMETERS  # type: ignore
 
 
-class WorkChainSummary(ResultsComponent[WorkChainSummaryModel]):
+class WorkflowSummary(ResultsComponent[WorkflowSummaryModel]):
     has_settings_report = False
     has_download_widget = False
 

--- a/src/aiidalab_qe/app/result/components/viewer/__init__.py
+++ b/src/aiidalab_qe/app/result/components/viewer/__init__.py
@@ -1,7 +1,7 @@
-from .model import WorkChainResultsViewerModel
-from .viewer import WorkChainResultsViewer
+from .model import WorkflowResultsViewerModel
+from .viewer import WorkflowResultsViewer
 
 __all__ = [
-    "WorkChainResultsViewer",
-    "WorkChainResultsViewerModel",
+    "WorkflowResultsViewer",
+    "WorkflowResultsViewerModel",
 ]

--- a/src/aiidalab_qe/app/result/components/viewer/model.py
+++ b/src/aiidalab_qe/app/result/components/viewer/model.py
@@ -5,7 +5,7 @@ from aiidalab_qe.common.mixins import HasModels
 from aiidalab_qe.common.panel import ResultsModel
 
 
-class WorkChainResultsViewerModel(
+class WorkflowResultsViewerModel(
     ResultsComponentModel,
     HasModels[ResultsModel],
 ):

--- a/src/aiidalab_qe/app/result/components/viewer/structure/model.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+
 import traitlets as tl
 from ase.formula import Formula
 
@@ -57,11 +59,10 @@ class StructureResultsModel(ResultsModel):
         self.selected_view = "relaxed" if self.selected_view == "initial" else "initial"
 
     def _get_structure(self) -> orm.StructureData | None:
-        try:
-            return self.source.structure if self.source else None
-        except AttributeError:
-            # If source is outputs but job failed, there may not be a structure
+        if not self.source:
             return None
+        with contextlib.suppress(AttributeError):
+            return self.source.structure if self.source else None
 
     def _get_structure_info(self):
         structure = self.structure

--- a/src/aiidalab_qe/app/result/components/viewer/structure/model.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/model.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import contextlib
-
 import traitlets as tl
 from ase.formula import Formula
 
@@ -59,10 +57,10 @@ class StructureResultsModel(ResultsModel):
         self.selected_view = "relaxed" if self.selected_view == "initial" else "initial"
 
     def _get_structure(self) -> orm.StructureData | None:
-        if not self.source:
-            return None
-        with contextlib.suppress(AttributeError):
+        try:
             return self.source.structure if self.source else None
+        except AttributeError:
+            return None
 
     def _get_structure_info(self):
         structure = self.structure

--- a/src/aiidalab_qe/app/result/components/viewer/viewer.py
+++ b/src/aiidalab_qe/app/result/components/viewer/viewer.py
@@ -7,12 +7,12 @@ from aiidalab_qe.common.infobox import InAppGuide
 from aiidalab_qe.common.panel import ResultsPanel
 from aiidalab_qe.plugins.utils import get_entry_items
 
-from .model import WorkChainResultsViewerModel
+from .model import WorkflowResultsViewerModel
 from .structure import StructureResultsModel, StructureResultsPanel
 
 
-class WorkChainResultsViewer(ResultsComponent[WorkChainResultsViewerModel]):
-    def __init__(self, model: WorkChainResultsViewerModel, **kwargs):
+class WorkflowResultsViewer(ResultsComponent[WorkflowResultsViewerModel]):
+    def __init__(self, model: WorkflowResultsViewerModel, **kwargs):
         # NOTE: here we want to add the structure and plugin models to the viewer
         # model BEFORE we define the observation of the process uuid. This ensures
         # that when the process changes, its reflected in the sub-models prior to
@@ -70,7 +70,7 @@ class WorkChainResultsViewer(ResultsComponent[WorkChainResultsViewerModel]):
         if children:
             self.tabs.selected_index = 0
 
-    def _add_structure_panel(self, viewer_model: WorkChainResultsViewerModel):
+    def _add_structure_panel(self, viewer_model: WorkflowResultsViewerModel):
         structure_model = StructureResultsModel()
         structure_model.process_uuid = viewer_model.process_uuid
         self.structure_results = StructureResultsPanel(model=structure_model)
@@ -81,7 +81,7 @@ class WorkChainResultsViewer(ResultsComponent[WorkChainResultsViewerModel]):
             **self.panels,
         }
 
-    def _fetch_plugin_results(self, viewer_model: WorkChainResultsViewerModel):
+    def _fetch_plugin_results(self, viewer_model: WorkflowResultsViewerModel):
         entries = get_entry_items("aiidalab_qe.properties", "result")
         for identifier, entry in entries.items():
             for key in ("panel", "model"):

--- a/src/aiidalab_qe/app/result/step.py
+++ b/src/aiidalab_qe/app/result/step.py
@@ -8,8 +8,8 @@ from aiidalab_widgets_base import ProcessMonitor
 
 from .components import ResultsComponent
 from .components.status import WorkChainStatusModel, WorkChainStatusPanel
-from .components.summary import WorkChainSummary, WorkChainSummaryModel
-from .components.viewer import WorkChainResultsViewer, WorkChainResultsViewerModel
+from .components.summary import WorkflowSummary, WorkflowSummaryModel
+from .components.viewer import WorkflowResultsViewer, WorkflowResultsViewerModel
 from .model import ResultsStepModel
 
 
@@ -24,12 +24,12 @@ class ResultsStep(DependentWizardStep[ResultsStepModel]):
     ):
         super().__init__(model=model, **kwargs)
 
-        summary_model = WorkChainSummaryModel()
-        self.summary_panel = WorkChainSummary(model=summary_model)
+        summary_model = WorkflowSummaryModel()
+        self.summary_panel = WorkflowSummary(model=summary_model)
         self._model.add_model("summary", summary_model)
 
-        results_model = WorkChainResultsViewerModel()
-        self.results_panel = WorkChainResultsViewer(model=results_model)
+        results_model = WorkflowResultsViewerModel()
+        self.results_panel = WorkflowResultsViewer(model=results_model)
         self._model.add_model("results", results_model)
 
         status_model = WorkChainStatusModel()

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -50,7 +50,7 @@ class CodeModel(Model):
 
     @property
     def is_ready(self):
-        return self.is_active and bool(self.selected)
+        return self.is_active and self.selected is not None
 
     @property
     def first_option(self):

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import typing as t
 import warnings
 
@@ -20,10 +21,8 @@ class HasInputStructure(tl.HasTraits):
     def input_structure(self) -> StructureType | None:
         if not self.structure_uuid:
             return None
-        try:
+        with contextlib.suppress(NotExistent):
             return t.cast(StructureType, orm.load_node(self.structure_uuid))
-        except NotExistent:
-            return None
 
     @property
     def has_structure(self):
@@ -123,10 +122,8 @@ class HasProcess(tl.HasTraits):
     def process(self) -> orm.WorkChainNode | None:
         if not self.process_uuid:
             return None
-        try:
+        with contextlib.suppress(NotExistent):
             return t.cast(orm.WorkChainNode, orm.load_node(self.process_uuid))
-        except NotExistent:
-            return None
 
     @property
     def has_process(self):
@@ -190,7 +187,7 @@ class HasBlockers(tl.HasTraits):
         if self.is_blocked:
             formatted = "\n".join(f"<li>{item}</li>" for item in self.blockers)
             self.blocker_messages = f"""
-                <div class="alert alert-danger">
+                <div class="alert alert-danger" style="margin-top: 8px;">
                     <b>The step is blocked due to the following reason(s):</b>
                     <ul>
                         {formatted}

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import typing as t
 import warnings
 
@@ -21,8 +20,10 @@ class HasInputStructure(tl.HasTraits):
     def input_structure(self) -> StructureType | None:
         if not self.structure_uuid:
             return None
-        with contextlib.suppress(NotExistent):
+        try:
             return t.cast(StructureType, orm.load_node(self.structure_uuid))
+        except NotExistent:
+            return None
 
     @property
     def has_structure(self):
@@ -122,8 +123,10 @@ class HasProcess(tl.HasTraits):
     def process(self) -> orm.WorkChainNode | None:
         if not self.process_uuid:
             return None
-        with contextlib.suppress(NotExistent):
+        try:
             return t.cast(orm.WorkChainNode, orm.load_node(self.process_uuid))
+        except NotExistent:
+            return None
 
     @property
     def has_process(self):
@@ -135,11 +138,9 @@ class HasProcess(tl.HasTraits):
 
     @property
     def properties(self) -> list:
-        # read the attributes directly instead of using the `get_list` method
-        # to avoid error in case of the orm.List object being converted to a orm.Data object
         return (
             self.inputs.properties.base.attributes.get("list")
-            if self.has_process
+            if self.inputs and "properties" in self.inputs
             else []
         )
 

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -7,7 +7,6 @@ Authors:
 
 from __future__ import annotations
 
-import os
 import typing as t
 import warnings
 
@@ -18,13 +17,7 @@ from aiida import orm
 from aiida.common.extendeddicts import AttributeDict
 from aiidalab_qe.common.code.model import CodeModel
 from aiidalab_qe.common.infobox import InAppGuide
-from aiidalab_qe.common.mixins import (
-    Confirmable,
-    HasBlockers,
-    HasInputStructure,
-    HasModels,
-    HasProcess,
-)
+from aiidalab_qe.common.mixins import Confirmable, HasBlockers, HasModels, HasProcess
 from aiidalab_qe.common.mvc import Model
 from aiidalab_qe.common.widgets import (
     PwCodeResourceSetupWidget,
@@ -132,11 +125,6 @@ class ConfigurationSettingsPanel(Panel[PM]):
         self._unsubscribe()
         if self._model.include:
             self.update(specific)
-        if "PYTEST_CURRENT_TEST" in os.environ:
-            # Skip resetting to avoid having to inject a structure when testing
-            return
-        if isinstance(self._model, HasInputStructure) and not self._model.has_structure:
-            self._reset()
 
     def update(self, specific=""):
         """Updates the model if not yet updated.
@@ -148,20 +136,20 @@ class ConfigurationSettingsPanel(Panel[PM]):
         """
         if self._model.updated:
             return
-        if not self._model.locked:
+        if not self._model.locked and specific != "widgets":
             self._model.update(specific)
+        self._update()
         self._model.updated = True
+
+    def _update(self):
+        """Updates the panel UI."""
+        pass
 
     def _unsubscribe(self):
         """Unlinks any linked widgets."""
         for link in self._links:
             link.unlink()
         self._links.clear()
-
-    def _reset(self):
-        """Resets the model to present defaults."""
-        self._model.updated = False
-        self._model.reset()
 
 
 class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):

--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import typing as t
 from copy import deepcopy
 
@@ -167,10 +168,8 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
     def process(self) -> ProcessNodeType | None:
         if not self.process_uuid:
             return None
-        try:
+        with contextlib.suppress(NotExistent):
             return t.cast(ProcessNodeType, orm.load_node(self.process_uuid))
-        except NotExistent:
-            return None
 
     def initialize(self):
         self._build_header()

--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import typing as t
 from copy import deepcopy
 
@@ -168,8 +167,10 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
     def process(self) -> ProcessNodeType | None:
         if not self.process_uuid:
             return None
-        with contextlib.suppress(NotExistent):
+        try:
             return t.cast(ProcessNodeType, orm.load_node(self.process_uuid))
+        except NotExistent:
+            return None
 
     def initialize(self):
         self._build_header()

--- a/tests/configuration/test_advanced.py
+++ b/tests/configuration/test_advanced.py
@@ -1,14 +1,14 @@
 from aiidalab_qe.app.configuration.advanced import (
     AdvancedConfigurationSettingsModel,
     AdvancedConfigurationSettingsPanel,
-)
-from aiidalab_qe.app.configuration.advanced.convergence import (
     ConvergenceConfigurationSettingsModel,
     ConvergenceConfigurationSettingsPanel,
-)
-from aiidalab_qe.app.configuration.advanced.general import (
     GeneralConfigurationSettingsModel,
     GeneralConfigurationSettingsPanel,
+    HubbardConfigurationSettingsModel,
+    HubbardConfigurationSettingsPanel,
+    MagnetizationConfigurationSettingsModel,
+    MagnetizationConfigurationSettingsPanel,
 )
 
 
@@ -165,10 +165,6 @@ def test_advanced_smearing_settings():
 
 def test_advanced_hubbard_settings(generate_structure_data):
     """Test Hubbard widget."""
-    from aiidalab_qe.app.configuration.advanced.hubbard import (
-        HubbardConfigurationSettingsModel,
-        HubbardConfigurationSettingsPanel,
-    )
 
     model = HubbardConfigurationSettingsModel()
     hubbard = HubbardConfigurationSettingsPanel(model=model)
@@ -230,10 +226,6 @@ def test_advanced_hubbard_settings(generate_structure_data):
 def test_advanced_magnetic_settings(generate_structure_data):
     """Test Magnetization widget."""
     from aiida.orm import StructureData
-    from aiidalab_qe.app.configuration.advanced.magnetization import (
-        MagnetizationConfigurationSettingsModel,
-        MagnetizationConfigurationSettingsPanel,
-    )
     from aiidalab_qe.app.configuration.advanced.pseudos.utils import (
         get_pseudo_family_by_label,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,20 +14,12 @@ from aiida.manage.manager import get_manager
 from aiida.orm.utils.serialize import serialize
 from aiida.plugins import DataFactory, OrbitalFactory
 from aiida_quantumespresso.workflows.pdos import PdosWorkChain
-from aiidalab_qe.app.configuration.advanced import AdvancedConfigurationSettingsModel
-from aiidalab_qe.app.configuration.advanced.convergence import (
+from aiidalab_qe.app.configuration.advanced import (
+    AdvancedConfigurationSettingsModel,
     ConvergenceConfigurationSettingsModel,
-)
-from aiidalab_qe.app.configuration.advanced.general import (
     GeneralConfigurationSettingsModel,
-)
-from aiidalab_qe.app.configuration.advanced.magnetization import (
     MagnetizationConfigurationSettingsModel,
-)
-from aiidalab_qe.app.configuration.advanced.pseudos import (
     PseudosConfigurationSettingsModel,
-)
-from aiidalab_qe.app.configuration.advanced.smearing import (
     SmearingConfigurationSettingsModel,
 )
 from aiidalab_qe.app.configuration.basic import BasicConfigurationSettingsModel

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -3,7 +3,7 @@ import typing as t
 import pytest
 
 from aiida import orm
-from aiidalab_qe.app.configuration.advanced.pseudos import (
+from aiidalab_qe.app.configuration.advanced import (
     PseudosConfigurationSettingsModel,
     PseudosConfigurationSettingsPanel,
 )

--- a/tests/test_pseudo.py
+++ b/tests/test_pseudo.py
@@ -194,14 +194,14 @@ def test_pseudos_settings(generate_structure_data, generate_upf_data):
     pseudos.render()
 
     # Check uploaders
-    assert len(pseudos.setter_widget.children) == 2
+    assert len(pseudos.pseudos_list.children) == 2
 
     message = "{ecutwfc} | {ecutrho} | {functional} | {relativistic}"
 
     # Check Si uploader (Si.upf)
     Si_uploader = t.cast(
         PseudoPotentialUploader,
-        pseudos.setter_widget.children[0],  # type: ignore
+        pseudos.pseudos_list.children[0],  # type: ignore
     )
     assert Si_uploader._model.kind_name == "Si"
     assert Si_uploader._model.kind_symbol == "Si"
@@ -222,7 +222,7 @@ def test_pseudos_settings(generate_structure_data, generate_upf_data):
     # Check O uploader (O.upf)
     O_uploader = t.cast(
         PseudoPotentialUploader,
-        pseudos.setter_widget.children[1],  # type: ignore
+        pseudos.pseudos_list.children[1],  # type: ignore
     )
     assert O_uploader._model.kind_name == "O"
     assert O_uploader._model.kind_symbol == "O"

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -4,10 +4,10 @@ import pytest
 from bs4 import BeautifulSoup
 
 from aiidalab_qe.app.result import ResultsStep, ResultsStepModel
-from aiidalab_qe.app.result.components.summary import WorkChainSummaryModel
+from aiidalab_qe.app.result.components.summary import WorkflowSummaryModel
 from aiidalab_qe.app.result.components.viewer import (
-    WorkChainResultsViewer,
-    WorkChainResultsViewerModel,
+    WorkflowResultsViewer,
+    WorkflowResultsViewerModel,
 )
 from aiidalab_qe.app.result.components.viewer.structure import (
     StructureResultsModel,
@@ -28,7 +28,7 @@ def test_result_step(app_to_submit, generate_qeapp_workchain):
     step.render()
     assert step.toggle_controls.value == "Status"
     results_viewer_model = t.cast(
-        WorkChainResultsViewerModel, model.get_model("results")
+        WorkflowResultsViewerModel, model.get_model("results")
     )
     # All jobs are completed, so there should be no process status notifications
     for _, results_model in results_viewer_model.get_models():
@@ -51,8 +51,8 @@ def test_workchainview(generate_qeapp_workchain):
     """Test the result tabs are properly updated"""
     workchain = generate_qeapp_workchain()
     workchain.node.seal()
-    model = WorkChainResultsViewerModel()
-    viewer = WorkChainResultsViewer(model=model)
+    model = WorkflowResultsViewerModel()
+    viewer = WorkflowResultsViewer(model=model)
     model.process_uuid = workchain.node.uuid
     viewer.render()
     assert len(viewer.tabs.children) == 2
@@ -62,7 +62,7 @@ def test_workchainview(generate_qeapp_workchain):
 def test_summary_report(data_regression, generate_qeapp_workchain):
     """Test the summary report can be properly generated."""
     workchain = generate_qeapp_workchain()
-    model = WorkChainSummaryModel()
+    model = WorkflowSummaryModel()
     model.process_uuid = workchain.node.uuid
     report_parameters = model._generate_report_parameters()
     # Discard variable parameters
@@ -86,7 +86,7 @@ def test_summary_report_advanced_settings(data_regression, generate_qeapp_workch
     workchain = generate_qeapp_workchain(
         spin_type="collinear", electronic_type="metal", initial_magnetic_moments=0.1
     )
-    model = WorkChainSummaryModel()
+    model = WorkflowSummaryModel()
     model.process_uuid = workchain.node.uuid
     report_parameters = model._generate_report_parameters()
     moments = report_parameters["advanced_settings"]["initial_magnetic_moments"]
@@ -116,7 +116,7 @@ def test_summary_report_symmetry_group(
         run_bands=False,
         relax_type="none",
     )
-    model = WorkChainSummaryModel()
+    model = WorkflowSummaryModel()
     model.process_uuid = workchain.node.uuid
     report_parameters = model._generate_report_parameters()
     assert symmetry_key in report_parameters["initial_structure_properties"]
@@ -125,7 +125,7 @@ def test_summary_report_symmetry_group(
 def test_summary_view(generate_qeapp_workchain):
     """Test the report html can be properly generated."""
     workchain = generate_qeapp_workchain()
-    model = WorkChainSummaryModel()
+    model = WorkflowSummaryModel()
     model.process_uuid = workchain.node.uuid
     report_html = model.generate_report_html()
     parsed = BeautifulSoup(report_html, "html.parser")


### PR DESCRIPTION
This PR compiles several driveby updates extracted from the app duplication work.

## Summary of changes

- Added new fields `scf_conv_thr_abs` and `etot_conv_thr_abs` to the `ConvergenceConfigurationSettingsModel`, and updated their calculation to be per-structure, improving clarity and accuracy in threshold display. The UI now shows these absolute values with units and only displays them when a structure is present.

- Refactored `set_model_state` in `AdvancedConfigurationSettingsModel` to directly set all relevant sub-models (general, convergence, smearing, pseudos, magnetization, hubbard) using context managers for trait notifications, and removed the now-redundant `_set_pw_parameters` method, simplifying and centralizing state initialization.

- Renamed and refactored widgets and methods in the magnetization panel for clarity (e.g., `kind_moment_widgets` to `moments_list`, `_build_kinds_widget` to `_build_moments_list`), and simplified the update logic to remove unnecessary checks and flags.

- Simplified the update logic in the Hubbard panel by removing the `updated` flag and associated logic, and added a `needs_eigenvalues_widget` property to the model for clearer widget display logic.

- Made all advanced panels and models importable from the advanced settings module directly.

- Renamed various methods/classes for clarity/brevity.