### PR TITLE
Deduplicate packages in QE image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,12 @@ RUN set -ex; \
     fi && \
     tar xf hq.tar.gz -C /opt/conda/
 
+# Install common dependencies such as pymatgen and pandas via conda,
+# to avoid building them when installing via pip
+# TODO: Remove this once it is part of the full-stack image.
+RUN mamba install aiida-core.atomic_tools -y && \
+    mamba clean --all -f -y
+
 # Install the app and its plugins into the user's local Python environment
 RUN python -m pip install --user --no-cache-dir . ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
 


### PR DESCRIPTION
Packages from `aiida-core.atomic_tools` were being installed both in `.local` and `/opt/conda`.

Staged on top of #1536 

This PR saves around 400Mb, roughly the same amount gained in #1534 


<img width="1311" height="161" alt="image" src="https://github.com/user-attachments/assets/222c535d-3160-4b8b-b985-2f2f7b93c9db" />
 