### PR TITLE
Check blocked state only if not confirmed

### DIFF
--- a/src/aiidalab_qe/app/configuration/model.py
+++ b/src/aiidalab_qe/app/configuration/model.py
@@ -126,10 +126,10 @@ class ConfigurationStepModel(
                 model.set_model_state(state[identifier])
 
     def update_state(self):
-        if self.is_blocked:
-            self.state = State.BLOCKED
-        elif self.confirmed:
+        if self.confirmed:
             self.state = State.SUCCESS
+        elif self.is_blocked:
+            self.state = State.BLOCKED
         elif self.is_previous_step_successful and self.has_all_dependencies:
             self.state = State.CONFIGURED
         else:

--- a/src/aiidalab_qe/app/structure/model.py
+++ b/src/aiidalab_qe/app/structure/model.py
@@ -30,10 +30,10 @@ class StructureStepModel(
         self.structure_uuid = state.get("uuid")
 
     def update_state(self):
-        if self.is_blocked:
-            self.state = State.BLOCKED
-        elif self.confirmed:
+        if self.confirmed:
             self.state = State.SUCCESS
+        elif self.is_blocked:
+            self.state = State.BLOCKED
         elif self.structure_uuid:
             # We check the UUID directly (not using `has_structure`), as the structure
             # may not yet be stored.

--- a/src/aiidalab_qe/app/submission/model.py
+++ b/src/aiidalab_qe/app/submission/model.py
@@ -169,10 +169,10 @@ class SubmissionStepModel(
                 model.set_model_state(state[identifier])
 
     def update_state(self):
-        if self.is_blocked:
-            self.state = State.BLOCKED
-        elif self.confirmed:
+        if self.confirmed:
             self.state = State.SUCCESS
+        elif self.is_blocked:
+            self.state = State.BLOCKED
         elif self.is_previous_step_successful and self.has_all_dependencies:
             self.state = State.CONFIGURED
         else:


### PR DESCRIPTION
We were checking for a blocked state first, which applies also to completed jobs.
This PR moves blocking state checks after completion checks, to avoid blocking
already finished jobs.

Blocking such jobs SHOULD NOT happen in principle, but it can happen due to
bugs. This PR ensures at least that users aren't blocked for such reasons. The
blockers still appear (so we can still detect bugs), but now they don't block the
wizard.