### PR TITLE
Add `beautifulsoup4` dep (used in guide system)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dev =
     pytest-cov~=5.0
 
 [options.package_data]
-aiidalab_qe.app.parameters = qeapp.yaml
+aiidalab_qe.parameters = qeapp.yaml
 aiidalab_qe.app.static.images = *
 aiidalab_qe.app.static.styles = *.css
 aiidalab_qe.app.static.templates = *.jinja

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     plotly~=5.24
     kaleido~=0.2.1
     upf_tools~=0.1.9
+    beautifulsoup4~=4.11
 
 python_requires = >=3.9
 


### PR DESCRIPTION
This should've been added in #763. We haven't had issues because `bs4` is a dependency of `nbconvert`, so we get it from there. However, #1337 updates the installation scheme, which means `bs4` is not available when needed (failing tests there). This PR adds the explicit dependency.

Pinging @danielhollas 