### PR TITLE
Install app and plugins in .local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN set -ex; \
     tar xf hq.tar.gz -C /opt/conda/
 
 # Install the app and its plugins into the user's local Python environment
-RUN python -m pip install . ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
+RUN python -m pip install --user --no-cache-dir . ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,12 +80,9 @@ WORKDIR ${QE_APP_SRC}
 COPY --chown=${NB_UID}:${NB_GID} src/ ${QE_APP_SRC}/src
 COPY --chown=${NB_UID}:${NB_GID} setup.cfg pyproject.toml LICENSE README.md ${QE_APP_SRC}
 
-# NOTE: euphonic must be build separately with --no-build-isolation,
-# otherwise it fails to build on arm64 due to missing build-time numpy dependency.
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=type=cache,sharing=locked,target=${UV_CACHE_DIR},uid=${NB_UID},gid=${NB_GID} \
-    uv pip install --strict --no-build-isolation euphonic==1.3.2 && \
-    uv pip install --strict . ${AIIDA_HQ_PKG} ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
+    uv pip install --strict ${AIIDA_HQ_PKG}
 
 ###############################################################################
 # 6) home_build stage
@@ -107,6 +104,9 @@ RUN set -ex; \
       wget --no-verbose -c -O hq.tar.gz "${HQ_URL_AMD64}"; \
     fi && \
     tar xf hq.tar.gz -C /opt/conda/
+
+# Install the app and its plugins into the user's local Python environment
+RUN python -m pip install . ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 
@@ -196,9 +196,7 @@ RUN mamba install aiida-core.atomic_tools -y && \
 # Use uv cache from the previous build step
 RUN --mount=from=uv,source=/uv,target=/bin/uv \
     --mount=type=cache,sharing=locked,target=${UV_CACHE_DIR},uid=${NB_UID},gid=${NB_GID} \
-    --mount=from=build_deps,source=${QE_APP_SRC},target=${QE_APP_SRC},rw \
-    uv pip install --strict --compile-bytecode \
-      ${QE_APP_SRC} ${AIIDA_HQ_PKG} ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
+    uv pip install --strict --compile-bytecode ${AIIDA_HQ_PKG}
 
 # copy hq binary
 COPY --from=home_build /opt/conda/hq /usr/local/bin/


### PR DESCRIPTION
#1337 was great for ephemeral deployments (i.e., demo server), but
does not work for persistent ones (e.g., institutional). #1337
installs the app and its plugins into conda, instead of .local.
However, existing instances prior to #1337 have the app and its
plugins in .local. Though Python defers to .local for imports, this is
 not true for entry points. The app's plugin system is based on
 loading entry points, which triggers an entry point search across a
 plugin's dependencies, which are now duplicated between .local and
 conda. This prevents the use of the given plugin.

This PR keeps most of the recent changes to the image but shifts the
installation of the app and plugins to .local. This means they are
tarred and untarred on home when the container is first deployed
(fresh volume). For existing volumes, conflicts are only in version.
No more entry point conflicts!