### PR TITLE
Fix download button logic

### DIFF
--- a/src/aiidalab_qe/common/widgets.py
+++ b/src/aiidalab_qe/common/widgets.py
@@ -134,20 +134,23 @@ class DownloadButton(ipw.Button):
         display(
             HTML(
                 f"""
-            <html>
-            <body>
-            <a id="{link_id}" download="{self.filename}" href="data:text/plain;base64,{payload}" download>
-            </a>
+                    <html>
+                        <body>
+                            <a
+                                id="{link_id}"
+                                download="{self.filename}"
+                                href="data:text/plain;base64,{payload}"
+                            ></a>
 
-            <script>
-            (function download() {{
-            document.getElementById('{id}').click();
-            }})()
-            </script>
+                            <script>
+                                (function download() {{
+                                    document.getElementById('{link_id}').click();
+                                }})()
+                            </script>
 
-            </body>
-            </html>
-            """
+                        </body>
+                    </html>
+                """
             )
         )
 


### PR DESCRIPTION
- Remove redundant download attribute
- Correct the `id` variable in the script

@danielhollas this is unrelated to your [issue](https://github.com/aiidalab/aiidalab-qe/issues/1491#issuecomment-5179665563), but caught it while looking at that. I guess this widget never worked (or at least not in my time 😅). We'll have to backport this to the 3.9 version as well (will do in a separate PR).

I didn't add a new test because this is effectively just fixing a typo.