### PR TITLE
Keep active guide as "No Guides if specific guide is null

### DIFF
--- a/src/aiidalab_qe/app/app.py
+++ b/src/aiidalab_qe/app/app.py
@@ -257,7 +257,7 @@ class AppModel(tl.HasTraits):
 
     def update_active_guide(self, category, guide):
         """Sets the current active guide."""
-        active_guide = f"{category}/{guide}" if category != "No guides" else category
+        active_guide = "No guides" if guide is None else f"{category}/{guide}"
         guide_manager.active_guide = active_guide
 
     def get_state_from_process(self) -> dict:


### PR DESCRIPTION
In the new tech stack, the first option of radio buttons is not selected by default. In this case, this causes the guide selector to remain null when a guides category is selected. This PR prevents an attempt to parse the active guide when `guide` is `None`.