### PR TITLE
Add Python 3.12 / AiiDA 2.8 compatibility for the QE app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.12']
+                python-version: ['3.12']
                 aiida-core-version: ['2.8']
             fail-fast: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ###############################################################################
 # 1) Global ARGs
 ###############################################################################
-ARG FULL_STACK_VER=2026.1030
+ARG FULL_STACK_VER=pr-479
 ARG UV_VER=0.11.15
 ARG QE_VER=7.4
 ARG QE_DIR=/opt/conda/envs/quantum-espresso-${QE_VER}

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ COPY --chown=${NB_UID}:${NB_GID} setup.cfg pyproject.toml LICENSE README.md ${QE
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=type=cache,sharing=locked,target=${UV_CACHE_DIR},uid=${NB_UID},gid=${NB_GID} \
     uv pip install --strict --no-build-isolation euphonic==1.3.2 && \
-    uv pip install --strict . ${AIIDA_HQ_PKG} ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
+    uv pip install --strict . ${AIIDA_HQ_PKG} ${MUON_PKG} aiidalab-qe-vibroscopy "aiida-bader>=0.1.10"
 
 ###############################################################################
 # 6) home_build stage
@@ -126,8 +126,8 @@ RUN --mount=from=qe_conda_env,source=${QE_DIR},target=${QE_DIR} \
     verdi code create core.code.installed --label python --computer=${COMPUTER_LABEL} --default-calc-job-plugin pythonjob.pythonjob --filepath-executable=/opt/conda/bin/python -n && \
     verdi code create core.code.installed --label bader --computer=${COMPUTER_LABEL} --default-calc-job-plugin bader.bader --filepath-executable=${QE_DIR}/bin/bader -n && \
     verdi code create core.code.installed --label wannier90 --computer=${COMPUTER_LABEL} --default-calc-job-plugin wannier90.wannier90 --filepath-executable=/opt/conda/bin/wannier90.x -n && \
-    # run post_install for plugin
-    python -m aiida_bader post-install && \
+    # Import Bader PAW pseudopotentials; the code is created explicitly above.
+    python -c 'from aiida import load_profile; load_profile(); from aiida_bader.utils import install_pseudos; install_pseudos()' && \
     python -m aiidalab_qe_vibroscopy setup-phonopy && \
     python -m aiidalab_qe_muon setup-python3 && \
     # wannier90 plugin need SSSP 1.1
@@ -198,7 +198,7 @@ RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=type=cache,sharing=locked,target=${UV_CACHE_DIR},uid=${NB_UID},gid=${NB_GID} \
     --mount=from=build_deps,source=${QE_APP_SRC},target=${QE_APP_SRC},rw \
     uv pip install --strict --compile-bytecode \
-      ${QE_APP_SRC} ${AIIDA_HQ_PKG} ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
+      ${QE_APP_SRC} ${AIIDA_HQ_PKG} ${MUON_PKG} aiidalab-qe-vibroscopy "aiida-bader>=0.1.10"
 
 # copy hq binary
 COPY --from=home_build /opt/conda/hq /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ###############################################################################
 # 1) Global ARGs
 ###############################################################################
-ARG FULL_STACK_VER=pr-479
+ARG FULL_STACK_VER=edge
 ARG UV_VER=0.11.15
 ARG QE_VER=7.4
 ARG QE_DIR=/opt/conda/envs/quantum-espresso-${QE_VER}

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     plotly>=5.24,<7
     beautifulsoup4~=4.11
 
-python_requires = >=3.9
+python_requires = >=3.12
 
 [options.packages.find]
 where = src
@@ -57,6 +57,7 @@ dev =
     pre-commit~=3.2
     pytest~=7.4
     pytest-regressions~=2.2
+    upf_tools~=0.1.9
     pgtest==1.3.1
     pytest-cov~=5.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,20 +24,17 @@ package_dir =
     = src
 packages = find:
 install_requires =
-    aiida-core~=2.5,<3
+    aiida-core>=2.8,<3
     Jinja2~=3.0
-    aiida-quantumespresso~=4.12.1
-    aiidalab-widgets-base[optimade]~=2.5.0
+    aiida-quantumespresso>=4.17,<5
+    aiidalab-widgets-base[optimade]>=3.0.0a0,<4
     aiida-pseudo~=1.4
     filelock~=3.8
-    importlib-resources~=5.2
+    importlib-resources>=5.2,<8
     aiida-wannier90-workflows==2.7.0
-    anywidget==0.9.13
+    anywidget>=0.9.13,<1
     table_widget~=0.0.2
-    shakenbreak~=3.3.1
-    plotly~=5.24
-    kaleido~=0.2.1
-    upf_tools~=0.1.9
+    plotly>=5.24,<7
     beautifulsoup4~=4.11
 
 python_requires = >=3.9
@@ -46,6 +43,15 @@ python_requires = >=3.9
 where = src
 
 [options.extras_require]
+export =
+    kaleido~=0.2.1
+
+pseudos =
+    upf_tools~=0.1.9
+
+defects =
+    shakenbreak~=3.3.1
+
 dev =
     bumpver~=2023.1124
     pre-commit~=3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,9 +30,9 @@ install_requires =
     aiidalab-widgets-base[optimade]>=3.0.0a0,<4
     aiida-pseudo~=1.4
     filelock~=3.8
-    importlib-resources>=5.2,<8
+    importlib-resources~=5.2
     aiida-wannier90-workflows==2.7.0
-    anywidget>=0.9.13,<1
+    anywidget==0.9.13
     table_widget~=0.0.2
     plotly>=5.24,<7
     beautifulsoup4~=4.11

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
@@ -1,8 +1,6 @@
 import typing as t
 
 from aiida_pseudo.groups.family import PseudoPotentialFamily
-from upf_tools import UPFDict
-
 from aiida import orm
 from aiida.plugins import DataFactory, GroupFactory
 
@@ -89,6 +87,14 @@ def get_pseudo_family_by_label(label) -> PseudoPotentialFamily:
 
 
 def get_upf_dict(pseudo):
+    try:
+        from upf_tools import UPFDict
+    except ModuleNotFoundError as err:
+        raise ModuleNotFoundError(
+            "Parsing UPF pseudo files requires the optional 'upf_tools' dependency. "
+            "Install the 'pseudos' extra to enable this feature."
+        ) from err
+
     with pseudo.as_path() as pseudo_path:
         upf_dict = UPFDict.from_upf(pseudo_path.as_posix())
     return upf_dict

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
@@ -1,6 +1,7 @@
 import typing as t
 
 from aiida_pseudo.groups.family import PseudoPotentialFamily
+
 from aiida import orm
 from aiida.plugins import DataFactory, GroupFactory
 

--- a/src/aiidalab_qe/app/utils/plugin_manager.py
+++ b/src/aiidalab_qe/app/utils/plugin_manager.py
@@ -461,8 +461,8 @@ class PluginManager:
 
             # Define the title with checkmark if installed
             title_with_icon = f"{plugin_data.get('title')} {'✅' if installed else ''}"
-            self.accordion.set_title(i, title_with_icon)
             self.accordion.children = [*self.accordion.children, box]
+            self.accordion.set_title(i, title_with_icon)
 
     def display_ui(self) -> None:
         """

--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -18,7 +18,7 @@ from aiidalab_widgets_base import LoadingWidget
 
 from .state import STATE_ICONS
 
-TITLE_MAPPING = {
+BASE_TITLE_MAPPING = {
     "QeAppWorkChain": "Quantum ESPRESSO app workflow",
     "PwRelaxWorkChain": "Structure relaxation workflow manager",
     "PwBaseWorkChain": {
@@ -35,14 +35,18 @@ TITLE_MAPPING = {
         "relax": "Structure geometry optimization",
         "md": "Molecular dynamics simulation",
     },
-} | {
-    process: human_readable
-    for metadata in get_entry_items(
-        "aiidalab_qe.properties",
-        "metadata",
-    ).values()
-    for process, human_readable in metadata.get("process_labels", {}).items()
 }
+
+
+def get_title_mapping():
+    return BASE_TITLE_MAPPING | {
+        process: human_readable
+        for metadata in get_entry_items(
+            "aiidalab_qe.properties",
+            "metadata",
+        ).values()
+        for process, human_readable in metadata.get("process_labels", {}).items()
+    }
 
 
 class SimplifiedProcessTreeModel(Model, HasProcess):
@@ -212,13 +216,14 @@ class ProcessTreeNode(ipw.VBox, t.Generic[ProcessNodeType]):
         node = self.process
         if not (label := node.process_label):
             return "Unknown"
+        title_mapping = get_title_mapping()
         if label in ("PwBaseWorkChain", "PwCalculation"):
             inputs = node.inputs.pw if label == "PwBaseWorkChain" else node.inputs
             parameters = inputs.parameters.base.attributes.all
             calculation: str = parameters["CONTROL"]["calculation"]
             calculation = calculation.replace("vc-", "")
-            return TITLE_MAPPING.get(label, {}).get(calculation, label)
-        return TITLE_MAPPING.get(label, label)
+            return title_mapping.get(label, {}).get(calculation, label)
+        return title_mapping.get(label, label)
 
 
 class ProcessTreeBranches(ipw.VBox):

--- a/src/aiidalab_qe/common/process/tree.py
+++ b/src/aiidalab_qe/common/process/tree.py
@@ -18,7 +18,7 @@ from aiidalab_widgets_base import LoadingWidget
 
 from .state import STATE_ICONS
 
-BASE_TITLE_MAPPING = {
+TITLE_MAPPING = {
     "QeAppWorkChain": "Quantum ESPRESSO app workflow",
     "PwRelaxWorkChain": "Structure relaxation workflow manager",
     "PwBaseWorkChain": {
@@ -39,7 +39,7 @@ BASE_TITLE_MAPPING = {
 
 
 def get_title_mapping():
-    return BASE_TITLE_MAPPING | {
+    return TITLE_MAPPING | {
         process: human_readable
         for metadata in get_entry_items(
             "aiidalab_qe.properties",

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -19,7 +19,6 @@ import numpy as np
 import traitlets
 from IPython.display import HTML, Javascript, display
 from pymatgen.io.ase import AseAtomsAdaptor
-from shakenbreak.distortions import distort, local_mc_rattle, rattle
 
 from aiida.orm import CalcJobNode, load_code, load_node
 from aiida.orm import Data as orm_Data
@@ -32,6 +31,17 @@ from aiidalab_widgets_base.utils import (
 )
 
 from .link_button import LinkButton
+
+
+def _load_shakenbreak_distortions():
+    try:
+        from shakenbreak.distortions import distort, local_mc_rattle, rattle
+    except ModuleNotFoundError as err:
+        raise ModuleNotFoundError(
+            "The defect distortion tools require the optional 'shakenbreak' "
+            "dependency. Install the 'defects' extra to enable this editor."
+        ) from err
+    return distort, local_mc_rattle, rattle
 
 __all__ = [
     "CalcJobOutputFollower",
@@ -1468,6 +1478,7 @@ class ShakeNBreakEditor(ipw.VBox):
             else:
                 frac_coords = self.str2vec(self.vacancy_coords.value)
 
+            distort, _, _ = _load_shakenbreak_distortions()
             self._apply_distortion(
                 distort,
                 num_nearest_neighbours=self.num_nearest_neighbours.value,
@@ -1501,6 +1512,7 @@ class ShakeNBreakEditor(ipw.VBox):
             else:
                 self.wrong_syntax.layout.visibility = "hidden"
 
+                _, local_mc_rattle, _ = _load_shakenbreak_distortions()
                 self._apply_distortion(
                     local_mc_rattle,
                     site_index=site_index,
@@ -1510,6 +1522,7 @@ class ShakeNBreakEditor(ipw.VBox):
                 )
 
     def _apply_random_distortion_all(self, _=None):
+        _, _, rattle = _load_shakenbreak_distortions()
         self._apply_distortion(
             rattle,
             active_atoms=None,

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -43,6 +43,7 @@ def _load_shakenbreak_distortions():
         ) from err
     return distort, local_mc_rattle, rattle
 
+
 __all__ = [
     "CalcJobOutputFollower",
     "LinkButton",

--- a/src/aiidalab_qe/plugins/bands/bands_workchain.py
+++ b/src/aiidalab_qe/plugins/bands/bands_workchain.py
@@ -6,12 +6,32 @@ from aiida import orm
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain
 from aiida.plugins import DataFactory, WorkflowFactory
+from aiida_quantumespresso.workflows.pw.bands import (
+    validate_inputs as validate_pw_bands_inputs,
+)
 
 GAMMA = "\u0393"
 
 PwBandsWorkChain = WorkflowFactory("quantumespresso.pw.bands")
 ProjwfcBandsWorkChain = WorkflowFactory("wannier90_workflows.projwfcbands")
 KpointsData = DataFactory("core.array.kpoints")
+
+
+def _validate_projwfc_bands_inputs(inputs, port):
+    """Validate projected bands inputs with the AiiDA 2.8 validator signature."""
+    return validate_pw_bands_inputs(inputs, port)
+
+
+def _patch_projwfc_bands_validator(workchain_cls=None):
+    """Patch aiida-wannier90-workflows 2.7 validator signature for AiiDA 2.8."""
+    ProjwfcBandsWorkChain.spec().inputs.validator = _validate_projwfc_bands_inputs
+    if workchain_cls is not None and "bands_projwfc" in workchain_cls.spec().inputs:
+        workchain_cls.spec().inputs["bands_projwfc"].validator = (
+            _validate_projwfc_bands_inputs
+        )
+
+
+_patch_projwfc_bands_validator()
 
 
 def points_per_branch(vector_a, vector_b, reciprocal_cell, bands_kpoints_distance):
@@ -306,6 +326,7 @@ class BandsWorkChain(WorkChain):
             builder.pop("bands", None)
             builder_bands_projwfc.pop("relax", None)
             builder_bands_projwfc.pop("structure", None)
+            _patch_projwfc_bands_validator(cls)
             builder.bands_projwfc = builder_bands_projwfc
 
         else:

--- a/src/aiidalab_qe/plugins/bands/bands_workchain.py
+++ b/src/aiidalab_qe/plugins/bands/bands_workchain.py
@@ -26,9 +26,9 @@ def _patch_projwfc_bands_validator(workchain_cls=None):
     """Patch aiida-wannier90-workflows 2.7 validator signature for AiiDA 2.8."""
     ProjwfcBandsWorkChain.spec().inputs.validator = _validate_projwfc_bands_inputs
     if workchain_cls is not None and "bands_projwfc" in workchain_cls.spec().inputs:
-        workchain_cls.spec().inputs["bands_projwfc"].validator = (
-            _validate_projwfc_bands_inputs
-        )
+        workchain_cls.spec().inputs[
+            "bands_projwfc"
+        ].validator = _validate_projwfc_bands_inputs
 
 
 _patch_projwfc_bands_validator()

--- a/src/aiidalab_qe/workflows/__init__.py
+++ b/src/aiidalab_qe/workflows/__init__.py
@@ -248,7 +248,8 @@ class QeAppWorkChain(WorkChain):
             self.out("structure", self.ctx.current_structure)
 
     def should_run_plugin(self, name):
-        return name in self.inputs
+        """Return whether a plugin was requested by the selected properties."""
+        return name in self.inputs.properties.get_list()
 
     def run_plugin(self):
         """Run the plugin `WorkChain`."""

--- a/start.py
+++ b/start.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import ipywidgets as ipw
 
-
 _APP_DIR = Path(__file__).parent
 
 

--- a/start.py
+++ b/start.py
@@ -1,7 +1,28 @@
+import base64
+import mimetypes
+from pathlib import Path
+
 import ipywidgets as ipw
 
 
+_APP_DIR = Path(__file__).parent
+
+
+def _image_data_uri(relative_path):
+    path = _APP_DIR / relative_path
+    mime_type = mimetypes.guess_type(path.name)[0] or "image/png"
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
 def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
+    logo = _image_data_uri("src/aiidalab_qe/app/static/images/logo.png")
+    workbench = _image_data_uri("miscellaneous/logos/workbench.png")
+    history = _image_data_uri("miscellaneous/logos/history.png")
+    plugins = _image_data_uri("miscellaneous/logos/plugins.png")
+    download = _image_data_uri("miscellaneous/logos/download.png")
+    qe_logo = _image_data_uri("miscellaneous/logos/qe-logo.png")
+
     return ipw.HTML(f"""
         <style>
             details {{
@@ -29,7 +50,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                 href="{appbase}/qe.ipynb"
                 target="_blank"
             >
-                <img src="{appbase}/src/aiidalab_qe/app/static/images/logo.png" />
+                <img src="{logo}" />
             </a>
             <div class="features">
                 <a
@@ -38,7 +59,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     target="_blank">
                     <img
                         class="feature-logo"
-                        src="{appbase}/miscellaneous/logos/workbench.png"
+                        src="{workbench}"
                         alt="New calculation"
                     />
                     <div class="feature-label">New calculation</div>
@@ -49,7 +70,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     target="_blank">
                     <img
                         class="feature-logo"
-                        src="{appbase}/miscellaneous/logos/history.png"
+                        src="{history}"
                         alt="Calculation history"
                     />
                     <div class="feature-label">Calculation history</div>
@@ -60,7 +81,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     target="_blank">
                     <img
                         class="feature-logo"
-                        src="{appbase}/miscellaneous/logos/plugins.png"
+                        src="{plugins}"
                         alt="Plugin store"
                     />
                     <div class="feature-label">Plugin store</div>
@@ -71,7 +92,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     target="_blank">
                     <img
                         class="feature-logo"
-                        src="{appbase}/miscellaneous/logos/download.png"
+                        src="{download}"
                         alt="Download examples"
                     />
                     <div class="feature-label">Download examples</div>
@@ -82,7 +103,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     target="_blank">
                     <img
                         class="feature-logo"
-                        src="{appbase}/miscellaneous/logos/qe-logo.png"
+                        src="{qe_logo}"
                         alt="Quantum ESPRESSO"
                     />
                     <div class="feature-label">Quantum ESPRESSO</div>

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -56,7 +56,7 @@ def test_workchainview(generate_qeapp_workchain):
     model.process_uuid = workchain.node.uuid
     viewer.render()
     assert len(viewer.tabs.children) == 2
-    assert viewer.tabs._titles["0"] == "Structure"  # type: ignore
+    assert viewer.tabs.titles[0] == "Structure"
 
 
 def test_summary_report(data_regression, generate_qeapp_workchain):

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -25,6 +25,12 @@ def docker_compose_file(pytestconfig):
 
 
 @pytest.fixture(scope="session")
+def docker_setup():
+    """Start compose without Docker's --wait; notebook_service handles readiness."""
+    return ["up --build -d"]
+
+
+@pytest.fixture(scope="session")
 def docker_compose(docker_services):
     return docker_services._docker_compose
 

--- a/tests_integration/docker-compose.yml
+++ b/tests_integration/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         image: ${REGISTRY:-}${QE_IMAGE:-aiidalab/qe}${TAG:-}
         environment:
             TZ: Europe/Zurich
-            DOCKER_STACKS_JUPYTER_CMD: notebook
+            DOCKER_STACKS_JUPYTER_CMD: nbclassic
             SETUP_DEFAULT_AIIDA_PROFILE: 'true'
             AIIDALAB_DEFAULT_APPS: ''
             JUPYTER_TOKEN: ${JUPYTER_TOKEN}

--- a/tests_integration/docker-compose.yml
+++ b/tests_integration/docker-compose.yml
@@ -11,3 +11,5 @@ services:
             JUPYTER_TOKEN: ${JUPYTER_TOKEN}
         ports:
             - 0.0.0.0:${AIIDALAB_PORT:-8998}:8888
+        healthcheck:
+            disable: true

--- a/tests_integration/test_app.py
+++ b/tests_integration/test_app.py
@@ -22,9 +22,12 @@ def test_qe_app_select_silicon_and_confirm(
 
     driver.find_element(By.CLASS_NAME, "qe-app-step-ready")  # ready on start
 
-    # Open structure selection step
+    # Open structure selection step. The exact accordion DOM classes differ
+    # between ipywidgets/Jupyter versions, but the rendered title is stable.
     element = WebDriverWait(driver, 60).until(
-        EC.presence_of_element_located((By.CLASS_NAME, "p-Accordion-child"))
+        EC.element_to_be_clickable(
+            (By.XPATH, "//span[contains(.,'Step 1: Select structure')]")
+        )
     )
     element.click()
     # check that element has CSS class


### PR DESCRIPTION
Hi @edan-bainglass and @danielhollas,

I started this branch as an early compatibility port of the QE app to the upcoming AiiDAlab stack based on Python 3.12, AiiDA core 2.8, ipywidgets 8, and Notebook 7 through nbclassic.

This PR is meant to make the work visible, avoid duplicated effort, and provide a concrete example showing that the QE app can run successfully in the new environment. **I am perfectly fine if we decide not to merge it directly and instead cherry-pick selected changes from it.**

Testing environment:

I am testing this branch inside a local development AiiDAlab Docker image:

* Docker image: `aiidalab/full-stack:dev`
* Built locally on top of the Docker stack work in `aiidalab/aiidalab-docker-stack#479`
* Python: `3.12.11`
* AiiDA core: `2.8.0`
* AiiDAlab: `26.5.2`
* Notebook: `7.x` base, running through `nbclassic`
* ipywidgets: `8.x`
* aiida-quantumespresso: `4.17.0`
* aiidalab-widgets-base: `3.0.0a0`

Summary of changes so far:

* updates dependency metadata and CI for Python 3.12 / AiiDA 2.8
* uses the `aiidalab/aiidalab-docker-stack#479` full-stack image for Docker builds
* fixes homepage image loading in the new environment by embedding the start-page images directly in the widget, instead of relying on static paths that seem fragile in this stack
* fixes ipywidgets 8 accordion/title handling
* fixes AiiDA 2.8 plugin execution logic
* patches the bands/projwfc validator signature mismatch
* fixes Docker setup for `aiida-bader`
* updates Docker integration tests for nbclassic and container readiness

Latest checks are green:

* `CI`
* `Build Docker image and test`
* `Build Docker image and upload`

Manual smoke test: Si bulk workflow completed successfully, including relax, bands, projwfc bands, and PDOS.

I will now try to prepare an equivalent PR for the Python 3.9 environment. As a next step, I also want to check and, if appropriate, enable the new base-restart options in the QE app.


<img width="829" height="330" alt="image" src="https://github.com/user-attachments/assets/aab7068d-e743-4457-97e4-683671eaf649" />

<img width="839" height="675" alt="image" src="https://github.com/user-attachments/assets/5245274b-598f-4cf2-a2ae-ee2f94532668" />
