### PR TITLE
Fix blockers system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ output-format = "full"
 target-version = "py39"
 
 [tool.ruff.lint]
-ignore = ["E501", "E402", "TRY003", "RUF012", "N806"]
+ignore = ["ARG002", "E501", "E402", "TRY003", "RUF012", "N806"]
 select = [
   "A",    # flake8-builtins
   "ARG",  # flake8-unused-arguments

--- a/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/convergence/model.py
@@ -50,7 +50,7 @@ class ConvergenceConfigurationSettingsModel(
 
     include = True  # build-in panel
 
-    def update(self, specific=""):
+    def _update(self, specific=""):
         if specific == "structure":
             self._update_help_message()
         if specific in {"structure", "protocol"}:

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/hubbard.py
@@ -86,7 +86,7 @@ class HubbardConfigurationSettingsPanel(
     def _on_eigenvalues_definition(self, _):
         self._toggle_eigenvalues_widget()
 
-    def _update(self):
+    def _update_ui(self):
         self._show_loading()
         self._build_hubbard_widget()
         self._toggle_hubbard_widget()
@@ -171,18 +171,20 @@ class HubbardConfigurationSettingsPanel(
                     [
                         lambda eigenvalues,
                         kind_index=kind_index,
-                        state_index=state_index: str(
-                            int(eigenvalues[kind_index][0][state_index][-1])
+                        state_index=state_index: (
+                            str(int(eigenvalues[kind_index][0][state_index][-1]))
                         ),
                         lambda value,
                         kind_index=kind_index,
                         state_index=state_index,
-                        kind_name=kind_name: update(
-                            kind_index,
-                            1,
-                            state_index,
-                            kind_name,
-                            float(value),
+                        kind_name=kind_name: (
+                            update(
+                                kind_index,
+                                1,
+                                state_index,
+                                kind_name,
+                                float(value),
+                            )
                         ),
                     ],
                 )
@@ -204,18 +206,20 @@ class HubbardConfigurationSettingsPanel(
                     [
                         lambda eigenvalues,
                         kind_index=kind_index,
-                        state_index=state_index: str(
-                            int(eigenvalues[kind_index][1][state_index][-1])
+                        state_index=state_index: (
+                            str(int(eigenvalues[kind_index][1][state_index][-1]))
                         ),
                         lambda value,
                         kind_index=kind_index,
                         state_index=state_index,
-                        kind_name=kind_name: update(
-                            kind_index,
-                            2,
-                            state_index,
-                            kind_name,
-                            float(value),
+                        kind_name=kind_name: (
+                            update(
+                                kind_index,
+                                2,
+                                state_index,
+                                kind_name,
+                                float(value),
+                            )
                         ),
                     ],
                 )

--- a/src/aiidalab_qe/app/configuration/advanced/hubbard/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/hubbard/model.py
@@ -47,7 +47,7 @@ class HubbardConfigurationSettingsModel(
     def needs_eigenvalues_widget(self):
         return len(self.applicable_kind_names) > 0
 
-    def update(self, specific=""):  # noqa: ARG002
+    def _update(self, specific=""):
         if not self.has_structure:
             self.applicable_kind_names = []
             self.orbital_labels = []

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/magnetization.py
@@ -128,7 +128,7 @@ class MagnetizationConfigurationSettingsPanel(
         self._toggle_widgets()
         self._model.update_type_help()
 
-    def _update(self):
+    def _update_ui(self):
         self._show_loading()
         self._build_moments_list()
         self._switch_widgets()

--- a/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/magnetization/model.py
@@ -64,7 +64,7 @@ class MagnetizationConfigurationSettingsModel(
             lambda spin_type: spin_type == "collinear",
         )
 
-    def update(self, specific=""):  # noqa: ARG002
+    def _update(self, specific=""):
         if self.spin_type == "none" or not self.has_structure:
             self._defaults["moments"] = {}
         else:

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -106,7 +106,7 @@ class PseudosConfigurationSettingsModel(
 
     include = True  # build-in panel
 
-    def update(self, specific=""):
+    def _update(self, specific=""):
         if not self.has_structure:
             return
         family = self.family

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -255,7 +255,7 @@ class PseudosConfigurationSettingsPanel(
     def _on_ecut_change(self, _):
         self._model.update_blockers()
 
-    def _update(self):
+    def _update_ui(self):
         self._build_pseudos_list()
         self._model.update_family_header()
 

--- a/src/aiidalab_qe/app/configuration/advanced/smearing/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/smearing/model.py
@@ -30,7 +30,7 @@ class SmearingConfigurationSettingsModel(PanelModel):
 
     include = True  # build-in panel
 
-    def update(self, specific=""):  # noqa: ARG002
+    def _update(self, specific=""):
         parameters = (
             PwBaseWorkChain.get_protocol_inputs(self.protocol)
             .get("pw", {})

--- a/src/aiidalab_qe/app/configuration/model.py
+++ b/src/aiidalab_qe/app/configuration/model.py
@@ -60,9 +60,8 @@ class ConfigurationStepModel(
             </div>
         """
 
-    def update(self):
+    def _update(self, specific=""):
         self.update_relaxation_options()
-        self.update_blockers()
 
     def update_relaxation_options(self):
         if self.has_pbc:
@@ -127,7 +126,9 @@ class ConfigurationStepModel(
                 model.set_model_state(state[identifier])
 
     def update_state(self):
-        if self.confirmed:
+        if self.is_blocked:
+            self.state = State.BLOCKED
+        elif self.confirmed:
             self.state = State.SUCCESS
         elif self.is_previous_step_successful and self.has_all_dependencies:
             self.state = State.CONFIGURED
@@ -173,7 +174,3 @@ class ConfigurationStepModel(
     def _check_blockers(self):
         if not self.has_structure:
             yield "No selected input structure"
-
-        for _, model in self.get_models():
-            if model.is_blocked:
-                yield from model.blockers

--- a/src/aiidalab_qe/app/configuration/step.py
+++ b/src/aiidalab_qe/app/configuration/step.py
@@ -255,14 +255,16 @@ class ConfigurationStep(ConfirmableDependentWizardStep[ConfigurationStepModel]):
                     lambda _: not self._model.has_pbc,
                 )
 
-            def toggle_plugin(change, identifier=identifier, model=model, info=info):
+            panel: ConfigurationSettingsPanel = configuration["panel"](model=model)
+
+            def toggle_plugin(change, identifier=identifier, panel=panel, info=info):
                 if change["new"]:
                     info.value = (
                         f"Customize {identifier} settings in <b>Step 2.2</b> if needed"
                     )
                 else:
                     info.value = ""
-                model.update()
+                panel.refresh()
                 self._update_tabs()
 
             model.observe(
@@ -279,7 +281,6 @@ class ConfigurationStep(ConfirmableDependentWizardStep[ConfigurationStepModel]):
                 )
             )
 
-            panel: ConfigurationSettingsPanel = configuration["panel"](model=model)
             self.settings[identifier] = panel
 
         self._model.installed_properties_fetched = True

--- a/src/aiidalab_qe/app/configuration/step.py
+++ b/src/aiidalab_qe/app/configuration/step.py
@@ -197,7 +197,6 @@ class ConfigurationStep(ConfirmableDependentWizardStep[ConfigurationStepModel]):
 
     def _on_input_structure_change(self, _):
         self._model.update()
-        self._model.update_state()
 
     def _on_installed_properties_fetched(self, _):
         if not self.rendered:

--- a/src/aiidalab_qe/app/result/components/viewer/structure/model.py
+++ b/src/aiidalab_qe/app/result/components/viewer/structure/model.py
@@ -36,8 +36,8 @@ class StructureResultsModel(ResultsModel):
         parameters = self.inputs.relax.base.pw.parameters.get_dict()
         return "relax" in parameters["CONTROL"]["calculation"]
 
-    def update(self):
-        super().update()
+    def _update(self, specific=""):
+        super()._update(specific)
         with self.hold_trait_notifications():
             if not self.is_relaxed or self.selected_view == "initial":
                 self.sub_header = self._SUB_HEADER_TEMPLATE.format(content="Initial")

--- a/src/aiidalab_qe/app/result/model.py
+++ b/src/aiidalab_qe/app/result/model.py
@@ -38,11 +38,7 @@ class ResultsStepModel(
     def is_failed(self):
         return self.state is State.FAIL
 
-    @property
-    def is_loading(self):
-        return super().is_loading and not (self.is_active or self.is_failed)
-
-    def update(self):
+    def _update(self, specific=""):
         self._update_process_remote_folder_state()
 
     def kill_process(self):

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -107,6 +107,10 @@ footer {
   background-color: var(--color-failed);
 }
 
+.p-Accordion-child:has(.qe-app-step-blocked) > .p-Collapse-header {
+  background-color: var(--color-blocked);
+}
+
 .p-TabBar-tab {
   min-width: fit-content !important;
 }

--- a/src/aiidalab_qe/app/static/styles/variables.css
+++ b/src/aiidalab_qe/app/static/styles/variables.css
@@ -5,6 +5,7 @@
   --color-active: #d9edf7;
   --color-success: #dff0d8;
   --color-failed: #f2dede;
+  --color-blocked: #f2dede;
   --color-info: #00bcd4;
   --color-info-dark: #0097a7;
   --color-primary: #007bff;

--- a/src/aiidalab_qe/app/structure/model.py
+++ b/src/aiidalab_qe/app/structure/model.py
@@ -30,7 +30,9 @@ class StructureStepModel(
         self.structure_uuid = state.get("uuid")
 
     def update_state(self):
-        if self.confirmed:
+        if self.is_blocked:
+            self.state = State.BLOCKED
+        elif self.confirmed:
             self.state = State.SUCCESS
         elif self.structure_uuid:
             # We check the UUID directly (not using `has_structure`), as the structure

--- a/src/aiidalab_qe/app/structure/step.py
+++ b/src/aiidalab_qe/app/structure/step.py
@@ -194,13 +194,13 @@ class StructureStep(ConfirmableWizardStep[StructureStepModel]):
         self.manager.viewer._viewer._set_size("100%", "300px")
 
     def _on_installation_change(self, _):
-        self._model.update_blockers()
+        self._model.update()
 
     def _on_sssp_installed(self, _):
         self._toggle_sssp_installation_widget()
 
     def _on_input_structure_change(self, _):
-        self._model.update_state()
+        self._model.update()
 
     def _install_sssp(self, auto_setup):
         self.sssp_installation = PseudosInstallWidget(auto_start=False)

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -65,11 +65,10 @@ class SubmissionStepModel(
         if not self.has_process:
             self._submit()
 
-    def update(self):
+    def _update(self, specific=""):
         self.update_process_label()
         self.update_plugin_inclusion()
         self.update_plugin_overrides()
-        self.update_blockers()
         for _, model in self.get_models():
             model.update()
 
@@ -167,11 +166,11 @@ class SubmissionStepModel(
                 model.set_model_state(state[identifier])
 
     def update_state(self):
-        if self.confirmed:
+        if self.is_blocked:
+            self.state = State.BLOCKED
+        elif self.confirmed:
             self.state = State.SUCCESS
-        elif self.is_previous_step_successful and (
-            self.has_structure and self.input_parameters
-        ):
+        elif self.is_previous_step_successful and self.has_all_dependencies:
             self.state = State.CONFIGURED
         else:
             self.state = State.INIT

--- a/src/aiidalab_qe/app/wizard/wizard.py
+++ b/src/aiidalab_qe/app/wizard/wizard.py
@@ -21,6 +21,7 @@ class Wizard(ipw.Accordion):
         State.ACTIVE: "\u231b",
         State.SUCCESS: "\u2713",
         State.FAIL: "\u00d7",
+        State.BLOCKED: "\u25cf",
     }
 
     TITLES = {

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -179,8 +179,7 @@ class HasBlockers(tl.HasTraits):
         return any(self.blockers)
 
     def update_blockers(self):
-        blockers = self._check_blockers()
-        blockers = list(blockers) if blockers is not None else []
+        blockers = list(self._check_blockers() or [])
         if isinstance(self, HasModels):
             for _, model in self.get_models():
                 if isinstance(model, HasBlockers):
@@ -194,5 +193,5 @@ class HasBlockers(tl.HasTraits):
                 if isinstance(model, HasBlockers):
                     model.reset_blockers()
 
-    def _check_blockers(self):
+    def _check_blockers(self) -> t.Generator[str, None, None] | None:
         pass

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -187,5 +187,12 @@ class HasBlockers(tl.HasTraits):
                     blockers.extend(model.blockers)
         self.blockers = blockers
 
+    def reset_blockers(self):
+        self.blockers = []
+        if isinstance(self, HasModels):
+            for _, model in self.get_models():
+                if isinstance(model, HasBlockers):
+                    model.reset_blockers()
+
     def _check_blockers(self):
         pass

--- a/src/aiidalab_qe/common/mixins.py
+++ b/src/aiidalab_qe/common/mixins.py
@@ -8,7 +8,9 @@ import traitlets as tl
 from aiida import orm
 from aiida.common.exceptions import NotExistent
 from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
-from aiidalab_qe.common.mvc import Model
+
+if t.TYPE_CHECKING:
+    from aiidalab_qe.common.mvc import Model
 
 StructureType = t.Union[orm.StructureData, HubbardStructureData]
 
@@ -44,7 +46,7 @@ class HasInputStructure(tl.HasTraits):
         return len(self.input_structure.sites) if self.has_structure else 0
 
 
-M = t.TypeVar("M", bound=Model)
+M = t.TypeVar("M", bound="Model")
 
 
 class HasModels(t.Generic[M]):
@@ -80,16 +82,14 @@ class HasModels(t.Generic[M]):
         return self._models.items()
 
     def _link_model(self, model: M):
-        assert isinstance(model, Model), "HasModels only works with Model instances"
         tl.dlink(
             (self, "locked"),
             (model, "locked"),
         )
-        if isinstance(self, HasBlockers) and isinstance(model, HasBlockers):
-            tl.dlink(
-                (model, "blockers"),
-                (self, "blockers"),
-            )
+        tl.dlink(
+            (model, "blockers"),
+            (self, "blockers"),
+        )
         for dependency in model.dependencies:
             dependency_parts = dependency.rsplit(".", 1)
             if len(dependency_parts) == 1:  # from parent
@@ -173,33 +173,19 @@ class Confirmable(tl.HasTraits):
 
 class HasBlockers(tl.HasTraits):
     blockers = tl.List(tl.Unicode())
-    blocker_messages = tl.Unicode("")
 
     @property
     def is_blocked(self):
         return any(self.blockers)
 
     def update_blockers(self):
-        blockers = list(self._check_blockers())
+        blockers = self._check_blockers()
+        blockers = list(blockers) if blockers is not None else []
         if isinstance(self, HasModels):
             for _, model in self.get_models():
                 if isinstance(model, HasBlockers):
-                    blockers += model.blockers
+                    blockers.extend(model.blockers)
         self.blockers = blockers
 
-    def update_blocker_messages(self):
-        if self.is_blocked:
-            formatted = "\n".join(f"<li>{item}</li>" for item in self.blockers)
-            self.blocker_messages = f"""
-                <div class="alert alert-danger" style="margin-top: 8px;">
-                    <b>The step is blocked due to the following reason(s):</b>
-                    <ul>
-                        {formatted}
-                    </ul>
-                </div>
-            """
-        else:
-            self.blocker_messages = ""
-
     def _check_blockers(self):
-        raise NotImplementedError
+        pass

--- a/src/aiidalab_qe/common/mvc.py
+++ b/src/aiidalab_qe/common/mvc.py
@@ -4,6 +4,8 @@ import typing as t
 
 import traitlets as tl
 
+from aiidalab_qe.common.mixins import HasBlockers
+
 
 class MetaHasTraitsLast(tl.MetaHasTraits):
     """A metaclass that ensures that `HasTraits` is pushed to the end of the MRO.
@@ -18,7 +20,11 @@ class MetaHasTraitsLast(tl.MetaHasTraits):
         return super().__new__(cls, name, bases, classdict)
 
 
-class Model(tl.HasTraits, metaclass=MetaHasTraitsLast):
+class Model(
+    tl.HasTraits,
+    HasBlockers,
+    metaclass=MetaHasTraitsLast,
+):
     """A parent class for all MVC models.
 
     The class extends `traitlet`'s `HasTraits` and uses a metaclass to
@@ -32,15 +38,12 @@ class Model(tl.HasTraits, metaclass=MetaHasTraitsLast):
         The identifier for this model.
     `dependencies` : `list[str]`
         A list of dependencies for this model.
-    `updated` : `bool`
-        Whether the model has been updated.
     `locked` : `bool`
         Whether the model is locked.
     """
 
     identifier = ""
     dependencies: list[str] = []
-    updated = False
 
     locked = tl.Bool(False)
 
@@ -62,6 +65,14 @@ class Model(tl.HasTraits, metaclass=MetaHasTraitsLast):
         `specific` : `str`, optional
             If provided, specifies the level of update.
         """
+        if self.locked or specific == "widgets":
+            return
+        self._update(specific)
+        self.update_blockers()
+        self.update_state()
+
+    def update_state(self):
+        """Update the model state."""
         pass
 
     def get_model_state(self) -> dict:
@@ -74,6 +85,10 @@ class Model(tl.HasTraits, metaclass=MetaHasTraitsLast):
 
     def reset(self):
         """Reset the model to present defaults."""
+        pass
+
+    def _update(self, specific=""):
+        """Internal method to update the model."""
         pass
 
     def _get_default(self, trait: dict) -> t.Any:

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -17,7 +17,7 @@ from aiida import orm
 from aiida.common.extendeddicts import AttributeDict
 from aiidalab_qe.common.code.model import CodeModel
 from aiidalab_qe.common.infobox import InAppGuide
-from aiidalab_qe.common.mixins import Confirmable, HasBlockers, HasModels, HasProcess
+from aiidalab_qe.common.mixins import Confirmable, HasModels, HasProcess
 from aiidalab_qe.common.mvc import Model
 from aiidalab_qe.common.widgets import (
     PwCodeResourceSetupWidget,
@@ -29,7 +29,7 @@ from aiidalab_widgets_base import LoadingWidget
 DEFAULT: dict = DEFAULT_PARAMETERS  # type: ignore
 
 
-class PanelModel(Model, Confirmable, HasBlockers):
+class PanelModel(Model, Confirmable):
     """Base class for all panel models.
 
     Attributes
@@ -103,9 +103,6 @@ class ConfigurationSettingsModel(PanelModel):
         super().__init__(*args, **kwargs)
 
 
-CSM = t.TypeVar("CSM", bound=ConfigurationSettingsModel)
-
-
 class ConfigurationSettingsPanel(Panel[PM]):
     """Base class for configuration settings panels."""
 
@@ -121,28 +118,12 @@ class ConfigurationSettingsPanel(Panel[PM]):
         `specific` : `str`, optional
             If provided, specifies the level of refresh.
         """
-        self._model.updated = False
         self._unsubscribe()
         if self._model.include:
-            self.update(specific)
-
-    def update(self, specific=""):
-        """Updates the model if not yet updated.
-
-        Parameters
-        ----------
-        `specific` : `str`, optional
-            If provided, specifies the level of update.
-        """
-        if self._model.updated:
-            return
-        if not self._model.locked and specific != "widgets":
             self._model.update(specific)
-        self._update()
-        self._model.updated = True
+            self._update_ui()
 
-    def _update(self):
-        """Updates the panel UI."""
+    def _update_ui(self):
         pass
 
     def _unsubscribe(self):
@@ -386,7 +367,7 @@ class PluginResourceSettingsModel(ResourceSettingsModel):
         super().add_model(identifier, model)
         model.activate()
 
-    def update(self):
+    def _update(self, specific=""):
         """Updates the code models from the global resources.
 
         Skips synchronization with global resources if the user has chosen to override
@@ -539,7 +520,7 @@ class ResultsModel(PanelModel, HasProcess):
         node = self.fetch_child_process_node()
         return node and node.is_finished_ok
 
-    def update(self):
+    def _update(self, specific=""):
         self.auto_render = self.has_results
 
     def update_process_status_notification(self):

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -44,6 +44,10 @@ class PanelModel(Model, Confirmable):
 
     include = tl.Bool(False)
 
+    def update_blockers(self):
+        if self.include:
+            super().update_blockers()
+
 
 PM = t.TypeVar("PM", bound=PanelModel)
 
@@ -122,6 +126,8 @@ class ConfigurationSettingsPanel(Panel[PM]):
         if self._model.include:
             self._model.update(specific)
             self._update_ui()
+        else:
+            self._model.reset_blockers()
 
     def _update_ui(self):
         pass

--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -48,7 +48,7 @@ class RollingOutput(ipw.VBox):
     value = traitlets.Unicode()
     auto_scroll = traitlets.Bool()
 
-    def __init__(self, num_min_lines=10, max_output_height="200px", **kwargs):  # noqa: ARG002
+    def __init__(self, num_min_lines=10, max_output_height="200px", **kwargs):
         self._num_min_lines = num_min_lines
         self._output = ipw.HTML(layout=ipw.Layout(min_width="80em"))
         self._refresh_output()

--- a/src/aiidalab_qe/common/wizard.py
+++ b/src/aiidalab_qe/common/wizard.py
@@ -6,7 +6,7 @@ import typing as t
 import ipywidgets as ipw
 import traitlets as tl
 
-from aiidalab_qe.common.mixins import Confirmable, HasBlockers
+from aiidalab_qe.common.mixins import Confirmable
 from aiidalab_qe.common.mvc import Model
 from aiidalab_qe.common.widgets import WarningWidget
 from aiidalab_widgets_base import LoadingWidget
@@ -15,6 +15,7 @@ from aiidalab_widgets_base import LoadingWidget
 class State(enum.Enum):
     """Local copy of AWB's `WizardAppWidgetStep.State`"""
 
+    BLOCKED = -2
     FAIL = -1
     INIT = 0
     CONFIGURED = 1
@@ -91,9 +92,7 @@ class WizardStep(ipw.VBox, t.Generic[WSM]):
 class ConfirmableWizardStepModel(
     WizardStepModel,
     Confirmable,
-    HasBlockers,
 ):
-    blockers = tl.List(tl.Unicode())
     blocker_messages = tl.Unicode("")
 
     def __init__(self, *args, **kwargs):
@@ -107,9 +106,23 @@ class ConfirmableWizardStepModel(
             ]
         )
 
-    @property
-    def is_blocked(self):
-        return any(self.blockers)
+    def update_blockers(self):
+        if self.state is not State.INIT:
+            super().update_blockers()
+
+    def update_blocker_messages(self):
+        if self.is_blocked:
+            formatted = "\n".join(f"<li>{item}</li>" for item in self.blockers)
+            self.blocker_messages = f"""
+                <div class="alert alert-danger" style="margin-top: 8px;">
+                    <b>The step is blocked due to the following reason(s):</b>
+                    <ul>
+                        {formatted}
+                    </ul>
+                </div>
+            """
+        else:
+            self.blocker_messages = ""
 
     def lock(self):
         super().lock()
@@ -181,8 +194,9 @@ class ConfirmableWizardStep(WizardStep[CWSM]):
         self._model.update_state()
 
     def _on_blockers_change(self, _):
-        self._model.update_blocker_messages()
-        self._model.update_state()
+        if self._model.state is not State.INIT:
+            self._model.update_blocker_messages()
+            self._model.update_state()
 
 
 class DependentWizardStepModel(WizardStepModel):
@@ -197,12 +211,6 @@ class DependentWizardStepModel(WizardStepModel):
     @property
     def has_all_dependencies(self) -> bool:
         return all(getattr(self, dep) for dep in self._dependencies)
-
-    @property
-    def is_loading(self):
-        return not (
-            self.has_all_dependencies and (self.is_configured or self.is_successful)
-        )
 
 
 DWSM = t.TypeVar("DWSM", bound=DependentWizardStepModel)
@@ -239,7 +247,7 @@ class DependentWizardStep(WizardStep[DWSM]):
     def _update_content(self, _=None):
         if not self._model.is_previous_step_successful:
             self._show_missing_info_warning()
-        elif self._model.is_loading:
+        elif not self._model.has_all_dependencies:
             self._show_loading_message()
         else:
             self._show_content()

--- a/src/aiidalab_qe/plugins/electronic_structure/result/model.py
+++ b/src/aiidalab_qe/plugins/electronic_structure/result/model.py
@@ -62,8 +62,8 @@ class ElectronicStructureResultsModel(ResultsModel):
     def needs_property_selector(self):
         return len(self.identifiers) > 1
 
-    def update(self):
-        super().update()
+    def _update(self, specific=""):
+        super()._update(specific)
         self.identifiers = list(
             filter(
                 lambda identifier: identifier in self.properties,

--- a/src/aiidalab_qe/plugins/pdos/model.py
+++ b/src/aiidalab_qe/plugins/pdos/model.py
@@ -26,7 +26,7 @@ class PdosConfigurationSettingsModel(PanelModel, HasInputStructure):
     pdos_degauss = tl.Float(0.005)
     energy_grid_step = tl.Float(0.01)
 
-    def update(self, specific=""):
+    def _update(self, specific=""):
         with self.hold_trait_notifications():
             if not specific or specific != "mesh":
                 parameters = PdosWorkChain.get_protocol_inputs(self.protocol)


### PR DESCRIPTION
This PR fixes various issues with the blockers system. It also extends the mechanism to all models, for furture support.
In passing, the PR fixes a few inconsistencies with state handling and component updating.

For context, a blocking system was introduced a while back to the app to allow blocking wizard steps for any given reason. For example, the submission step is blocked if QE or its codes are still being installed. Since, the system was expanded in the configuration step to block for unreasonable configuration. This is implemented in a way that allows each panel model to define its own blocker(s). However, the system was incomplete, evident by various inconsistencies and bugs discovered along the way. This PR aims to resolve these issues, as well as introduce `BLOCKED` as a new actionable wizard step state, so that we can better track blocking events.