### PR TITLE
Fix pseudopotential metadata handling

### DIFF
--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -16,9 +16,8 @@ from aiidalab_qe.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.setup.pseudos import PSEUDODOJO_VERSION, SSSP_VERSION, PseudoFamily
 
 from .utils import (
-    get_info_from_family,
+    get_info_from_family_by_md5,
     get_pseudo_family_by_label,
-    get_pseudo_family_by_md5,
     get_upf_dict,
 )
 
@@ -356,11 +355,7 @@ class PseudosConfigurationSettingsModel(
             else:
                 functional = pseudo.base.extras.get("functional", None)
                 if functional is None:
-                    # Family-based pseudos may not yet have the extra information.
-                    # We use the pseudo's md5 hash to retrieve the family and extract the info.
-                    family = get_pseudo_family_by_md5(pseudo.md5)
-                    if family is not None:
-                        functional, _ = get_info_from_family(family)
+                    functional, _ = get_info_from_family_by_md5(pseudo.md5)
                 functional_set.add(functional)
 
         functional = functional_set.pop() if len(functional_set) == 1 else None
@@ -442,11 +437,7 @@ class PseudosConfigurationSettingsModel(
                 functional = pseudo.base.extras.get("functional", None)
                 relativistic = pseudo.base.extras.get("relativistic", None)
                 if functional is None or relativistic is None:
-                    # Family-based pseudos may not yet have the extra information.
-                    # We use the pseudo's md5 hash to retrieve the family and extract the info.
-                    family = get_pseudo_family_by_md5(pseudo.md5)
-                    if family is not None:
-                        functional, relativistic = get_info_from_family(family)
+                    functional, relativistic = get_info_from_family_by_md5(pseudo.md5)
                 functional_set.add(functional)
                 relativistic_set.add(relativistic)
 

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -16,8 +16,9 @@ from aiidalab_qe.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.setup.pseudos import PSEUDODOJO_VERSION, SSSP_VERSION, PseudoFamily
 
 from .utils import (
-    get_info_from_family_by_md5,
+    get_info_from_family,
     get_pseudo_family_by_label,
+    get_pseudo_family_by_md5,
     get_upf_dict,
 )
 
@@ -355,7 +356,11 @@ class PseudosConfigurationSettingsModel(
             else:
                 functional = pseudo.base.extras.get("functional", None)
                 if functional is None:
-                    functional, _ = get_info_from_family_by_md5(pseudo.md5)
+                    # Family-based pseudos may not yet have the extra information.
+                    # We use the pseudo's md5 hash to retrieve the family and extract the info.
+                    family = get_pseudo_family_by_md5(pseudo.md5)
+                    if family is not None:
+                        functional, _ = get_info_from_family(family)
                 functional_set.add(functional)
 
         functional = functional_set.pop() if len(functional_set) == 1 else None
@@ -437,7 +442,11 @@ class PseudosConfigurationSettingsModel(
                 functional = pseudo.base.extras.get("functional", None)
                 relativistic = pseudo.base.extras.get("relativistic", None)
                 if functional is None or relativistic is None:
-                    functional, relativistic = get_info_from_family_by_md5(pseudo.md5)
+                    # Family-based pseudos may not yet have the extra information.
+                    # We use the pseudo's md5 hash to retrieve the family and extract the info.
+                    family = get_pseudo_family_by_md5(pseudo.md5)
+                    if family is not None:
+                        functional, relativistic = get_info_from_family(family)
                 functional_set.add(functional)
                 relativistic_set.add(relativistic)
 

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -329,7 +329,7 @@ class PseudosConfigurationSettingsModel(
         self.update_family_parameters()
 
     def update_functional(self):
-        if not self.dictionary or self.locked:
+        if not self.dictionary or self.family or self.locked:
             return
         pseudos: list[UpfData] = []
         for kind_name, uuid in self.dictionary.items():

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/model.py
@@ -15,7 +15,12 @@ from aiidalab_qe.common.panel import PanelModel
 from aiidalab_qe.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.setup.pseudos import PSEUDODOJO_VERSION, SSSP_VERSION, PseudoFamily
 
-from .utils import get_pseudo_family_by_label, get_upf_dict
+from .utils import (
+    get_info_from_family,
+    get_pseudo_family_by_label,
+    get_pseudo_family_by_md5,
+    get_upf_dict,
+)
 
 SsspFamily = GroupFactory("pseudo.family.sssp")
 PseudoDojoFamily = GroupFactory("pseudo.family.pseudo_dojo")
@@ -331,13 +336,13 @@ class PseudosConfigurationSettingsModel(
     def update_functional(self):
         if not self.dictionary or self.family or self.locked:
             return
-        pseudos: list[UpfData] = []
+
+        functional_set = set()
         for kind_name, uuid in self.dictionary.items():
             kind = self.input_structure.get_kind(kind_name)
             try:
                 assert uuid is not None
                 pseudo = orm.load_node(uuid)
-                pseudos.append(pseudo)
             except AssertionError:
                 print(
                     f"The selected pseudopotential family does not contain a pseudopotential for {kind.symbol}. Consider changing the family or uploading a custom pseudopotential."
@@ -348,7 +353,16 @@ class PseudosConfigurationSettingsModel(
                     f"Pseudopotential with UUID {uuid} does not exist for {kind.symbol}."
                 )
                 continue
-        functional_set = {pp.base.extras.get("functional", None) for pp in pseudos}
+            else:
+                functional = pseudo.base.extras.get("functional", None)
+                if functional is None:
+                    # Family-based pseudos may not yet have the extra information.
+                    # We use the pseudo's md5 hash to retrieve the family and extract the info.
+                    family = get_pseudo_family_by_md5(pseudo.md5)
+                    if family is not None:
+                        functional, _ = get_info_from_family(family)
+                functional_set.add(functional)
+
         functional = functional_set.pop() if len(functional_set) == 1 else None
         self._defaults["functional"] = functional
         self.functional = self._get_default("functional")
@@ -411,27 +425,36 @@ class PseudosConfigurationSettingsModel(
         if not (self.has_structure and self.dictionary):
             return
 
-        pseudos: list[UpfData] = []
+        functional_set = set()
+        relativistic_set = set()
         for kind_name, uuid in self.dictionary.items():
             kind = self.input_structure.get_kind(kind_name)
             try:
                 assert uuid is not None
                 pseudo = orm.load_node(uuid)
-                pseudos.append(pseudo)
             except AssertionError:
                 yield f"The selected pseudopotential family does not contain a pseudopotential for {kind.symbol}. Consider changing the family or uploading a custom pseudopotential."
                 return
             except exceptions.NotExistent:
                 yield f"Pseudopotential with UUID {uuid} does not exist for {kind.symbol}."
                 return
+            else:
+                functional = pseudo.base.extras.get("functional", None)
+                relativistic = pseudo.base.extras.get("relativistic", None)
+                if functional is None or relativistic is None:
+                    # Family-based pseudos may not yet have the extra information.
+                    # We use the pseudo's md5 hash to retrieve the family and extract the info.
+                    family = get_pseudo_family_by_md5(pseudo.md5)
+                    if family is not None:
+                        functional, relativistic = get_info_from_family(family)
+                functional_set.add(functional)
+                relativistic_set.add(relativistic)
 
-        functional_set = {pp.base.extras.get("functional", None) for pp in pseudos}
         if len(functional_set) != 1:
             yield "All pseudopotentials must have the same exchange-correlation (XC) functional."
         elif self.functional and self.functional not in functional_set:
             yield "Selected exchange-correlation (XC) functional is not consistent with the pseudopotentials."
 
-        relativistic_set = {pp.base.extras.get("relativistic", None) for pp in pseudos}
         if self.spin_orbit == "soc":
             if relativistic_set != {"full"}:
                 yield "For spin-orbit coupling (SOC) calculations, all pseudopotentials must be fully relativistic."

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/pseudos.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 import ipywidgets as ipw
 
 from aiida import orm
@@ -54,6 +56,8 @@ class PseudosConfigurationSettingsPanel(
             self._on_ecut_change,
             ["ecutwfc", "ecutrho"],
         )
+
+        self._uploader_dictionary_observers: list[t.Callable] = []
 
     def render(self):
         if self.rendered:
@@ -223,6 +227,7 @@ class PseudosConfigurationSettingsPanel(
         self.refresh(specific="widgets")
 
     def _on_input_structure_change(self, _):
+        self._unsubscribe_uploader_observations()
         self.refresh(specific="structure")
 
     def _on_protocol_change(self, _):
@@ -258,6 +263,11 @@ class PseudosConfigurationSettingsPanel(
     def _update_ui(self):
         self._build_pseudos_list()
         self._model.update_family_header()
+
+    def _unsubscribe_uploader_observations(self):
+        for observer in self._uploader_dictionary_observers:
+            self._model.unobserve(observer, "dictionary")
+        self._uploader_dictionary_observers.clear()
 
     def _toggle_upload_warning(self):
         self._model.show_upload_warning = not self._model.family
@@ -316,6 +326,7 @@ class PseudosConfigurationSettingsPanel(
                 synchronize_pseudo,
                 "dictionary",
             )
+            self._uploader_dictionary_observers.append(synchronize_pseudo)
 
             uploader = PseudoPotentialUploader(model=uploader_model)
             uploader.render()

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/uploader/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/uploader/model.py
@@ -6,7 +6,7 @@ from ..utils import (
     FUNCTIONAL_MAPPING,
     UpfData,
     get_info_from_family,
-    get_pseudo_family_by_content,
+    get_pseudo_family_by_md5,
     get_upf_dict,
 )
 
@@ -52,7 +52,7 @@ class PseudoPotentialUploaderModel(Model):
                 f"Failed to read UPF data from pseudo potential with UUID {self.pseudo.uuid}"
             ) from err
 
-        if pseudo_family := get_pseudo_family_by_content(self.pseudo.md5):
+        if pseudo_family := get_pseudo_family_by_md5(self.pseudo.md5):
             functional, relativistic = get_info_from_family(pseudo_family)
         else:
             functional = FUNCTIONAL_MAPPING.get(

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/uploader/model.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/uploader/model.py
@@ -45,10 +45,6 @@ class PseudoPotentialUploaderModel(Model):
         if not self.pseudo:
             return
 
-        keys = ("functional", "relativistic")
-        if all(key in self.pseudo.base.extras.all for key in keys):
-            return
-
         try:
             upf_dict = get_upf_dict(self.pseudo)
         except Exception as err:

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
@@ -26,12 +26,12 @@ RELATIVISTIC_MAPPING = {
 
 def get_info_from_family(pseudo_family: PseudoPotentialFamily):
     try:
-        if isinstance(pseudo_family, SsspFamily):
-            functional = pseudo_family.label.split("/")[2]
-            relativistic = None
+        label_parts = pseudo_family.label.split("/")
+        functional = label_parts[2]
+        if isinstance(pseudo_family, PseudoDojoFamily):
+            relativistic = RELATIVISTIC_MAPPING.get(label_parts[3])
         else:
-            functional = pseudo_family.label.split("/")[2]
-            relativistic = pseudo_family.label.split("/")[3]
+            relativistic = None
     except TypeError as err:
         raise ValueError(
             "Pseudo family label format is invalid. Expected format: 'family/functional/relativistic'."
@@ -39,7 +39,7 @@ def get_info_from_family(pseudo_family: PseudoPotentialFamily):
     except Exception as err:
         raise ValueError("Invalid pseudo family label format") from err
     else:
-        return functional, RELATIVISTIC_MAPPING.get(relativistic or "", relativistic)
+        return functional, relativistic
 
 
 def get_pseudo_by_filename(filename: str):
@@ -64,7 +64,7 @@ def get_pseudo_by_md5(md5: str):
     )
 
 
-def get_pseudo_family_by_content(md5: str) -> t.Optional[PseudoPotentialFamily]:
+def get_pseudo_family_by_md5(md5: str) -> t.Optional[PseudoPotentialFamily]:
     return (
         orm.QueryBuilder()
         .append(

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
@@ -42,6 +42,13 @@ def get_info_from_family(pseudo_family: PseudoPotentialFamily):
         return functional, relativistic
 
 
+def get_info_from_family_by_md5(md5: str):
+    pseudo_family = get_pseudo_family_by_md5(md5)
+    if pseudo_family:
+        return get_info_from_family(pseudo_family)
+    return None, None
+
+
 def get_pseudo_by_filename(filename: str):
     return (
         orm.QueryBuilder()

--- a/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
+++ b/src/aiidalab_qe/app/configuration/advanced/pseudos/utils.py
@@ -42,13 +42,6 @@ def get_info_from_family(pseudo_family: PseudoPotentialFamily):
         return functional, relativistic
 
 
-def get_info_from_family_by_md5(md5: str):
-    pseudo_family = get_pseudo_family_by_md5(md5)
-    if pseudo_family:
-        return get_info_from_family(pseudo_family)
-    return None, None
-
-
 def get_pseudo_by_filename(filename: str):
     return (
         orm.QueryBuilder()


### PR DESCRIPTION
We were mishandling the functional/relativistic information from
pseudo extras. This PR aims to resolve these issues by first guarding
against redundant functional updates, then removing a blocker from
setting the extras info, and finally by defaulting to the family if
the extras info is missing (likely not yet set).

Peripherally, the PR adds a cache for observations set at each 
rerender of the pseudopotential uploader widgets. The cache is used to
unsubscribe from the observations at each refresh (structure change)
to avoid observer accumulation.

Closes #1530 