### PR TITLE
Fix bug report handler

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -31,7 +31,6 @@ aiida-bader:
     category: calculation
     requires_aiidalab_qe: '>24.04.0'
 
-
 aiida-qe-xspec:
     title: Core-level spectroscopy (aiida-qe-xspec)
     description: Core-level spectroscopy calculations with Quantum ESPRESSO.
@@ -48,12 +47,12 @@ aiidalab-qe-wannier90:
     title: Wannier functions (aiidalab-qe-wannier90)
     description: A plugin to compute Wannier functions using Quantum ESPRESSO and the Wannier90 code.
     author: Xing Wang, Junfeng Qiao, Nicola Marzari and Giovanni Pizzi
-    github: https://github.com/superstar54/aiidalab-qe-wannier90
+    github: https://github.com/aiidalab/aiidalab-qe-wannier90
     documentation: https://aiidalab-qe-wannier90.readthedocs.io/
     pip: aiidalab-qe-wannier90
     status: beta
     category: calculation
-    requires_aiidalab_qe: '>24.04.0'
+    requires_aiidalab_qe: '>26.01.0'
 
 aiidalab-qe-hp:
     title: Hubbard parameters (aiidalab-qe-hp)

--- a/src/aiidalab_qe/app/app.py
+++ b/src/aiidalab_qe/app/app.py
@@ -292,7 +292,7 @@ class AppView(ipw.VBox):
     def __init__(self) -> None:
         """`AppView` constructor."""
 
-        self.output = ipw.VBox()
+        self.output = ipw.Output()
 
         logo = ipw.Image(
             value=(files(images_folder) / "logo.png").read_bytes(),


### PR DESCRIPTION
#1425 changed the widget in which we inject the bug handler from an `Output` to a `VBox`. However, AWB expects it to be an `Output` widget, so this broke the feature. More details for why this was done in the PR, but for now, we must revert. At least until we update AWB.