### PR TITLE
Bump `aiida-wannier90-workflows` version to `2.7.0`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     aiida-pseudo~=1.4
     filelock~=3.8
     importlib-resources~=5.2
-    aiida-wannier90-workflows==2.3.0
+    aiida-wannier90-workflows==2.7.0
     anywidget==0.9.13
     table_widget~=0.0.2
     shakenbreak~=3.3.1


### PR DESCRIPTION
The wannier90 app plugin requires v2.7.0 of the plugin. The app requires the aiida plugin for its bands workflow, which was tested in the app at this updated version.