### PR TITLE
Fix bug with `DbUser` access

### DIFF
--- a/src/aiidalab_qe/app/main.py
+++ b/src/aiidalab_qe/app/main.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import ipywidgets as ipw
 from IPython.display import display
 
+from aiida import orm
 from aiidalab_qe.app.static import styles
 from aiidalab_widgets_base.bug_report import (
     install_create_github_issue_exception_handler,
@@ -31,6 +32,10 @@ class QeApp:
         show_log=False,
     ):
         """Initialize the AiiDAlab QE application with the necessary setup."""
+
+        # HACK somehow resolves https://github.com/aiidalab/aiidalab-qe/issues/1356
+        # TODO investigate why this is needed and how it resolves the issue
+        _ = orm.User.collection.get_default().email
 
         url_query = url_query or {}
 


### PR DESCRIPTION
@giovannipizzi good to get your eyes on this.

The resource panels in step 3 store the default user's email to be used for filtering code selectors by owner.
```python
self.DEFAULT_USER_EMAIL = orm.User.collection.get_default().email
```
This in principle should be thread-safe, as the email is a string (not a node). 
However, after introducing this, we started getting errors (see references below).
These happen at random, suggeting threading issues, though I was unable to find any.
It appears that "touching" the user's email early (this PR) somehow resolves this matter consistently.
It is not yet clear how or why - TBD!

---

Fixes #1182
Fixes #1356

#1356 is already closed, but I suspect it is not actually resolved. This PR appears to fix that one as well.