### PR TITLE
Update about page

### DIFF
--- a/src/aiidalab_qe/app/app.py
+++ b/src/aiidalab_qe/app/app.py
@@ -309,6 +309,13 @@ class AppView(ipw.VBox):
             tooltip="View a list of previous calculations",
         )
 
+        self.plugin_manager_link = LinkButton(
+            description="Plugin manager",
+            link="./plugin_manager.ipynb",
+            icon="puzzle-piece",
+            tooltip="Manage community-developed plugins that extend the app's functionality",
+        )
+
         self.setup_resources_link = LinkButton(
             description="Setup resources",
             link="../home/code_setup.ipynb",
@@ -333,6 +340,7 @@ class AppView(ipw.VBox):
         self.external_links = ipw.HBox(
             children=[
                 self.calculation_history_link,
+                self.plugin_manager_link,
                 self.setup_resources_link,
                 self.new_workflow_link,
                 self.duplicate_workflow_link,

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -33,7 +33,7 @@
   border-left: 2px solid var(--jp-border-color1);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 992px) {
   .app-controls {
     flex-direction: column;
   }

--- a/src/aiidalab_qe/app/static/styles/infobox.css
+++ b/src/aiidalab_qe/app/static/styles/infobox.css
@@ -11,13 +11,22 @@
 .info-box.in-app-guide.show {
   display: flex !important;
 }
+#about {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+#about p,
 #about ol {
-  margin-top: 5px;
+  margin: 0.5rem 0;
+}
+#about p {
+  line-height: 1.5;
+}
+#about ol,
+#about ul {
   list-style: none;
   line-height: 2;
-}
-#about p:last-of-type {
-  margin-bottom: 0.5em;
 }
 .in-app-guide:has(#guide-header),
 .in-app-guide:has(#post-guide) {

--- a/src/aiidalab_qe/app/static/templates/about.jinja
+++ b/src/aiidalab_qe/app/static/templates/about.jinja
@@ -1,57 +1,102 @@
 <div id="about">
+  <section id="general">
+    <h3>About the Quantum ESPRESSO (QE) app</h3>
     <p>
-      The Quantum ESPRESSO app (or QE app for short) is a graphical front end for calculating materials properties using
-      <a href="https://www.quantum-espresso.org/" target="_blank">Quantum ESPRESSO</a> (QE).
-      Each property is calculated by workflows powered by the <a href="https://www.aiida.net/" target="_bland">AiiDA</a>
-      engine, and maintained in the <a href="https://aiida-quantumespresso.readthedocs.io/en/latest/"
-        target="_blank">aiida-quantumespresso</a> plugin and many other plugins developed by the AiiDA community.
+      The Quantum ESPRESSO (QE) app is a graphical user interface for computing
+      materials properties using the
+      <a href="https://www.quantum-espresso.org/" target="_blank"
+        >Quantum ESPRESSO</a
+      >
+      simulation package. It enables users to run complex simulations through
+      automated, reproducible workflows powered by the
+      <a href="https://www.aiida.net/" target="_bland">AiiDA</a>
+      engine. These workflows are maintained by the AiiDA team via the
+      <a
+        href="https://aiida-quantumespresso.readthedocs.io/en/latest/"
+        target="_blank"
+        >aiida-quantumespresso</a
+      >
+      plugin. and are further extended by a growing ecosystem of
+      community-developed plugins.
     </p>
-    <p>
-      The QE app allows you to calculate properties in a simple 4-step process:
-    </p>
+    <p>The app guides you through the following steps:</p>
     <ol>
+      <li>⚛️ <b>Step 1:</b> Select the structure of interest.</li>
       <li>
-        🔍 <strong>Step 1:</strong> Select the structure you want to run.
+        ⚙️ <b>Step 2:</b> Select the properties of interest and configure their
+        calculation parameters.
       </li>
       <li>
-        ⚙️ <strong>Step 2:</strong> Select the properties you are interested in.
+        💻 <b>Step 3:</b> Choose computational resources and submit your
+        workflow.
       </li>
-      <li>
-        💻 <strong>Step 3:</strong> Choose the computational resources you want to run on and submit your workflow.
-      </li>
-      <li>
-        🚀 <strong>Step 4:</strong> Monitor and view your workflow results.
-      </li>
+      <li>🚀 <b>Step 4:</b> Monitor and view your workflow results.</li>
     </ol>
+    <p>We provide the following tools at the top of the app:</p>
+    <ul>
+      <li>
+        <b><i class="fa fa-list"></i> Calculation history</b>: View a history of
+        submitted workflows.
+      </li>
+      <li>
+        <b><i class="fa fa-puzzle-piece"></i> Plugin manager</b>: Manage
+        community-developed plugins.
+      </li>
+      <li>
+        <b><i class="fa fa-database"></i> Setup resources</b>: Manage your
+        computational resources.
+      </li>
+      <li>
+        <b><i class="fa fa-plus-circle"></i> New calculation</b>: Start a new
+        calculation in a new tab.
+      </li>
+      <li>
+        <b><i class="fa fa-clone"></i> Duplicate</b>: Copy the current settings
+        in a new tab (great for running similar calculations with minor
+        modifications).
+      </li>
+    </ul>
+  </section>
+  <section id="tutorials">
+    <h3>Tutorials</h3>
     <p>
-      New users can go straight to the first step and select their structure.
+      Follow the
+      <a
+        href="https://aiidalab-qe.readthedocs.io/tutorials/basic.html"
+        target="_blank"
+        >basic</a
+      >
+      tutorial to get started with the Quantum ESPRESSO app, or try out the
+      <a
+        href="https://aiidalab-qe.readthedocs.io/tutorials/advanced.html"
+        target="_blank"
+        >advanced</a
+      >
+      tutorial to learn additional features offered by the app. In addition, we
+      maintain several
+      <a
+        href="https://aiidalab-qe.readthedocs.io/howto/in_app_guides.html"
+        target="_blank"
+        >in-app guides</a
+      >
+      to help you get started with the app. Community plugins (installable via
+      the
+      <b>Plugin manager</b>) may provide additional guides. To access the
+      guides, click on the <b><i class="fa fa-book"></i> Tutorials</b> button at
+      the top of the app.
     </p>
-    <p>
-      Completed workflows can be viewed in the <strong>Calculation history</strong> section.
-    </p>
-    <p>
-      To start a new calculation in a separate tab, click the <strong>New calculation</strong> button.
-    </p>
-    <p>
-      You can also check out the
-      <a href="https://aiidalab-qe.readthedocs.io/tutorials/basic.html" target="_blank">basic</a> tutorial to get
-      started
-      with the Quantum ESPRESSO app, or try out the
-      <a href="https://aiidalab-qe.readthedocs.io/tutorials/advanced.html" target="_blank">advanced</a> tutorial to
-      learn
-      additional features offered by the app.
-    </p>
-    <p>
-      For a more in-depth dive into the app's features, please refer to the
-      <a href="https://aiidalab-qe.readthedocs.io/howto/index.html" target="_blank">how-to guides</a>.
-    </p>
-    <div class="alert alert-success">
-      <h4>Cite</h4>
-      If you use the AiiDAlab QE app in your work, please cite:
-      <div style="padding: 6px 20px 0;">
-        Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
-        Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-        <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
-      </div>
+  </section>
+  <section id="cite">
+    <h3>How to cite</h3>
+    If you use the AiiDAlab QE app in your work, please cite:
+    <div style="padding: 8px 24px 0">
+      Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
+      Making atomistic materials calculations accessible with the AiiDAlab
+      Quantum ESPRESSO app<br />
+      <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026).
+      <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank"
+        >https://doi.org/10.1038/s41524-025-01936-4</a
+      >
     </div>
+  </section>
 </div>

--- a/start.py
+++ b/start.py
@@ -22,10 +22,6 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             details[open] summary::before {{
                 content: "▼";
             }}
-            #citation {{
-                line-height: 1.5;
-                padding: 0 2rem 1rem;
-            }}
         </style>
         <div class="app-container">
             <a
@@ -94,12 +90,4 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             </div>
 
         </div>
-        <details>
-            <summary>&nbsp; If you use the AiiDAlab QE app in your work, click here for the citation</summary>
-            <div id="citation">
-                Wang, X., Bainglass, E., Bonacci, M., Ortega-Guerrero, A. et al.<br />
-                Making atomistic materials calculations accessible with the AiiDAlab Quantum ESPRESSO app<br />
-                <em>npj. Comput. Mater.</em> <b>12</b>, 72 (2026). <a href="https://doi.org/10.1038/s41524-025-01936-4" target="_blank">https://doi.org/10.1038/s41524-025-01936-4</a>
-            </div>
-        </details>
     """)


### PR DESCRIPTION
This PR aims to update the language of the About page. In the process it also removes the citation of the QE paper from the home app container (looked bad - should keep container minimal), as well as add a top-level button to the plugin store.

<img width="917" height="895" alt="image" src="https://github.com/user-attachments/assets/13545a12-f8a6-4018-8191-e072474f8088" />
