### PR TITLE
Add QE app article citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,25 @@
 This is an AiiDAlab application for Quantum ESPRESSO workflows.
 The app allows the execution of a workflow with Quantum ESPRESSO that includes the selection of an input structure, its relaxation, the bands structure calculation, and more!
 
-**The app is currently in an early development stage!**
-
 ## For developers
 
 The package uses pre-commit hooks to check the style consistency of all commits.
 To use those you need to first install the pre-commit package itself, e.g. with:
+
 ```
 pip install .[dev]
 ```
+
 and then install the pre-commit hooks with
+
 ```
 pre-commit install
 ```
+
 The pre-commit checks should now be automatically executed prior to each commit.
 
 To run unit tests in the AiiDAlab container, you need to run `pytest` from within the `aiida-core-services` conda environment:
+
 ```
 conda activate aiida-core-services
 pytest -sv tests
@@ -56,26 +59,37 @@ Pull requests into the default branch are further released on ghcr.io with the `
 To create a new release, clone the repository, install development dependencies with `pip install '.[dev]'`, and then execute `bumpver update`.
 This will:
 
-  1. Create a tagged release with bumped version and push it to the repository.
-  2. Trigger a GitHub actions workflow that creates a GitHub release.
+1. Create a tagged release with bumped version and push it to the repository.
+2. Trigger a GitHub actions workflow that creates a GitHub release.
 
 For more details of the releases plan and management, please go to [the wiki](https://github.com/aiidalab/aiidalab-qe/wiki/Releases-management).
 
 Additional notes:
 
-  - Use the `--dry` option to preview the release change.
-  - The release tag (e.g. a/b/rc) is determined from the last release.
-    Use the `--tag` option to switch the release tag.
-  - For making "outdated" release since we fix minor version to `2x.04.xx` and `2x.10.xx`, use e.g. `bumpver update --set-version v23.10.0rc4 --ignore-vcs-tag` to make the release.
+- Use the `--dry` option to preview the release change.
+- The release tag (e.g. a/b/rc) is determined from the last release.
+  Use the `--tag` option to switch the release tag.
+- For making "outdated" release since we fix minor version to `2x.04.xx` and `2x.10.xx`, use e.g. `bumpver update --set-version v23.10.0rc4 --ignore-vcs-tag` to make the release.
+
+## Cite
+
+If you use the AiiDAlab QE app in your research, please cite:
+
+<div style="padding: 6px 20px 0;">
+  Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+  Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
+  <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+</div>
 
 ## Acknowledgements
-We acknowledge support from:
-* [MARVEL National Centre for Competency in Research](https://nccr-marvel.ch/) funded by the [Swiss National Science Foundation](https://www.snf.ch/en).
-* [BIG-MAP project](https://www.big-map.eu) funded by the Horizon 2020 research and innovation programme (Grant No. 957189).
-* [MARKETPLACE project](https://www.the-marketplace-project.eu/) funded by Horizon 2020 under the H2020-NMBP-25-2017 call (Grant No. 760173).
-* [MaX European Centre of Excellence](https://www.max-centre.eu/) funded by the Horizon 2020 EINFRA-5 program (Grant No. 676598).
-* [DOME 4.0 project](https://dome40.eu/) funded by the EU Horizon 2020 Research and Innovation Programme (Grant No. 953163)
 
+We acknowledge support from:
+
+- [MARVEL National Centre for Competency in Research](https://nccr-marvel.ch/) funded by the [Swiss National Science Foundation](https://www.snf.ch/en).
+- [BIG-MAP project](https://www.big-map.eu) funded by the Horizon 2020 research and innovation programme (Grant No. 957189).
+- [MARKETPLACE project](https://www.the-marketplace-project.eu/) funded by Horizon 2020 under the H2020-NMBP-25-2017 call (Grant No. 760173).
+- [MaX European Centre of Excellence](https://www.max-centre.eu/) funded by the Horizon 2020 EINFRA-5 program (Grant No. 676598).
+- [DOME 4.0 project](https://dome40.eu/) funded by the EU Horizon 2020 Research and Innovation Programme (Grant No. 953163)
 
 <div style="display: flex; flex-wrap: wrap; justify-content: space-around; align-items: center; gap: 50px; text-align: center;">
  <img src="miscellaneous/logos/MARVEL.png" alt="MARVEL" height="75px">
@@ -85,3 +99,4 @@ We acknowledge support from:
  <img src="miscellaneous/logos/EU_flag.png" alt="EU" height="75px">
  <img src="miscellaneous/logos/DOME_4.0.png" alt="DOME 4.0" height="75px">
 </div>
+```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you use the AiiDAlab QE app in your research, please cite:
 <div style="padding: 6px 20px 0;">
   Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
   Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-  <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+  <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
 </div>
 
 ## Acknowledgements

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -152,6 +152,15 @@ If you use the app for research, please follow these links to:
 - `cite AiiDAlab <https://aiidalab.readthedocs.io/en/latest/index.html#how-to-cite>`_
 - `cite Quantum ESPRESSO <https://www.quantum-espresso.org/Doc/user_guide/node6.html>`_
 
+.. raw:: html
+
+   In addition, please cite the following article:
+   <div style="padding: 6px 20px 0;">
+      Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+      Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
+      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+   </div>
+
 ----
 
 Acknowledgements

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -158,7 +158,7 @@ If you use the app for research, please follow these links to:
    <div style="padding: 6px 20px 0;">
       Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
       Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
    </div>
 
 ----

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -145,21 +145,20 @@ Welcome Page
 How to cite
 ===========
 
-If you use the app for research, please follow these links to:
+.. raw:: html
+
+   If you use the app in your research, please cite:
+   <div style="padding: 8px 20px">
+      Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+      Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
+      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
+   </div>
+   In addition, please follow these links to:
 
 - `cite AiiDA <https://aiida.readthedocs.io/projects/aiida-core/en/latest/#how-to-cite>`_
 - `cite AiiDA's Quantum ESPRESSO plugin <https://aiida-quantumespresso.readthedocs.io/en/latest/#how-to-cite>`_
 - `cite AiiDAlab <https://aiidalab.readthedocs.io/en/latest/index.html#how-to-cite>`_
 - `cite Quantum ESPRESSO <https://www.quantum-espresso.org/Doc/user_guide/node6.html>`_
-
-.. raw:: html
-
-   In addition, please cite the following article:
-   <div style="padding: 6px 20px 0;">
-      Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
-      Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
-   </div>
 
 ----
 

--- a/src/aiidalab_qe/app/static/styles/infobox.css
+++ b/src/aiidalab_qe/app/static/styles/infobox.css
@@ -11,12 +11,12 @@
 .info-box.in-app-guide.show {
   display: flex !important;
 }
-.about ol {
+#about ol {
   margin-top: 5px;
   list-style: none;
   line-height: 2;
 }
-.about p:last-of-type {
+#about p:last-of-type {
   margin-bottom: 0.5em;
 }
 .in-app-guide:has(#guide-header),
@@ -33,6 +33,7 @@
 #post-guide {
   margin: 1em 0;
 }
+#about .alert,
 .in-app-guide .alert {
   color: black;
   margin: 10px 0;
@@ -46,6 +47,7 @@
 .in-app-guide .alert.alert-success {
   border-color: #8fbc8f;
 }
+#about h4,
 .in-app-guide h4 {
   font-weight: bold;
 }

--- a/src/aiidalab_qe/app/static/templates/about.jinja
+++ b/src/aiidalab_qe/app/static/templates/about.jinja
@@ -45,4 +45,10 @@
       For a more in-depth dive into the app's features, please refer to the
       <a href="https://aiidalab-qe.readthedocs.io/howto/index.html" target="_blank">how-to guides</a>.
     </p>
+    If you use the AiiDAlab QE app in your work, please cite:
+    <div style="padding: 6px 20px 0;">
+      Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+      Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
+      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+    </div>
 </div>

--- a/src/aiidalab_qe/app/static/templates/about.jinja
+++ b/src/aiidalab_qe/app/static/templates/about.jinja
@@ -49,6 +49,6 @@
     <div style="padding: 6px 20px 0;">
       Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
       Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
     </div>
 </div>

--- a/src/aiidalab_qe/app/static/templates/about.jinja
+++ b/src/aiidalab_qe/app/static/templates/about.jinja
@@ -1,4 +1,4 @@
-<div class="about">
+<div id="about">
     <p>
       The Quantum ESPRESSO app (or QE app for short) is a graphical front end for calculating materials properties using
       <a href="https://www.quantum-espresso.org/" target="_blank">Quantum ESPRESSO</a> (QE).
@@ -45,10 +45,13 @@
       For a more in-depth dive into the app's features, please refer to the
       <a href="https://aiidalab-qe.readthedocs.io/howto/index.html" target="_blank">how-to guides</a>.
     </p>
-    If you use the AiiDAlab QE app in your work, please cite:
-    <div style="padding: 6px 20px 0;">
-      Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
-      Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
+    <div class="alert alert-success">
+      <h4>Cite</h4>
+      If you use the AiiDAlab QE app in your work, please cite:
+      <div style="padding: 6px 20px 0;">
+        Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+        Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
+        <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
+      </div>
     </div>
 </div>

--- a/start.py
+++ b/start.py
@@ -99,7 +99,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             <div id="citation">
                 Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
                 Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-                <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+                <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
             </div>
         </details>
     """)

--- a/start.py
+++ b/start.py
@@ -8,7 +8,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                 border: 1px solid #aaaaaa;
                 border-radius: 4px;
                 padding: 1rem 2rem 0.25rem;
-                margin-bottom: 1rem;
+                margin: 1rem 2px 2rem;
             }}
             summary {{
                 font-weight: bold;

--- a/start.py
+++ b/start.py
@@ -3,6 +3,30 @@ import ipywidgets as ipw
 
 def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
     return ipw.HTML(f"""
+        <style>
+            details {{
+                border: 1px solid #aaaaaa;
+                border-radius: 4px;
+                padding: 1rem 2rem 0.25rem;
+                margin-bottom: 1rem;
+            }}
+            summary {{
+                font-weight: bold;
+                margin: -0.5em -0.5em 0;
+                padding: 0.5em;
+                cursor: pointer;
+            }}
+            summary::before {{
+                content: "▶";
+            }}
+            details[open] summary::before {{
+                content: "▼";
+            }}
+            #citation {{
+                line-height: 1.5;
+                padding: 0 2rem 1rem;
+            }}
+        </style>
         <div class="app-container">
             <a
                 class="logo"
@@ -68,5 +92,14 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     <div class="feature-label">Quantum ESPRESSO</div>
                 </a>
             </div>
+
         </div>
+        <details>
+            <summary>&nbsp; If you use the AiiDAlab QE app in your work, click here for the citation</summary>
+            <div id="citation">
+                Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+                Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
+                <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4">https://doi.org/10.1038/s41524-025-01936-4</a>
+            </div>
+        </details>
     """)


### PR DESCRIPTION
This PR adds a citation to the QE app article in the following locations:
- AiiDAlab Home app container
- QE app About section
- QE app documentation

---

<img width="1100" height="585" alt="image" src="https://github.com/user-attachments/assets/11d2e8a3-d26d-4011-9dc2-691ea28354a5" />

---

<img width="1099" height="654" alt="image" src="https://github.com/user-attachments/assets/a2014d2f-59a0-4067-989f-e277b7a8a69e" />

---

<img width="942" height="607" alt="image" src="https://github.com/user-attachments/assets/5a18d4b2-29c8-41c6-b5ea-691212102b8c" />
