### PR TITLE
Update `package_data` to point to relocated default parameters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dev =
     pytest-cov~=5.0
 
 [options.package_data]
-aiidalab_qe.app.parameters = qeapp.yaml
+aiidalab_qe.parameters = qeapp.yaml
 aiidalab_qe.app.static.images = *
 aiidalab_qe.app.static.styles = *.css
 aiidalab_qe.app.static.templates = *.jinja


### PR DESCRIPTION
Missed this in #1456