### PR TITLE
Fix dependency incompatibilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG COMPUTER_LABEL="localhost"
 
 ARG HQ_URL_AMD64="https://github.com/It4innovations/hyperqueue/releases/download/v${HQ_VER}/hq-v${HQ_VER}-linux-x64.tar.gz"
 ARG HQ_URL_ARM64="https://github.com/It4innovations/hyperqueue/releases/download/v${HQ_VER}/hq-v${HQ_VER}-linux-arm64-linux.tar.gz"
-ARG MUON_PKG="aiidalab-qe-muon@git+https://github.com/aiidalab/aiidalab-qe-muon@v1.1.3"
+ARG MUON_PKG="aiidalab-qe-muon@git+https://github.com/aiidalab/aiidalab-qe-muon@support/1.1.x"
 ARG AIIDA_HQ_PKG="aiida-hyperqueue~=0.3.0"
 
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,8 +105,8 @@ RUN python -m pip install --user --no-cache-dir . \
     aiidalab-qe-pp \
     aiida-qe-xspec \
     # the following git-installed plugins are due to PyPI quarantines - discard when resolved
-    aiida-wannier90-workflows@git+https://github.com/aiidateam/aiida-wannier90-workflows@v2.7.1 \
     aiida-wannier90@git+https://github.com/aiidateam/aiida-wannier90@v2.2.0 \
+    aiida-wannier90-workflows@git+https://github.com/aiidateam/aiida-wannier90-workflows@v2.7.1 \
     aiida-skeaf@git+https://github.com/aiidaplugins/aiida-skeaf@v0.2.0 \
     aiidalab-qe-wannier90
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,21 +30,9 @@ ARG QE_DIR
 ARG TARGETARCH
 
 USER ${NB_USER}
-RUN echo "Installing QE and Bader..." && \
-    mamba create -p ${QE_DIR} --yes qe=${QE_VER} bader && \
+RUN echo "Installing QE, Wannier90, and Bader..." && \
+    mamba create -p ${QE_DIR} --yes qe=${QE_VER} wannier90 bader && \
     mamba clean --all -f -y
-
-USER root
-# Build wannier90 and copy the binary to $QE_DIR conda env
-# TODO: Make a conda-forge package for wannier90!
-RUN apt-get -q update && \
-    apt-get -q install -y --no-install-recommends gfortran libblas-dev liblapack-dev libopenmpi-dev && \
-    git clone --depth=1 https://github.com/wannier-developers/wannier90.git /tmp/wannier90 && \
-    cd /tmp/wannier90 && \
-    cp config/make.inc.gfort make.inc && \
-    echo -e "COMMS=mpi\nMPIF90=mpif90" >> make.inc && \
-    make -j wannier && \
-    cp wannier90.x ${QE_DIR}/bin/wannier90.x
 
 ###############################################################################
 # 3) base stage to setup common environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ ARG HQ_URL_ARM64="https://github.com/It4innovations/hyperqueue/releases/download
 ARG MUON_PKG="aiidalab-qe-muon@git+https://github.com/aiidalab/aiidalab-qe-muon@v1.1.3"
 ARG AIIDA_HQ_PKG="aiida-hyperqueue~=0.3.0"
 
-
 ###############################################################################
 # 2) qe_conda_env stage
 #    - Creates the quantum-espresso conda environment in /opt/conda/envs/quantum-espresso-<QE_VER>
@@ -98,7 +97,18 @@ RUN mamba install aiida-core.atomic_tools -y && \
     mamba clean --all -f -y
 
 # Install the app and its plugins into the user's local Python environment
-RUN python -m pip install --user --no-cache-dir . ${MUON_PKG} aiidalab-qe-vibroscopy aiida-bader
+RUN python -m pip install --user --no-cache-dir . \
+    ${MUON_PKG} \
+    aiidalab-qe-vibroscopy \
+    aiida-bader \
+    aiidalab-qe-hp \
+    aiidalab-qe-pp \
+    aiida-qe-xspec \
+    # the following git-installed plugins are due to PyPI quarantines - discard when resolved
+    aiida-wannier90-workflows@git+https://github.com/aiidateam/aiida-wannier90-workflows \
+    aiida-wannier90@git+https://github.com/aiidateam/aiida-wannier90 \
+    aiida-skeaf@git+https://github.com/aiidaplugins/aiida-skeaf \
+    aiidalab-qe-wannier90
 
 ENV PSEUDO_FOLDER=/tmp/pseudo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,9 +105,9 @@ RUN python -m pip install --user --no-cache-dir . \
     aiidalab-qe-pp \
     aiida-qe-xspec \
     # the following git-installed plugins are due to PyPI quarantines - discard when resolved
-    aiida-wannier90-workflows@git+https://github.com/aiidateam/aiida-wannier90-workflows \
-    aiida-wannier90@git+https://github.com/aiidateam/aiida-wannier90 \
-    aiida-skeaf@git+https://github.com/aiidaplugins/aiida-skeaf \
+    aiida-wannier90-workflows@git+https://github.com/aiidateam/aiida-wannier90-workflows@v2.7.1 \
+    aiida-wannier90@git+https://github.com/aiidateam/aiida-wannier90@v2.2.0 \
+    aiida-skeaf@git+https://github.com/aiidaplugins/aiida-skeaf@v0.2.0 \
     aiidalab-qe-wannier90
 
 ENV PSEUDO_FOLDER=/tmp/pseudo

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ project_urls =
 package_dir =
     = src
 packages = find:
+# Dependency pinning:
+# - hiphive==1.3.1: to avoid an spglib inconsistency
 install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
@@ -35,8 +37,8 @@ install_requires =
     aiida-wannier90-workflows @ git+https://github.com/aiidateam/aiida-wannier90-workflows@v2.7.1
     anywidget==0.9.13
     table_widget~=0.0.2
-    shakenbreak~=3.3.1  # uses hiphive, which we pin...
-    hiphive==1.3.1  # ...to avoid an spglib inconsistency
+    shakenbreak~=3.3.1
+    hiphive==1.3.1
     plotly~=5.24
     kaleido~=0.2.1
     upf_tools~=0.1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ package_dir =
 packages = find:
 # Dependency pinning:
 # - hiphive==1.3.1: to avoid an spglib inconsistency
+# - phonopy<2.26.0: to avoid scikit-build-core build issues
 install_requires =
     aiida-core~=2.5,<3
     Jinja2~=3.0
@@ -37,6 +38,7 @@ install_requires =
     aiida-wannier90-workflows @ git+https://github.com/aiidateam/aiida-wannier90-workflows@v2.7.1
     anywidget==0.9.13
     table_widget~=0.0.2
+    phonopy~=2.19,<2.26.0
     shakenbreak~=3.3.1
     hiphive==1.3.1
     plotly~=5.24

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ install_requires =
     aiida-pseudo~=1.4
     filelock~=3.8
     importlib-resources~=5.2
-    aiida-wannier90-workflows>=2.7.1,<3
+    aiida-wannier90 @ git+https://github.com/aiidateam/aiida-wannier90@v2.2.0
+    aiida-wannier90-workflows @ git+https://github.com/aiidateam/aiida-wannier90-workflows@v2.7.1
     anywidget==0.9.13
     table_widget~=0.0.2
     shakenbreak~=3.3.1  # uses hiphive, which we pin...


### PR DESCRIPTION
This PR aims to stabilize the current, pre-upgrades state of the app:
- ~Install Wannier90 ecosystem from GitHub due to recent PyPI issues~ (see note below)
- Wannier90 v4 is now on Conda - update image accordingly
- Install all app plugins in the image (~10MB increase in image size)
- Pin phonopy due to breaking changes to the build system introduced in v2.26.0
- Remove inline comments from dependencies, which broke AiiDAlab compatibility checks that scan dependencies
- Pin aiidalab-qe-muon to a support branch that pins undi to a commit prior to dropping Python 3.9 support

I'd like to do one final release supporting Python 3.9, before we proceed with upgrading the app to the new infrastructure, to support existing deployments.

### Note regarding Wannier90 ecosystem

~I've pinned the problematic dependencies in the aiidalab-qe-wannier90 plugin directly, in version 0.1.10. It will take a day or so for @superstar54 to add me as maintainer on the PyPI project, as it appears that the API token needs refreshing. Once released, the image test will again pass here.~
Can't release to PyPI with Git-based dependencies 🥲 Restoring Git-references here