### PR TITLE
Bump version v25.08.1 -> v26.01.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ import time
 
 # -- Project information -----------------------------------------------------
 
-version = "v25.08.1"
+version = "v26.01.0"
 release = f"{version}-dev"
 project = "Quantum ESPRESSO App"
 copyright_first_year = "2023"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_qe
-version = 25.8.1
+version = 26.1.0
 description = Package for the AiiDAlab QE app
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -78,7 +78,7 @@ categories =
     quantum
 
 [bumpver]
-current_version = "v25.08.1"
+current_version = "v26.01.0"
 version_pattern = "v0Y.0M.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True

--- a/src/aiidalab_qe/version.py
+++ b/src/aiidalab_qe/version.py
@@ -2,4 +2,4 @@
 
 """This module contains project version information for both the app and the workflow."""
 
-__version__ = "v25.08.1"
+__version__ = "v26.01.0"


### PR DESCRIPTION
Make a release to include an important fix from #1451 .

I used `v26.01.0`, but open to discussion on the possible version tag.