### PR TITLE
Fix pseudo state and blockers propagation

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/advanced.py
+++ b/src/aiidalab_qe/app/configuration/advanced/advanced.py
@@ -85,6 +85,10 @@ class AdvancedConfigurationSettingsPanel(
             self._on_spin_type_change,
             "spin_type",
         )
+        self._model.observe(
+            self._on_blockers_change,
+            "blockers",
+        )
 
         self.sub_settings: dict[str, ConfigurationSettingsPanel] = {
             "general": self.general,
@@ -129,6 +133,16 @@ class AdvancedConfigurationSettingsPanel(
     def _on_spin_type_change(self, _):
         self._update_tabs()
 
+    def _on_advanced_tab_change(self, change):
+        tab: ConfigurationSettingsPanel = self.advanced_tabs.children[change["new"]]  # type: ignore
+        tab.render()
+
+    def _on_reset_to_defaults_button_click(self, _):
+        self._reset()
+
+    def _on_blockers_change(self, _):
+        self._model.update_blockers()
+
     def _update_tabs(self):
         if not self.rendered:
             return
@@ -148,13 +162,6 @@ class AdvancedConfigurationSettingsPanel(
         # Reset tab selection to the first tab (rendered by default) to avoid
         # possible redirection to an un-rendered tab
         self.advanced_tabs.selected_index = 0
-
-    def _on_advanced_tab_change(self, change):
-        tab: ConfigurationSettingsPanel = self.advanced_tabs.children[change["new"]]  # type: ignore
-        tab.render()
-
-    def _on_reset_to_defaults_button_click(self, _):
-        self._reset()
 
     def _reset(self):
         self._model.reset()

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -328,14 +328,9 @@ class PseudosConfigurationSettingsModel(
 
         self.update_family_parameters()
 
-    def get_cutoffs_by_index(self, index: int) -> list[float]:
-        return (
-            [self.cutoffs[0][index], self.cutoffs[1][index]]
-            if len(self.cutoffs[0]) > index
-            else [0.0, 0.0]
-        )
-
     def update_functional(self):
+        if not self.dictionary or self.locked:
+            return
         pseudos: list[UpfData] = []
         for kind_name, uuid in self.dictionary.items():
             kind = self.input_structure.get_kind(kind_name)
@@ -357,6 +352,13 @@ class PseudosConfigurationSettingsModel(
         functional = functional_set.pop() if len(functional_set) == 1 else None
         self._defaults["functional"] = functional
         self.functional = self._get_default("functional")
+
+    def get_cutoffs_by_index(self, index: int) -> list[float]:
+        return (
+            [self.cutoffs[0][index], self.cutoffs[1][index]]
+            if len(self.cutoffs[0]) > index
+            else [0.0, 0.0]
+        )
 
     def reset(self):
         with self.hold_trait_notifications():

--- a/src/aiidalab_qe/common/wizard.py
+++ b/src/aiidalab_qe/common/wizard.py
@@ -195,6 +195,7 @@ class ConfirmableWizardStep(WizardStep[CWSM]):
 
     def _on_blockers_change(self, _):
         if self._model.state is not State.INIT:
+            self._model.update_blockers()
             self._model.update_blocker_messages()
             self._model.update_state()
 


### PR DESCRIPTION
This PR addresses the following two issues:
1. The new functional update method was not guarded for an empty pseudos dictionary, which was incorrectly leading to `None` functionals.
2. The blockers were overwriting one another rather then accumulating, which is now correctly implemented for wizard steps and the advanced settings (which have sub-models).