### PR TITLE
Implement parameters-aware code selector toggling

### DIFF
--- a/src/aiidalab_qe/app/submission/global_settings/model.py
+++ b/src/aiidalab_qe/app/submission/global_settings/model.py
@@ -79,13 +79,12 @@ class GlobalResourceSettingsModel(
         code_model: CodeModel,
     ) -> CodeModel | None:
         """Registers a code with this model."""
-        base_code_model = None
         default_calc_job_plugin = code_model.default_calc_job_plugin
         name = default_calc_job_plugin.split(".")[-1]
         # "." in the model key means nested models
         model_key = default_calc_job_plugin.replace(".", "__")
 
-        if not self.has_model(default_calc_job_plugin):
+        if not self.has_model(model_key):
             if default_calc_job_plugin == "quantumespresso.pw":
                 base_code_model = PwCodeModel(
                     name=name,
@@ -107,7 +106,7 @@ class GlobalResourceSettingsModel(
         else:
             self.plugin_mapping[identifier].append(model_key)
 
-        return base_code_model
+        return self.get_model(model_key)
 
     def check_resources(self):
         if not self.has_model("quantumespresso__pw"):

--- a/src/aiidalab_qe/app/submission/global_settings/model.py
+++ b/src/aiidalab_qe/app/submission/global_settings/model.py
@@ -19,13 +19,6 @@ class GlobalResourceSettingsModel(
     title = "Global resources"
     identifier = "global"
 
-    dependencies = [
-        "structure_uuid",
-        "input_parameters",
-    ]
-
-    input_parameters = tl.Dict()
-
     plugin_overrides = tl.List(tl.Unicode())
     plugin_overrides_notification = tl.Unicode("")
 
@@ -33,6 +26,7 @@ class GlobalResourceSettingsModel(
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.dependencies.append("structure_uuid")
 
         self._RUN_ON_LOCALHOST_NUM_SITES_WARN_THRESHOLD = 10
         self._RUN_ON_LOCALHOST_VOLUME_WARN_THRESHOLD = 1000  # \AA^3
@@ -59,7 +53,9 @@ class GlobalResourceSettingsModel(
         for identifier, code_names in self.plugin_mapping.items():
             if identifier in properties:
                 for code_name in code_names:
-                    self.get_model(code_name).activate()
+                    code_model = self.get_model(code_name)
+                    if code_model.check_condition(self.input_parameters):
+                        code_model.activate()
 
     def update_plugin_overrides_notification(self):
         if self.plugin_overrides:
@@ -102,6 +98,7 @@ class GlobalResourceSettingsModel(
                     name=name,
                     description=name,
                     default_calc_job_plugin=default_calc_job_plugin,
+                    condition=code_model.check_condition,
                 )
             self.add_model(model_key, base_code_model)
 
@@ -238,7 +235,7 @@ class GlobalResourceSettingsModel(
             if identifier in properties:
                 for name in code_names:
                     code_model = self.get_model(name)
-                    if not code_model.is_ready:
+                    if code_model.is_active and code_model.selected is None:
                         blocker = True
                         yield message.format(
                             property=identifier,

--- a/src/aiidalab_qe/app/submission/global_settings/model.py
+++ b/src/aiidalab_qe/app/submission/global_settings/model.py
@@ -27,6 +27,7 @@ class GlobalResourceSettingsModel(
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.dependencies.append("structure_uuid")
+        self.conditions = {}
 
         self._RUN_ON_LOCALHOST_NUM_SITES_WARN_THRESHOLD = 10
         self._RUN_ON_LOCALHOST_VOLUME_WARN_THRESHOLD = 1000  # \AA^3
@@ -50,11 +51,14 @@ class GlobalResourceSettingsModel(
             if identifier != "quantumespresso__pw":
                 code_model.deactivate()
         properties = self._get_properties()
-        for identifier, code_names in self.plugin_mapping.items():
+        for identifier, global_model_keys in self.plugin_mapping.items():
             if identifier in properties:
-                for code_name in code_names:
-                    code_model = self.get_model(code_name)
-                    if code_model.check_condition(self.input_parameters):
+                for model_key in global_model_keys:
+                    code_model = self.get_model(model_key)
+                    if any(
+                        condition(self.input_parameters)
+                        for condition in self._get_active_conditions(model_key)
+                    ):
                         code_model.activate()
 
     def update_plugin_overrides_notification(self):
@@ -83,6 +87,10 @@ class GlobalResourceSettingsModel(
         name = default_calc_job_plugin.split(".")[-1]
         # "." in the model key means nested models
         model_key = default_calc_job_plugin.replace(".", "__")
+
+        if model_key not in self.conditions:
+            self.conditions[model_key] = {}
+        self.conditions[model_key][identifier] = code_model.check_condition
 
         if not self.has_model(model_key):
             if default_calc_job_plugin == "quantumespresso.pw":
@@ -203,6 +211,15 @@ class GlobalResourceSettingsModel(
 
     def _get_properties(self) -> list[str]:
         return self.input_parameters.get("workchain", {}).get("properties", [])
+
+    def _get_active_conditions(self, model_key: str) -> list[callable]:
+        active_conditions = []
+        properties = self._get_properties()
+        if model_key in self.conditions:
+            for identifier, condition in self.conditions[model_key].items():
+                if identifier in properties:
+                    active_conditions.append(condition)
+        return active_conditions
 
     def _check_blockers(self):
         if not self.input_parameters:

--- a/src/aiidalab_qe/app/submission/global_settings/setting.py
+++ b/src/aiidalab_qe/app/submission/global_settings/setting.py
@@ -31,11 +31,8 @@ class GlobalResourceSettingsPanel(ResourceSettingsPanel[GlobalResourceSettingsMo
             "plugin_overrides",
         )
 
-    def render(self):
-        if self.rendered:
-            return
-
-        self.code_widgets_container = ipw.VBox()
+    def _render(self):
+        super()._render()
 
         self.plugin_overrides_notification = ipw.HTML()
         ipw.dlink(
@@ -53,39 +50,11 @@ class GlobalResourceSettingsPanel(ResourceSettingsPanel[GlobalResourceSettingsMo
             self.plugin_overrides_notification,
         ]
 
-        self.rendered = True
-
-        # Render any active codes
-        for _, code_model in self._model.get_models():
-            if code_model.is_active:
-                self._toggle_code(code_model)
-
     def build_global_codes(self, codes: PluginCodes):
         for identifier, code_models in codes.items():
             for _, code_model in code_models.items():
-                self.register_code_trait_callbacks(code_model)
-                base_code_model = self._model.add_global_model(identifier, code_model)
-                if base_code_model is not None:
-                    base_code_model.observe(
-                        self._on_code_activation_change,
-                        "is_active",
-                    )
-                    base_code_model.observe(
-                        self._on_code_selection_change,
-                        "selected",
-                    )
-                    self.register_code_trait_callbacks(base_code_model)
-                    if base_code_model.default_calc_job_plugin == "quantumespresso.pw":
-                        base_code_model.observe(
-                            self._on_pw_code_resource_change,
-                            [
-                                "num_cpus",
-                                "num_nodes",
-                                "ntasks_per_node",
-                                "cpus_per_task",
-                                "max_wallclock_seconds",
-                            ],
-                        )
+                global_code_model = self._model.add_global_model(identifier, code_model)
+                self._register_code_trait_callbacks(global_code_model)
         self._model.update_global_codes()
 
     def reset(self):
@@ -101,17 +70,26 @@ class GlobalResourceSettingsPanel(ResourceSettingsPanel[GlobalResourceSettingsMo
     def _on_plugin_overrides_change(self, _):
         self._model.update_plugin_overrides_notification()
 
-    def _on_code_activation_change(self, change):
-        self._toggle_code(change["owner"])
-
-    def _on_code_selection_change(self, _):
-        self._model.update_blockers()
-
     def _on_pw_code_resource_change(self, _):
         self._model.check_resources()
 
     def _on_code_resource_change(self, _):
+        super()._on_code_resource_change(_)
         self._model.update_global_codes()
+
+    def _register_code_trait_callbacks(self, code_model: CodeModel):
+        super()._register_code_trait_callbacks(code_model)
+        if code_model.default_calc_job_plugin == "quantumespresso.pw":
+            code_model.observe(
+                self._on_pw_code_resource_change,
+                [
+                    "num_cpus",
+                    "num_nodes",
+                    "ntasks_per_node",
+                    "cpus_per_task",
+                    "max_wallclock_seconds",
+                ],
+            )
 
     def _render_code_widget(
         self,

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -15,7 +15,7 @@ from aiidalab_qe.common.widgets import (
 
 
 class CodeModel(Model):
-    is_active = tl.Bool(False)
+    is_active = tl.Bool(None, allow_none=True)
     options = tl.List(
         trait=tl.Tuple(tl.Unicode(), tl.Unicode()),  # code option (label, uuid)
         default_value=[],

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -15,7 +15,7 @@ from aiidalab_qe.common.widgets import (
 
 
 class CodeModel(Model):
-    is_active = tl.Bool(None, allow_none=True)
+    is_active = tl.Bool(False)
     options = tl.List(
         trait=tl.Tuple(tl.Unicode(), tl.Unicode()),  # code option (label, uuid)
         default_value=[],

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import typing as t
+
 import ipywidgets as ipw
 import traitlets as tl
 
@@ -36,12 +40,14 @@ class CodeModel(Model):
         description,
         default_calc_job_plugin,
         code_widget_class=QEAppComputationalResourcesWidget,
+        condition: t.Callable[[dict], bool] | None = None,
     ):
         self.name = name
         self.description = description
         self.default_calc_job_plugin = default_calc_job_plugin
         self.code_widget_class = code_widget_class
-        self.is_rendered = False
+        self.is_widget_rendered = False
+        self._condition = condition or (lambda _: True)
 
         ipw.dlink(
             (self, "num_cpus"),
@@ -55,6 +61,9 @@ class CodeModel(Model):
     @property
     def first_option(self):
         return self.options[0][1] if self.options else None  # type: ignore
+
+    def check_condition(self, paramters: dict) -> bool:
+        return self._condition(paramters)
 
     def activate(self):
         self.is_active = True

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -47,7 +47,7 @@ class CodeModel(Model):
         self.default_calc_job_plugin = default_calc_job_plugin
         self.code_widget_class = code_widget_class
         self.is_widget_rendered = False
-        self._condition = condition or (lambda _: True)
+        self.check_condition = condition or (lambda _: True)
 
         ipw.dlink(
             (self, "num_cpus"),
@@ -61,9 +61,6 @@ class CodeModel(Model):
     @property
     def first_option(self):
         return self.options[0][1] if self.options else None  # type: ignore
-
-    def check_condition(self, paramters: dict) -> bool:
-        return self._condition(paramters)
 
     def activate(self):
         self.is_active = True

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -155,6 +155,8 @@ class ConfigurationSettingsPanel(Panel[PM]):
 class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):
     """Base model for resource setting models."""
 
+    input_parameters = tl.Dict()
+
     global_codes = tl.Dict(
         key_trait=tl.Unicode(),
         value_trait=tl.Dict(),
@@ -166,6 +168,7 @@ class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):
         self.default_codes: dict[str, dict] = kwargs.pop("default_codes", {})
         self.default_user_email = default_user_email
         super().__init__(*args, **kwargs)
+        self.dependencies = ["input_parameters"]
 
     def add_model(self, identifier, model):
         super().add_model(identifier, model)
@@ -174,6 +177,13 @@ class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):
             user_email=self.default_user_email,
             default_code=self.default_codes.get(code_key, {}).get("code"),
         )
+
+    def update_active_codes(self):
+        for _, code_model in self.get_models():
+            if code_model.check_condition(self.input_parameters):
+                code_model.activate()
+            else:
+                code_model.deactivate()
 
     def refresh_codes(self):
         for _, code_model in self.get_models():
@@ -213,7 +223,47 @@ class ResourceSettingsPanel(Panel[RSM]):
         super().__init__(model, **kwargs)
         self.code_widgets = {}
 
-    def register_code_trait_callbacks(self, code_model: CodeModel):
+        self._model.observe(
+            self._on_input_parameters_change,
+            "input_parameters",
+        )
+
+        for _, code_model in self._model.get_models():
+            self._register_code_trait_callbacks(code_model)
+
+    def render(self):
+        if self.rendered:
+            return
+        self._render()
+        self.rendered = True
+        self._post_render()
+
+    def _render(self):
+        self.code_widgets_container = ipw.VBox()
+
+    def _post_render(self):
+        for _, code_model in self._model.get_models():
+            if code_model.is_active:
+                self._toggle_code(code_model)
+
+    def _on_input_parameters_change(self, _):
+        self._model.update_active_codes()
+        self._model.update_blockers()
+
+    def _on_code_activation_change(self, change):
+        self._toggle_code(change["owner"])
+
+    def _on_code_selection_change(self, _):
+        self._model.update_blockers()
+
+    def _on_code_resource_change(self, _):
+        pass
+
+    def _on_code_options_change(self, change: dict):
+        widget: ipw.Dropdown = change["owner"]
+        widget.disabled = not widget.options
+
+    def _register_code_trait_callbacks(self, code_model: CodeModel):
         """Registers event handlers on code model traits."""
         if code_model.default_calc_job_plugin == "quantumespresso.pw":
             code_model.observe(
@@ -234,18 +284,19 @@ class ResourceSettingsPanel(Panel[RSM]):
                 "max_wallclock_seconds",
             ],
         )
-
-    def _on_code_resource_change(self, _):
-        pass
-
-    def _on_code_options_change(self, change: dict):
-        widget: ipw.Dropdown = change["owner"]
-        widget.disabled = not widget.options
+        code_model.observe(
+            self._on_code_activation_change,
+            "is_active",
+        )
+        code_model.observe(
+            self._on_code_selection_change,
+            "selected",
+        )
 
     def _toggle_code(self, code_model: CodeModel):
         if not self.rendered:
             return
-        if not code_model.is_rendered:
+        if not code_model.is_widget_rendered:
             loading_message = LoadingWidget(f"Loading {code_model.name} code")
             self.code_widgets_container.children += (loading_message,)
         if code_model.name not in self.code_widgets:
@@ -256,12 +307,16 @@ class ResourceSettingsPanel(Panel[RSM]):
             self.code_widgets[code_model.name] = code_widget
         else:
             code_widget = self.code_widgets[code_model.name]
-        if not code_model.is_rendered:
+        if not code_model.is_widget_rendered:
             code_widget.observe(
                 code_widget.update_resources,
                 "value",
             )
             self._render_code_widget(code_model, code_widget)
+        if code_model.is_active:
+            code_widget.layout.display = "block"
+        else:
+            code_widget.layout.display = "none"
 
     def _render_code_widget(
         self,
@@ -315,17 +370,17 @@ class ResourceSettingsPanel(Panel[RSM]):
         )
         code_widgets = self.code_widgets_container.children[:-1]  # type: ignore
         self.code_widgets_container.children = [*code_widgets, code_widget]
-        code_model.is_rendered = True
+        code_model.is_widget_rendered = True
 
 
 class PluginResourceSettingsModel(ResourceSettingsModel):
     """Base model for plugin resource setting models."""
 
-    dependencies = [
-        "global.global_codes",
-    ]
-
     override = tl.Bool(False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dependencies.append("global.global_codes")
 
     def add_model(self, identifier, model: CodeModel):
         super().add_model(identifier, model)
@@ -380,9 +435,8 @@ class PluginResourceSettingsPanel(ResourceSettingsPanel[PRSM]):
             "override",
         )
 
-    def render(self):
-        if self.rendered:
-            return
+    def _render(self):
+        super()._render()
 
         self.override_help = ipw.HTML(
             "Click to override the resource settings for this plugin."
@@ -396,7 +450,6 @@ class PluginResourceSettingsPanel(ResourceSettingsPanel[PRSM]):
             (self._model, "override"),
             (self.override, "value"),
         )
-        self.code_widgets_container = ipw.VBox()
 
         self.children = [
             ipw.HBox(
@@ -407,15 +460,6 @@ class PluginResourceSettingsPanel(ResourceSettingsPanel[PRSM]):
             ),
             self.code_widgets_container,
         ]
-
-        self.rendered = True
-
-        # Render any active codes
-        for _, code_model in self._model.get_models():
-            if code_model.is_active:
-                self._toggle_code(code_model)
-
-        return self.code_widgets_container
 
     def _on_global_codes_change(self, _):
         self._model.update()

--- a/src/aiidalab_qe/plugins/bands/bands_workchain.py
+++ b/src/aiidalab_qe/plugins/bands/bands_workchain.py
@@ -291,6 +291,10 @@ class BandsWorkChain(WorkChain):
             builder.bands = builder_bands
 
         elif simulation_mode == "fat_bands":
+            if projwfc_code is None:
+                raise ValueError(
+                    "projwfc_code must be provided for fat bands simulation mode"
+                )
             builder_bands_projwfc = ProjwfcBandsWorkChain.get_builder_from_protocol(
                 pw_code,
                 projwfc_code,

--- a/src/aiidalab_qe/plugins/bands/resources.py
+++ b/src/aiidalab_qe/plugins/bands/resources.py
@@ -15,6 +15,11 @@ class BandsResourceSettingsModel(PluginResourceSettingsModel):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+
+        def condition(parameters):
+            bands_params = parameters.get("bands", {})
+            return bands_params.get("projwfc_bands", False)
+
         self.add_models(
             {
                 "pw": PwCodeModel(
@@ -26,6 +31,7 @@ class BandsResourceSettingsModel(PluginResourceSettingsModel):
                     name="projwfc.x",
                     description="projwfc.x",
                     default_calc_job_plugin="quantumespresso.projwfc",
+                    condition=condition,
                 ),
             }
         )

--- a/src/aiidalab_qe/plugins/bands/workchain.py
+++ b/src/aiidalab_qe/plugins/bands/workchain.py
@@ -64,7 +64,10 @@ def get_builder(codes, structure, parameters, **kwargs):
     bands_overrides["pw"]["parameters"]["SYSTEM"].pop("smearing", None)
     bands_overrides["pw"]["parameters"]["SYSTEM"].pop("degauss", None)
 
-    check_codes(pw_code, codes.get("projwfc_bands")["code"])
+    projwfc_code = None
+    if "projwfc_bands" in codes:
+        projwfc_code = codes.get("projwfc_bands")["code"]
+        check_codes(pw_code, projwfc_code)
 
     overrides = {
         "scf": scf_overrides,
@@ -79,7 +82,7 @@ def get_builder(codes, structure, parameters, **kwargs):
 
     bands_builder = BandsWorkChain.get_builder_from_protocol(
         pw_code=pw_code,
-        projwfc_code=codes.get("projwfc_bands")["code"],
+        projwfc_code=projwfc_code,
         structure=structure,
         simulation_mode=simulation_mode,
         protocol=protocol,

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -122,7 +122,6 @@ def test_qeapp_computational_resources_widget(app: Wizard):
     ],
 )
 def test_parameters_aware_codes(parameters, expected):
-
     def condition(params):
         return params.get("use_this_code", False)
 

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -1,7 +1,5 @@
 import typing as t
 
-import pytest
-
 from aiida import orm
 from aiidalab_qe.app.submission import SubmissionStep, SubmissionStepModel
 from aiidalab_qe.app.submission.global_settings import GlobalResourceSettingsModel

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -1,9 +1,14 @@
 import typing as t
 
+import pytest
+
+from aiida import orm
 from aiidalab_qe.app.submission import SubmissionStep, SubmissionStepModel
 from aiidalab_qe.app.submission.global_settings import GlobalResourceSettingsModel
 from aiidalab_qe.app.wizard import Wizard
 from aiidalab_qe.common.code import PwCodeModel
+from aiidalab_qe.common.code.model import CodeModel
+from aiidalab_qe.common.panel import ResourceSettingsModel, ResourceSettingsPanel
 from aiidalab_qe.common.widgets import PwCodeResourceSetupWidget
 from aiidalab_qe.common.wizard import State
 from aiidalab_qe.utils import shallow_copy_nested_dict
@@ -106,3 +111,38 @@ def test_qeapp_computational_resources_widget(app: Wizard):
         "ntasks_per_node": 1,
         "parallelization": {"npool": 2},
     }
+
+
+@pytest.mark.parametrize(
+    "parameters, expected",
+    [
+        ({"use_this_code": True}, True),
+        ({"use_this_code": False}, False),
+        ({}, False),
+    ],
+)
+def test_parameters_aware_codes(parameters, expected):
+
+    def condition(params):
+        return params.get("use_this_code", False)
+
+    code_model = CodeModel(
+        name="test",
+        description="Test Code Model",
+        default_calc_job_plugin="test.mock",
+        condition=condition,
+    )
+
+    default_user_email = orm.User.collection.get_default().email
+    model = ResourceSettingsModel(default_user_email=default_user_email)
+    model.add_model("test", code_model)
+
+    panel = ResourceSettingsPanel(model)
+    panel.render()
+
+    model.input_parameters = parameters
+
+    assert model.get_model("test").is_active == expected
+
+    display = "block" if expected else "none"
+    assert panel.code_widgets["test"].layout.display == display

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -48,7 +48,7 @@ def test_global_code_toggle(app: Wizard):
     global_resources.render()
 
     dos_code_model = global_resources_model.get_model("quantumespresso__dos")
-    assert dos_code_model.is_active is False
+    assert dos_code_model.is_active is None
 
     global_resources_model.input_parameters = {"workchain": {"properties": ["pdos"]}}
     assert dos_code_model.is_active is True

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -48,7 +48,7 @@ def test_global_code_toggle(app: Wizard):
     global_resources.render()
 
     dos_code_model = global_resources_model.get_model("quantumespresso__dos")
-    assert dos_code_model.is_active is None
+    assert dos_code_model.is_active is False
 
     global_resources_model.input_parameters = {"workchain": {"properties": ["pdos"]}}
     assert dos_code_model.is_active is True
@@ -113,15 +113,7 @@ def test_qeapp_computational_resources_widget(app: Wizard):
     }
 
 
-@pytest.mark.parametrize(
-    "parameters, expected",
-    [
-        ({"use_this_code": True}, True),
-        ({"use_this_code": False}, False),
-        ({}, False),
-    ],
-)
-def test_parameters_aware_codes(parameters, expected):
+def test_parameters_aware_codes():
     def condition(params):
         return params.get("use_this_code", False)
 
@@ -139,9 +131,10 @@ def test_parameters_aware_codes(parameters, expected):
     panel = ResourceSettingsPanel(model)
     panel.render()
 
-    model.input_parameters = parameters
+    model.input_parameters = {"use_this_code": True}
+    assert model.get_model("test").is_active
+    assert panel.code_widgets["test"].layout.display == "block"
 
-    assert model.get_model("test").is_active == expected
-
-    display = "block" if expected else "none"
-    assert panel.code_widgets["test"].layout.display == display
+    model.input_parameters = {"use_this_code": False}
+    assert not model.get_model("test").is_active
+    assert panel.code_widgets["test"].layout.display == "none"

--- a/tests/test_submit_qe_workchain/test_create_builder_default.yml
+++ b/tests/test_submit_qe_workchain/test_create_builder_default.yml
@@ -26,12 +26,6 @@ bands:
 codes:
   bands:
     codes:
-      projwfc_bands:
-        cpus: 1
-        cpus_per_task: 1
-        max_wallclock_seconds: 43200
-        nodes: 1
-        ntasks_per_node: 1
       pw:
         cpus: 2
         cpus_per_task: 1


### PR DESCRIPTION
This PR implements a parameters-aware code selector toggling system.

When registering conditional codes for a plugin, one can define a conditional

```python
def check_condition(parameters: dict) -> bool:
    needs_this_code = ...  # some check on parameters
    return needs_this_code
```

then assign it to the code resource at definition time

```python
CodeModel(
    name='...',
    description='...',
    default_calc_job_plugin='...',
    condition=check_condition,
)
```

Internally, the condition is evaluated when input parameters change, (de)activating the code, which then triggers its toggle (`display.layout` mutation).

Closes #1371
