### PR TITLE
Ignore notebook checkpoint files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tar.gz
 *.code-workspace
 .*.ipynb
+*-[0-9]*.ipynb
 .ipynb*
 build/
 export/


### PR DESCRIPTION
Some tech update along the way has changed notebook checkpoints from `.<name>-#.ipynb` to `<name>-#.ipynb` (no dot). This PR adds this pattern to .gitignore.