### PR TITLE
Fix absolute convergence thresholds

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
@@ -44,7 +44,7 @@ class ConvergenceConfigurationSettingsPanel(
             (self.scf_conv_thr, "step"),
         )
 
-        scf_conv_thr_abs = ipw.Label(
+        self.scf_conv_thr_abs = ipw.Label(
             layout=ipw.Layout(
                 width="150px",
                 text_align="center",
@@ -52,13 +52,13 @@ class ConvergenceConfigurationSettingsPanel(
         )
         ipw.dlink(
             (self.scf_conv_thr, "value"),
-            (scf_conv_thr_abs, "value"),
+            (self.scf_conv_thr_abs, "value"),
             lambda v: f"{v * self._model.get_num_atoms():.5e}",
         )
-        scf_conv_thr_abs.add_class("convergence-label")
+        self.scf_conv_thr_abs.add_class("convergence-label")
 
         scf_conv_thr_with_units = HBoxWithUnits(
-            widget=scf_conv_thr_abs,
+            widget=self.scf_conv_thr_abs,
             units="Ry",
             layout={"margin": "-8px 0 0 150px"},
         )
@@ -83,16 +83,16 @@ class ConvergenceConfigurationSettingsPanel(
             (self.etot_conv_thr, "step"),
         )
 
-        etot_conv_thr_abs = ipw.Label()
+        self.etot_conv_thr_abs = ipw.Label()
         ipw.dlink(
             (self.etot_conv_thr, "value"),
-            (etot_conv_thr_abs, "value"),
+            (self.etot_conv_thr_abs, "value"),
             lambda v: f"{v * self._model.get_num_atoms():.5e}",
         )
-        etot_conv_thr_abs.add_class("convergence-label")
+        self.etot_conv_thr_abs.add_class("convergence-label")
 
         etot_conv_thr_with_units = HBoxWithUnits(
-            widget=etot_conv_thr_abs,
+            widget=self.etot_conv_thr_abs,
             units="Ry",
             layout={"margin": "-8px 0 0 150px"},
         )

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/convergence.py
@@ -51,9 +51,9 @@ class ConvergenceConfigurationSettingsPanel(
             )
         )
         ipw.dlink(
-            (self._model, "scf_conv_thr_abs"),
+            (self.scf_conv_thr, "value"),
             (scf_conv_thr_abs, "value"),
-            lambda v: f"{v:.5e}",
+            lambda v: f"{v * self._model.get_num_atoms():.5e}",
         )
         scf_conv_thr_abs.add_class("convergence-label")
 
@@ -85,9 +85,9 @@ class ConvergenceConfigurationSettingsPanel(
 
         etot_conv_thr_abs = ipw.Label()
         ipw.dlink(
-            (self._model, "etot_conv_thr_abs"),
+            (self.etot_conv_thr, "value"),
             (etot_conv_thr_abs, "value"),
-            lambda v: f"{v:.5e}",
+            lambda v: f"{v * self._model.get_num_atoms():.5e}",
         )
         etot_conv_thr_abs.add_class("convergence-label")
 

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
@@ -29,10 +29,8 @@ class ConvergenceConfigurationSettingsModel(
     help_message = tl.Unicode()
     scf_conv_thr = tl.Float(0.0)
     scf_conv_thr_step = tl.Float(1e-10)
-    scf_conv_thr_abs = tl.Float(0.0)
     etot_conv_thr = tl.Float(0.0)
     etot_conv_thr_step = tl.Float(1e-5)
-    etot_conv_thr_abs = tl.Float(0.0)
     forc_conv_thr = tl.Float(0.0)
     forc_conv_thr_step = tl.Float(1e-4)
     kpoints_distance = tl.Float(0.0)
@@ -58,8 +56,7 @@ class ConvergenceConfigurationSettingsModel(
         if specific in {"structure", "protocol"}:
             self._update_thresholds()
         if not specific or specific != "mesh":
-            parameters = PwBaseWorkChain.get_protocol_inputs(self.protocol)
-            self._update_kpoints_distance(parameters)
+            self._update_kpoints_distance()
         self._update_kpoints_mesh()
 
     def reset(self):
@@ -80,7 +77,6 @@ class ConvergenceConfigurationSettingsModel(
         if not self.has_structure:
             self.help_message = "No structure available."
             return
-        num_atoms = len(self.input_structure.sites)
         self.help_message = f"""
             <div style="line-height: 1.4; margin-bottom: 5px;">
                 Setting the energy threshold for the self-consistent field (SCF)
@@ -91,26 +87,22 @@ class ConvergenceConfigurationSettingsModel(
                 thresholds, the actual value used in the calculation (shown below
                 widget) is given as:
                 <code>threshold x num_atoms</code>
-                (<code>num_atoms = {num_atoms}</code>)
+                (<code>num_atoms = {self.get_num_atoms()}</code>)
             </div>
         """
 
     def _update_thresholds(self):
         parameters = PwBaseWorkChain.get_protocol_inputs(self.protocol)
 
-        num_atoms = len(self.input_structure.sites) if self.has_structure else 1
-
         etot_value = parameters["meta_parameters"]["etot_conv_thr_per_atom"]
         self._set_value_and_step("etot_conv_thr", etot_value)
         self.etot_conv_thr = self._defaults["etot_conv_thr"]
         self.etot_conv_thr_step = self._defaults["etot_conv_thr_step"]
-        self.etot_conv_thr_abs = self.etot_conv_thr * num_atoms
 
         scf_value = parameters["meta_parameters"]["conv_thr_per_atom"]
         self._set_value_and_step("scf_conv_thr", scf_value)
         self.scf_conv_thr = self._defaults["scf_conv_thr"]
         self.scf_conv_thr_step = self._defaults["scf_conv_thr_step"]
-        self.scf_conv_thr_abs = self.scf_conv_thr * num_atoms
 
         forc_value = parameters["pw"]["parameters"]["CONTROL"]["forc_conv_thr"]
         self._set_value_and_step("forc_conv_thr", forc_value)
@@ -126,7 +118,8 @@ class ConvergenceConfigurationSettingsModel(
             step = 0.1
         self._defaults[f"{attribute}_step"] = step
 
-    def _update_kpoints_distance(self, parameters):
+    def _update_kpoints_distance(self):
+        parameters = PwBaseWorkChain.get_protocol_inputs(self.protocol)
         kpoints_distance = parameters["kpoints_distance"] if self.has_pbc else 100.0
         self._defaults["kpoints_distance"] = kpoints_distance
         self.kpoints_distance = self._defaults["kpoints_distance"]

--- a/src/aiidalab_qe/app/configuration/advanced/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/model.py
@@ -41,7 +41,7 @@ class AdvancedConfigurationSettingsModel(
     include = True
 
     def get_model_state(self) -> dict:
-        num_atoms = len(self.input_structure.sites) if self.has_structure else 1
+        num_atoms = self.get_num_atoms() or 1
 
         general = t.cast(
             GeneralConfigurationSettingsModel,
@@ -162,7 +162,7 @@ class AdvancedConfigurationSettingsModel(
         CONTROL: dict = PW_PARAMS.get("CONTROL", {})
         ELECTRONS: dict = PW_PARAMS.get("ELECTRONS", {})
 
-        num_atoms = len(self.input_structure.sites) if self.has_structure else 1
+        num_atoms = self.get_num_atoms() or 1
 
         self.spin_orbit = "soc" if "lspinorb" in SYSTEM else "wo_soc"
 

--- a/src/aiidalab_qe/app/submission/global_settings/model.py
+++ b/src/aiidalab_qe/app/submission/global_settings/model.py
@@ -130,7 +130,7 @@ class GlobalResourceSettingsModel(
         on_localhost = (
             orm.load_node(pw_code_model.selected).computer.hostname == "localhost"
         )
-        num_sites = len(self.input_structure.sites)
+        num_sites = self.get_num_atoms()
         volume = self.input_structure.get_cell_volume()
 
         code = orm.load_node(pw_code_model.selected)

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -40,6 +40,9 @@ class HasInputStructure(tl.HasTraits):
             for kind_name in self.input_structure.get_kind_names()
         )
 
+    def get_num_atoms(self) -> int:
+        return len(self.input_structure.sites) if self.has_structure else 0
+
 
 M = t.TypeVar("M", bound=Model)
 

--- a/tests/configuration/test_advanced.py
+++ b/tests/configuration/test_advanced.py
@@ -56,7 +56,7 @@ def test_advanced_general_settings():
 def test_advanced_convergence_settings(generate_structure_data):
     """Test Convergence Settings."""
     model = ConvergenceConfigurationSettingsModel()
-    _ = ConvergenceConfigurationSettingsPanel(model=model)
+    panel = ConvergenceConfigurationSettingsPanel(model=model)
 
     # Test structure-dependent convergence change
     model.structure_uuid = generate_structure_data("silica").uuid
@@ -79,6 +79,11 @@ def test_advanced_convergence_settings(generate_structure_data):
     model.scf_conv_thr = 0.1
     model.reset()
     assert model.scf_conv_thr == 4e-10
+
+    # Test absolute convergence threshold display
+    panel.render()
+    assert panel.scf_conv_thr_abs.value == f"{4e-10 * model.get_num_atoms():.5e}"
+    assert panel.etot_conv_thr_abs.value == f"{1e-4 * model.get_num_atoms():.5e}"
 
 
 def test_advanced_kpoints_settings():


### PR DESCRIPTION
The absolute convergence thresholds weren't properly linked to their corresponding widget. Also, there is no need for these to be model traits, as their are purely a UI feature in sync with the actual threshold traits.

Closes #1498