### PR TITLE
Update `logo` CSS class to center logo image

### DIFF
--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -12,7 +12,7 @@
 }
 
 .logo {
-  text-align: center;
+  margin: 2px auto;
 }
 
 #subtitle {
@@ -57,7 +57,8 @@
 /* replicate jupyter button behavior */
 .link-button:hover,
 .link-button:focus {
-  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, var(--md-shadow-key-penumbra-opacity)),
+  box-shadow:
+    0 2px 2px 0 rgba(0, 0, 0, var(--md-shadow-key-penumbra-opacity)),
     0 3px 1px -2px rgba(0, 0, 0, var(--md-shadow-key-umbra-opacity)),
     0 1px 5px 0 rgba(0, 0, 0, var(--md-shadow-ambient-shadow-opacity));
 }


### PR DESCRIPTION
#1425 discarded `Output` widgets. One was used to wrap the logo image. As such, the CSS class needed an update to accomplish the same image centering.