### PR TITLE
Pin aiidalab-widgets-base to 2.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
     aiida-quantumespresso~=4.12.1
-    aiidalab-widgets-base[optimade] @ git+https://github.com/aiidalab/aiidalab-widgets-base@master
+    aiidalab-widgets-base[optimade]~=2.5.0
     aiida-pseudo~=1.4
     filelock~=3.8
     importlib-resources~=5.2


### PR DESCRIPTION
Pin aiidalab-widgets-base to 2.5.0

The app currently depends on the latest AWB, which may break due to the ongoing migration to ipywidgets 8. Version 2.5.0 includes the required feature and provides a stable dependency.