### PR TITLE
Fix code loading bug

### DIFF
--- a/src/aiidalab_qe/app/submission/global_settings/model.py
+++ b/src/aiidalab_qe/app/submission/global_settings/model.py
@@ -47,6 +47,11 @@ class GlobalResourceSettingsModel(
         self.global_codes = self.get_model_state()["codes"]
 
     def update_active_codes(self):
+        """Toggle code selectors conditional on plugin activity and required parameters.
+
+        For a given code (e.g., pw), if at least one active plugin requires it (if any condition
+        registered for the code is met), we activate it.
+        """
         for identifier, code_model in self.get_models():
             if identifier != "quantumespresso__pw":
                 code_model.deactivate()

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ipywidgets as ipw
 import traitlets as tl
 from IPython.display import Javascript, display
 
@@ -64,6 +63,7 @@ class SubmissionStepModel(
         super().confirm()
         if not self.has_process:
             self._submit()
+        self.lock()
 
     def _update(self, specific=""):
         self.update_process_label()
@@ -150,7 +150,10 @@ class SubmissionStepModel(
             return
         self.process_label = self.process.label
         self.process_description = self.process.description
-        self.locked = True
+
+    def refresh_codes(self, filter_codes_for_user: bool = True):
+        for _, resource_model in self.get_models():
+            resource_model.refresh_codes(filter_codes_for_user=filter_codes_for_user)
 
     def get_model_state(self) -> dict:
         return {
@@ -206,20 +209,6 @@ class SubmissionStepModel(
 
             pk = process_node.pk
             display(Javascript(f"window.history.pushState(null, '', '?pk={pk}');"))
-
-    def _link_model(self, model: ResourceSettingsModel):
-        for dependency in model.dependencies:
-            dependency_parts = dependency.split(".")
-            if len(dependency_parts) == 1:  # from parent, e.g. input_structure
-                target_model = self
-                trait = dependency
-            else:  # from sibling, e.g. workchain.protocol
-                sibling, trait = dependency_parts
-                target_model = self.get_model(sibling)
-            ipw.dlink(
-                (target_model, trait),
-                (model, trait),
-            )
 
     def _get_properties(self) -> list[str]:
         return self.input_parameters.get("workchain", {}).get("properties", [])

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -245,12 +245,6 @@ class SubmissionStepModel(
         if not self.input_parameters:
             yield "No selected input parameters"
 
-        if self.installing_qe:
-            yield "Installing Quantum ESPRESSO codes..."
-
-        if not self.qe_installed:
-            yield "Quantum ESPRESSO is not yet installed"
-
     def _check_warnings(self):
         """Check for any warnings that should be displayed to the user."""
         return ""

--- a/src/aiidalab_qe/app/wizard/model.py
+++ b/src/aiidalab_qe/app/wizard/model.py
@@ -45,6 +45,8 @@ class WizardModel(Model, HasModels[WizardStepModel]):
                         SubmissionStepModel,
                         self.get_model("submit"),
                     )
+                    if process_uuid is not None:
+                        submission_model.refresh_codes(filter_codes_for_user=False)
                     submission_model.set_model_state(resources_state)
 
                     if step_index >= 3:

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -68,9 +68,15 @@ class CodeModel(Model):
     def deactivate(self):
         self.is_active = False
 
-    def update(self, user_email: str, default_code=None, refresh=False):
+    def update(
+        self,
+        user_email: str,
+        default_code: str | None = None,
+        filter_codes_for_user: bool = True,
+        refresh: bool = False,
+    ):
         if not self.options or refresh:
-            self.options = self._get_codes(user_email)
+            self.options = self._get_codes(user_email, filter_codes_for_user)
             if default_code:
                 try:
                     selected = orm.load_code(default_code).uuid
@@ -115,7 +121,11 @@ class CodeModel(Model):
         # in the app and thus will not be considered as an option!
         return uuid if uuid in [opt[1] for opt in self.options] else None
 
-    def _get_codes(self, user_email: str):
+    def _get_codes(
+        self,
+        user_email: str,
+        filter_codes_for_user: bool = True,
+    ) -> list[tuple[str, str]]:
         user = orm.User.collection.get(email=user_email)
 
         filters = (
@@ -124,25 +134,33 @@ class CodeModel(Model):
             else {}
         )
 
-        codes = (
-            orm.QueryBuilder()
-            .append(
-                orm.Code,
-                filters=filters,
-            )
-            .all(flat=True)
+        codes = t.cast(
+            list[orm.Code],
+            (
+                orm.QueryBuilder()
+                .append(
+                    orm.Code,
+                    filters=filters,
+                )
+                .all(flat=True)
+            ),
         )
 
         return [
             (self._full_code_label(code), code.uuid)
             for code in codes
-            if code.computer.is_user_configured(user)
-            and (self.allow_hidden_codes or not code.is_hidden)
-            and (self.allow_disabled_computers or code.computer.is_user_enabled(user))
+            if not filter_codes_for_user
+            or (
+                code.computer.is_user_configured(user)
+                and (self.allow_hidden_codes or not code.is_hidden)
+                and (
+                    self.allow_disabled_computers or code.computer.is_user_enabled(user)
+                )
+            )
         ]
 
     @staticmethod
-    def _full_code_label(code):
+    def _full_code_label(code: orm.Code) -> str:
         return f"{code.label}@{code.computer.label}"
 
 

--- a/src/aiidalab_qe/common/code/model.py
+++ b/src/aiidalab_qe/common/code/model.py
@@ -81,10 +81,7 @@ class CodeModel(Model):
                 try:
                     selected = orm.load_code(default_code).uuid
                 except NotExistent:
-                    selected = None
-                    self.warning = self._WARNING_TEMPLATE.format(
-                        warning=f"Code '{default_code}' not found"
-                    )
+                    selected = self.first_option
             else:
                 selected = self.first_option
             self.selected = selected

--- a/src/aiidalab_qe/common/panel.py
+++ b/src/aiidalab_qe/common/panel.py
@@ -172,12 +172,13 @@ class ResourceSettingsModel(PanelModel, HasModels[CodeModel]):
             else:
                 code_model.deactivate()
 
-    def refresh_codes(self):
+    def refresh_codes(self, filter_codes_for_user: bool = True):
         for _, code_model in self.get_models():
             code_key = code_model.default_calc_job_plugin.split(".")[-1]
             code_model.update(
                 user_email=self.default_user_email,
                 default_code=self.default_codes.get(code_key, {}).get("code"),
+                filter_codes_for_user=filter_codes_for_user,
                 refresh=True,
             )
 

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -136,3 +136,30 @@ def test_parameters_aware_codes():
     model.input_parameters = {"use_this_code": False}
     assert not model.get_model("test").is_active
     assert panel.code_widgets["test"].layout.display == "none"
+
+
+def test_filter_codes_for_user(app: Wizard, aiida_computer_ssh, aiida_code_installed):
+    unconfigured_computer = aiida_computer_ssh(
+        label="unconfigured_computer",
+        configure=False,
+    )
+    new_code = aiida_code_installed(
+        default_calc_job_plugin="quantumespresso.pw",
+        computer=unconfigured_computer,
+    ).store()
+
+    global_model = app.submit_model.get_model("global")
+
+    # In general, we filter out unconfigured codes so the user can't submit with them
+    app.submit_model.refresh_codes(filter_codes_for_user=True)
+    assert new_code.uuid not in [
+        code_uuid
+        for _, code_uuid in global_model.get_model("quantumespresso__pw").options
+    ]
+
+    # We allow for these codes when loading from a process, since the user can no longer submit
+    app.submit_model.refresh_codes(filter_codes_for_user=False)
+    assert new_code.uuid in [
+        code_uuid
+        for _, code_uuid in global_model.get_model("quantumespresso__pw").options
+    ]


### PR DESCRIPTION
To prevent users from submitting calculations with unconfigured codes, we filter them out:
https://github.com/aiidalab/aiidalab-qe/blob/9ba5c427838b0a171495a9376981834006767d31/src/aiidalab_qe/common/code/model.py#L136-L142

However, this SHOULD NOT happen when loading a process, since the user cannot submit in that state. But it was, so step 3 was emitting blockers due to unselected codes. Prior to #1513, the blockers didn't do their job of blocking the step, but now they do. So if someone loads the app from a process that was run by someone else (e.g., a downloaded example), step 3 is blocked and step 4 never loads.

This PR adds a `filter_codes_for_user` flag injected through the resources refresh mechanism that is generally `True` but set to `False` if we're loading a process. In addition, the PR relaxes default code handling, falling back on the first available code option if the default code does not exist. Finally, the PR removes the blocking of step 3 w.r.t the local QE installation status, since users should still be allowed to proceed with remote submission.