### PR TITLE
Don't show loading message on failed jobs

### DIFF
--- a/src/aiidalab_qe/app/result/model.py
+++ b/src/aiidalab_qe/app/result/model.py
@@ -31,8 +31,16 @@ class ResultsStepModel(
     ]
 
     @property
+    def is_active(self):
+        return self.state is State.ACTIVE
+
+    @property
+    def is_failed(self):
+        return self.state is State.FAIL
+
+    @property
     def is_loading(self):
-        return super().is_loading and self.state is not State.ACTIVE
+        return super().is_loading and not (self.is_active or self.is_failed)
 
     def update(self):
         self._update_process_remote_folder_state()


### PR DESCRIPTION
Fixes #1487

The results step model defines `is_loading` as its `super` (missing dependencies, or not configured, or not successful) plus not active. But that misses a failed status, which incorrectly triggers loading. This PR adds `not self.is_failed` to the check. This mechanism can for sure be improved. Will revisit in a later, focused PR.