### PR TITLE
🔍 Try running CI vs 5.0.0rc1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find:
 install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.12.1
+    aiida-quantumespresso==5.0.0rc1
     aiidalab-widgets-base[optimade]~=2.5.0
     aiida-pseudo~=1.4
     filelock~=3.8


### PR DESCRIPTION
Right. I removed Python 3.9 support at EOL, wasn't aware at the time that AiiDAlab was still relying on it.

```
 > [build_deps 5/5] RUN --mount=from=uv,source=/uv,target=/bin/uv     uv pip install --strict --system --cache-dir=/tmp/uv_cache .:
0.977   × No solution found when resolving dependencies:
0.977   ╰─▶ Because the current Python version (3.9.13) does not satisfy
0.977       Python>=3.10 and aiida-quantumespresso==5.0.0rc1 depends on
0.977       Python>=3.10, we can conclude that aiida-quantumespresso==5.0.0rc1
0.977       cannot be used.
0.977       And because aiidalab-qe==26.1.0 depends on
0.977       aiida-quantumespresso==5.0.0rc1, we can conclude that
0.977       aiidalab-qe==26.1.0 cannot be used.
0.977       And because only aiidalab-qe==26.1.0 is available and you require
0.977       aiidalab-qe, we can conclude that your requirements are unsatisfiable.
```

@yakutovicha how close are we to Python 3.10 support?