### PR TITLE
Add aiida-qe-converse plugin (NMR shielding + EFG/NQR quadrupolar parameters)

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -76,3 +76,13 @@ aiidalab-qe-pp:
     status: beta
     category: calculation
     requires_aiidalab_qe: '>26.05.0'
+
+aiida-qe-converse:
+    title: NMR shielding & EFG/NQR quadrupolar parameters (aiida-qe-converse)
+    description: Compute NMR chemical shielding tensors (converse GIPAW approach) and electric field gradient / NMR-NQR quadrupolar parameters (Cq, eta, nu_Q) with Quantum ESPRESSO via QE-CONVERSE (qe-converse.x / qe-efg.x). Requires a deployment with QE-CONVERSE built from source; GIPAW pseudopotentials are bundled and imported automatically on install.
+    author: Moritz Gubler
+    github: https://github.com/moritzgubler/aiidaConverseNMR@1.0.1
+    post_install: pseudos
+    status: beta
+    category: calculation
+    requires_aiidalab_qe: '>26.05.0'

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -79,7 +79,9 @@ aiidalab-qe-pp:
 
 aiida-qe-converse:
     title: NMR shielding & EFG/NQR quadrupolar parameters (aiida-qe-converse)
-    description: Compute NMR chemical shielding tensors (converse GIPAW approach) and electric field gradient / NMR-NQR quadrupolar parameters (Cq, eta, nu_Q) with Quantum ESPRESSO via QE-CONVERSE (qe-converse.x / qe-efg.x). Requires a deployment with QE-CONVERSE built from source; GIPAW pseudopotentials are bundled and imported automatically on install.
+    description: Compute NMR chemical shielding tensors (converse GIPAW approach) and electric field gradient / NMR-NQR quadrupolar parameters (Cq, eta,
+        nu_Q) with Quantum ESPRESSO via QE-CONVERSE (qe-converse.x / qe-efg.x). Requires a deployment with QE-CONVERSE built from source; GIPAW pseudopotentials
+        are bundled and imported automatically on install.
     author: Moritz Gubler
     github: https://github.com/moritzgubler/aiidaConverseNMR@1.0.1
     post_install: pseudos


### PR DESCRIPTION
## Summary
Adds `aiida-qe-converse` to the plugin registry: an aiidalab-qe plugin providing
- NMR chemical shielding tensors via the converse-GIPAW approach (`qe-converse.x`)
- Electric field gradient / NMR-NQR quadrupolar parameters (Cq, eta, nu_Q) (`qe-efg.x`)

Built on the [QE-CONVERSE](https://github.com/mammasmias/QE-CONVERSE) extension to Quantum ESPRESSO.

## ⚠️ Known limitation: does not work yet against the current stable AiiDAlab-QE release
This plugin requires **aiida-quantumespresso ≥ 4.16** to parse QE 7.5's XML output
schema (`qes_250521`) — older versions reject it outright with exit code 322 — which
in turn requires **Python ≥ 3.10**. The current *stable* `aiidalab/qe` image still
ships aiida-quantumespresso 4.12 on Python 3.9, so installing this plugin there fails
at the SCF-parsing step, not just degrades.

It does work against the dev image that already has the newer stack
(`ghcr.io/aiidalab/qe:pr-1512` — Python 3.12 / aiida-core 2.8 / aiida-quantumespresso
4.17), which is what I use for development and testing.

I understand this means the plugin isn't really usable through the Plugin Store until
a stable AiiDAlab-QE release ships aiida-quantumespresso ≥4.16. It makes sense to merge this after the aiidalab-qe has been upgraded. At that point I can also test wether the installation works from the user interface.