### PR TITLE
Wizard refactor

### DIFF
--- a/src/aiidalab_qe/app/app.py
+++ b/src/aiidalab_qe/app/app.py
@@ -16,8 +16,8 @@ from aiida import orm
 from aiida.orm.utils.serialize import deserialize_unsafe
 from aiidalab_qe.app.static import images as images_folder
 from aiidalab_qe.app.static import templates
-from aiidalab_qe.app.wizard import Wizard
-from aiidalab_qe.app.wizard.model import WizardModel
+from aiidalab_qe.app.wizard import QeWizard
+from aiidalab_qe.app.wizard.model import QeWizardModel
 from aiidalab_qe.common.guide_manager import guide_manager
 from aiidalab_qe.common.infobox import InAppGuide, InfoBox
 from aiidalab_qe.common.widgets import LinkButton
@@ -65,7 +65,7 @@ class AppController:
         """
         self._model = model
         self._view = view
-        self._wizard_model = WizardModel()
+        self._wizard_model = QeWizardModel()
         self._set_event_handlers()
 
     def enable_toggles(self) -> None:
@@ -81,7 +81,7 @@ class AppController:
         duplicating: bool = False,
     ) -> None:
         """Load and initialize the wizard."""
-        self.wizard = Wizard(self._wizard_model, auto_setup, log_widget)
+        self.wizard = QeWizard(self._wizard_model, auto_setup, log_widget)
 
         state = {"process_uuid": self._model.process_uuid}
         if self._model.process_uuid:
@@ -170,12 +170,12 @@ class AppController:
     def _on_duplicate_workflow_click(self, _):
         if not self._model.loaded:
             return
-        app: Wizard = self._view.app_container.children[0]  # type: ignore
+        app: QeWizard = self._view.app_container.children[0]  # type: ignore
         payload = {
             "step": min(app.current_step, 3),
             "structure_state": app.structure_model.get_model_state(),
-            "configuration_state": app.configure_model.get_model_state(),
-            "resources_state": app.submit_model.get_model_state(),
+            "configuration_state": app.configuration_model.get_model_state(),
+            "resources_state": app.submission_model.get_model_state(),
         }
         CURRENT_STATE_PATH.write_text(json.dumps(payload))
 

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -94,35 +94,29 @@ footer {
   text-align: right;
 }
 
-.jupyter-widget-Accordion-child:has(.qe-app-step-ready)
-  > .jupyter-widget-Collapse-header {
+.wizard > div:has(.qe-app-step-ready) > div:first-child {
   background-color: var(--color-ready);
 }
 
-.jupyter-widget-Accordion-child:has(.qe-app-step-configured)
-  > .jupyter-widget-Collapse-header {
+.wizard > div:has(.qe-app-step-configured) > div:first-child {
   background-color: var(--color-ready);
   filter: brightness(0.95);
   -webkit-filter: brightness(0.95);
 }
 
-.jupyter-widget-Accordion-child:has(.qe-app-step-active)
-  > .jupyter-widget-Collapse-header {
+.wizard > div:has(.qe-app-step-active) > div:first-child {
   background-color: var(--color-active);
 }
 
-.jupyter-widget-Accordion-child:has(.qe-app-step-success)
-  > .jupyter-widget-Collapse-header {
+.wizard > div:has(.qe-app-step-success) > div:first-child {
   background-color: var(--color-success);
 }
 
-.jupyter-widget-Accordion-child:has(.qe-app-step-fail)
-  > .jupyter-widget-Collapse-header {
+.wizard > div:has(.qe-app-step-fail) > div:first-child {
   background-color: var(--color-failed);
 }
 
-.jupyter-widget-Accordion-child:has(.qe-app-step-blocked)
-  > .jupyter-widget-Collapse-header {
+.wizard > div:has(.qe-app-step-blocked) > div:first-child {
   background-color: var(--color-blocked);
 }
 

--- a/src/aiidalab_qe/app/static/styles/custom.css
+++ b/src/aiidalab_qe/app/static/styles/custom.css
@@ -94,32 +94,6 @@ footer {
   text-align: right;
 }
 
-.wizard > div:has(.qe-app-step-ready) > div:first-child {
-  background-color: var(--color-ready);
-}
-
-.wizard > div:has(.qe-app-step-configured) > div:first-child {
-  background-color: var(--color-ready);
-  filter: brightness(0.95);
-  -webkit-filter: brightness(0.95);
-}
-
-.wizard > div:has(.qe-app-step-active) > div:first-child {
-  background-color: var(--color-active);
-}
-
-.wizard > div:has(.qe-app-step-success) > div:first-child {
-  background-color: var(--color-success);
-}
-
-.wizard > div:has(.qe-app-step-fail) > div:first-child {
-  background-color: var(--color-failed);
-}
-
-.wizard > div:has(.qe-app-step-blocked) > div:first-child {
-  background-color: var(--color-blocked);
-}
-
 .lm-TabBar-tab {
   min-width: fit-content !important;
 }

--- a/src/aiidalab_qe/app/static/styles/wizard.css
+++ b/src/aiidalab_qe/app/static/styles/wizard.css
@@ -1,0 +1,25 @@
+.wizard > div:has(.qe-app-step-ready) > div:first-child {
+  background-color: var(--color-ready);
+}
+
+.wizard > div:has(.qe-app-step-configured) > div:first-child {
+  background-color: var(--color-ready);
+  filter: brightness(0.95);
+  -webkit-filter: brightness(0.95);
+}
+
+.wizard > div:has(.qe-app-step-active) > div:first-child {
+  background-color: var(--color-active);
+}
+
+.wizard > div:has(.qe-app-step-success) > div:first-child {
+  background-color: var(--color-success);
+}
+
+.wizard > div:has(.qe-app-step-fail) > div:first-child {
+  background-color: var(--color-failed);
+}
+
+.wizard > div:has(.qe-app-step-blocked) > div:first-child {
+  background-color: var(--color-blocked);
+}

--- a/src/aiidalab_qe/app/wizard/__init__.py
+++ b/src/aiidalab_qe/app/wizard/__init__.py
@@ -1,7 +1,7 @@
-from .model import WizardModel
-from .wizard import Wizard
+from .model import QeWizardModel
+from .wizard import QeWizard
 
 __all__ = [
-    "Wizard",
-    "WizardModel",
+    "QeWizard",
+    "QeWizardModel",
 ]

--- a/src/aiidalab_qe/app/wizard/model.py
+++ b/src/aiidalab_qe/app/wizard/model.py
@@ -7,16 +7,17 @@ from aiidalab_qe.app.result import ResultsStepModel
 from aiidalab_qe.app.structure import StructureStepModel
 from aiidalab_qe.app.submission import SubmissionStepModel
 from aiidalab_qe.common.mixins import HasModels
-from aiidalab_qe.common.mvc import Model
-from aiidalab_qe.common.wizard import WizardStepModel
+from aiidalab_qe.common.wizard import WizardModel, WizardStepModel
 
 
-class WizardModel(Model, HasModels[WizardStepModel]):
+class QeWizardModel(WizardModel, HasModels[WizardStepModel]):
     state = tl.Dict(None, allow_none=True)
     selected_index = tl.Int(None, allow_none=True)
     loading = tl.Bool(False)
 
     def load_from_state(self, state: dict):
+        super().load_from_state(state)
+
         step_index = state.get("step", 0) - 1
         structure_state = state.get("structure_state")
         configuration_state = state.get("configuration_state")
@@ -35,7 +36,7 @@ class WizardModel(Model, HasModels[WizardStepModel]):
                 structure_model.confirm()
                 configuration_model = t.cast(
                     ConfigurationStepModel,
-                    self.get_model("configure"),
+                    self.get_model("configuration"),
                 )
                 configuration_model.set_model_state(configuration_state)
 
@@ -43,7 +44,7 @@ class WizardModel(Model, HasModels[WizardStepModel]):
                     configuration_model.confirm()
                     submission_model = t.cast(
                         SubmissionStepModel,
-                        self.get_model("submit"),
+                        self.get_model("submission"),
                     )
                     if process_uuid is not None:
                         submission_model.refresh_codes(filter_codes_for_user=False)
@@ -67,7 +68,7 @@ class WizardModel(Model, HasModels[WizardStepModel]):
         )
         configuration_model = t.cast(
             ConfigurationStepModel,
-            self.get_model("configure"),
+            self.get_model("configuration"),
         )
         if structure_model.confirmed:
             configuration_model.structure_uuid = structure_model.structure_uuid
@@ -81,11 +82,11 @@ class WizardModel(Model, HasModels[WizardStepModel]):
         )
         configuration_model = t.cast(
             ConfigurationStepModel,
-            self.get_model("configure"),
+            self.get_model("configuration"),
         )
         submission_model = t.cast(
             SubmissionStepModel,
-            self.get_model("submit"),
+            self.get_model("submission"),
         )
         if configuration_model.confirmed:
             submission_model.structure_uuid = structure_model.structure_uuid
@@ -97,7 +98,7 @@ class WizardModel(Model, HasModels[WizardStepModel]):
     def update_results_model(self):
         submission_model = t.cast(
             SubmissionStepModel,
-            self.get_model("submit"),
+            self.get_model("submission"),
         )
         results_model = t.cast(
             ResultsStepModel,
@@ -109,20 +110,6 @@ class WizardModel(Model, HasModels[WizardStepModel]):
         )
 
     def lock_app(self):
-        for identifier in ("structure", "configure", "submit"):
+        for identifier in ("structure", "configuration", "submission"):
             model = self.get_model(identifier)
             model.lock()
-
-    def auto_advance(self):
-        if self.selected_index is None:
-            return
-
-        model_list = list(self._models.values())
-        index = t.cast(int, self.selected_index)
-
-        if (
-            (selected_step := model_list[index]).auto_advance
-            and not (index + 1 == len(model_list))
-            and selected_step.is_successful
-        ):
-            self.selected_index += 1

--- a/src/aiidalab_qe/app/wizard/model.py
+++ b/src/aiidalab_qe/app/wizard/model.py
@@ -6,11 +6,10 @@ from aiidalab_qe.app.configuration import ConfigurationStepModel
 from aiidalab_qe.app.result import ResultsStepModel
 from aiidalab_qe.app.structure import StructureStepModel
 from aiidalab_qe.app.submission import SubmissionStepModel
-from aiidalab_qe.common.mixins import HasModels
-from aiidalab_qe.common.wizard import WizardModel, WizardStepModel
+from aiidalab_qe.common.wizard import WizardModel
 
 
-class QeWizardModel(WizardModel, HasModels[WizardStepModel]):
+class QeWizardModel(WizardModel):
     state = tl.Dict(None, allow_none=True)
     selected_index = tl.Int(None, allow_none=True)
     loading = tl.Bool(False)

--- a/src/aiidalab_qe/app/wizard/model.py
+++ b/src/aiidalab_qe/app/wizard/model.py
@@ -10,10 +10,6 @@ from aiidalab_qe.common.wizard import WizardModel
 
 
 class QeWizardModel(WizardModel):
-    state = tl.Dict(None, allow_none=True)
-    selected_index = tl.Int(None, allow_none=True)
-    loading = tl.Bool(False)
-
     def load_from_state(self, state: dict):
         super().load_from_state(state)
 

--- a/src/aiidalab_qe/app/wizard/wizard.py
+++ b/src/aiidalab_qe/app/wizard/wizard.py
@@ -20,13 +20,6 @@ ICONS = {
     State.BLOCKED: "\u25cf",
 }
 
-TITLES = {
-    "structure": "Select structure",
-    "configuration": "Configure workflow",
-    "submission": "Choose computational resources",
-    "results": "Status & results",
-}
-
 
 class QeWizard(Wizard):
     """The main widget that combines all the application steps together."""
@@ -38,32 +31,48 @@ class QeWizard(Wizard):
         log_widget: ipw.Output | None = None,
         **kwargs,
     ):
-        super().__init__(model, TITLES, ICONS, **kwargs)
+        super().__init__(model, ICONS, **kwargs)
 
         self.structure_model = StructureStepModel(auto_advance=True)
         self.structure_step = StructureStep(
             model=self.structure_model,
             auto_setup=auto_setup,
         )
-        self.add_step(self.structure_step, self.structure_model)
+        self.add_step(
+            step=self.structure_step,
+            model=self.structure_model,
+            title="Select structure",
+        )
 
         self.configuration_model = ConfigurationStepModel(auto_advance=True)
         self.configuration_step = ConfigurationStep(model=self.configuration_model)
-        self.add_step(self.configuration_step, self.configuration_model)
+        self.add_step(
+            step=self.configuration_step,
+            model=self.configuration_model,
+            title="Configure workflow",
+        )
 
         self.submission_model = SubmissionStepModel(auto_advance=True)
         self.submission_step = SubmissionStep(
             model=self.submission_model,
             auto_setup=auto_setup,
         )
-        self.add_step(self.submission_step, self.submission_model)
+        self.add_step(
+            step=self.submission_step,
+            model=self.submission_model,
+            title="Choose computational resources",
+        )
 
         self.results_model = ResultsStepModel()
         self.results_step = ResultsStep(
             model=self.results_model,
             log_widget=log_widget,
         )
-        self.add_step(self.results_step, self.results_model)
+        self.add_step(
+            step=self.results_step,
+            model=self.results_model,
+            title="Status & results",
+        )
 
         for model in self._models:
             model.observe(

--- a/src/aiidalab_qe/app/wizard/wizard.py
+++ b/src/aiidalab_qe/app/wizard/wizard.py
@@ -6,90 +6,67 @@ from aiidalab_qe.app.configuration import ConfigurationStep, ConfigurationStepMo
 from aiidalab_qe.app.result import ResultsStep, ResultsStepModel
 from aiidalab_qe.app.structure import StructureStep, StructureStepModel
 from aiidalab_qe.app.submission import SubmissionStep, SubmissionStepModel
-from aiidalab_qe.common.wizard import State, WizardStep
+from aiidalab_qe.common.wizard import State, Wizard
 
-from .model import WizardModel
+from .model import QeWizardModel
+
+ICONS = {
+    State.INIT: "\u25cb",
+    State.READY: "\u25ce",
+    State.CONFIGURED: "\u25cf",
+    State.ACTIVE: "\u231b",
+    State.SUCCESS: "\u2713",
+    State.FAIL: "\u00d7",
+    State.BLOCKED: "\u25cf",
+}
+
+TITLES = {
+    "structure": "Select structure",
+    "configuration": "Configure workflow",
+    "submission": "Choose computational resources",
+    "results": "Status & results",
+}
 
 
-class Wizard(ipw.Accordion):
+class QeWizard(Wizard):
     """The main widget that combines all the application steps together."""
-
-    ICONS = {
-        State.INIT: "\u25cb",
-        State.READY: "\u25ce",
-        State.CONFIGURED: "\u25cf",
-        State.ACTIVE: "\u231b",
-        State.SUCCESS: "\u2713",
-        State.FAIL: "\u00d7",
-        State.BLOCKED: "\u25cf",
-    }
-
-    TITLES = {
-        "structure": "Select structure",
-        "configure": "Configure workflow",
-        "submit": "Choose computational resources",
-        "results": "Status & results",
-    }
 
     def __init__(
         self,
-        model: WizardModel,
+        model: QeWizardModel,
         auto_setup: bool = True,
         log_widget: ipw.Output | None = None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
-
-        self._model = model
-        ipw.link(
-            (self._model, "selected_index"),
-            (self, "selected_index"),
-        )
+        super().__init__(model, TITLES, ICONS, **kwargs)
 
         self.structure_model = StructureStepModel(auto_advance=True)
         self.structure_step = StructureStep(
             model=self.structure_model,
             auto_setup=auto_setup,
         )
-        self._model.add_model("structure", self.structure_model)
+        self.add_step(self.structure_step, self.structure_model)
 
-        self.configure_model = ConfigurationStepModel(auto_advance=True)
-        self.configure_step = ConfigurationStep(model=self.configure_model)
-        self._model.add_model("configure", self.configure_model)
-        ipw.dlink(
-            (self.structure_model, "state"),
-            (self.configure_model, "previous_step_state"),
-        )
+        self.configuration_model = ConfigurationStepModel(auto_advance=True)
+        self.configuration_step = ConfigurationStep(model=self.configuration_model)
+        self.add_step(self.configuration_step, self.configuration_model)
 
-        self.submit_model = SubmissionStepModel(auto_advance=True)
-        self.submit_step = SubmissionStep(
-            model=self.submit_model,
+        self.submission_model = SubmissionStepModel(auto_advance=True)
+        self.submission_step = SubmissionStep(
+            model=self.submission_model,
             auto_setup=auto_setup,
         )
-        self._model.add_model("submit", self.submit_model)
-        ipw.dlink(
-            (self.configure_model, "state"),
-            (self.submit_model, "previous_step_state"),
-        )
+        self.add_step(self.submission_step, self.submission_model)
 
         self.results_model = ResultsStepModel()
         self.results_step = ResultsStep(
             model=self.results_model,
             log_widget=log_widget,
         )
-        self._model.add_model("results", self.results_model)
-        ipw.dlink(
-            (self.submit_model, "state"),
-            (self.results_model, "previous_step_state"),
-        )
+        self.add_step(self.results_step, self.results_model)
 
-        for step_model in (
-            self.structure_model,
-            self.configure_model,
-            self.submit_model,
-            self.results_model,
-        ):
-            step_model.observe(
+        for model in self._models:
+            model.observe(
                 self._on_step_state_change,
                 "state",
             )
@@ -98,59 +75,16 @@ class Wizard(ipw.Accordion):
             self._on_structure_confirmation_change,
             "confirmed",
         )
-        self.configure_model.observe(
+        self.configuration_model.observe(
             self._on_configuration_confirmation_change,
             "confirmed",
         )
-        self.submit_model.observe(
+        self.submission_model.observe(
             self._on_submission,
             "confirmed",
         )
 
-        self._model.observe(
-            self._on_state_change,
-            "state",
-        )
-        self._model.observe(
-            self._on_step_change,
-            "selected_index",
-        )
-
-        self.rendered = False
-
         self.render()
-
-    @property
-    def current_step(self) -> int:
-        return sum(
-            1
-            for _, model in self._model.get_models()
-            if model.is_configured or model.is_successful
-        )
-
-    def render(self):
-        if self.rendered:
-            return
-
-        self.children = [
-            self.structure_step,
-            self.configure_step,
-            self.submit_step,
-            self.results_step,
-        ]
-        self._update_titles()
-
-        self.rendered = True
-
-    def _on_state_change(self, change: dict):
-        self._model.load_from_state(change["new"] or {})
-
-    def _on_step_state_change(self, _=None):
-        self._update_titles()
-
-    def _on_step_change(self, change: dict):
-        if (step_index := change["new"]) is not None:
-            self._render_step(step_index)
 
     def _on_structure_confirmation_change(self, _):
         self._model.auto_advance()
@@ -164,13 +98,3 @@ class Wizard(ipw.Accordion):
         self._model.auto_advance()
         self._model.update_results_model()
         self._model.lock_app()  # TODO .lock() might be enough - check!
-
-    def _render_step(self, step_index: int):
-        step: WizardStep = self.children[step_index]  # type: ignore
-        step.render()
-
-    def _update_titles(self):
-        for i, (step_id, title) in enumerate(self.TITLES.items()):
-            step_model = self._model.get_model(step_id)
-            icon = self.ICONS.get(step_model.state)
-            self.set_title(i, f"{icon} Step {i + 1}: {title}")

--- a/src/aiidalab_qe/common/wizard.py
+++ b/src/aiidalab_qe/common/wizard.py
@@ -6,7 +6,7 @@ import typing as t
 import ipywidgets as ipw
 import traitlets as tl
 
-from aiidalab_qe.common.mixins import Confirmable
+from aiidalab_qe.common.mixins import Confirmable, HasModels
 from aiidalab_qe.common.mvc import Model
 from aiidalab_qe.common.widgets import WarningWidget
 from aiidalab_widgets_base import LoadingWidget
@@ -53,6 +53,7 @@ class WizardStep(ipw.VBox, t.Generic[WSM]):
         self.loading_message = LoadingWidget(f"Loading {model.identifier} step")
 
         super().__init__(children=[self.loading_message], **kwargs)
+        self.add_class("wizard-step")
 
         self._model = model
 
@@ -280,3 +281,110 @@ class ConfirmableDependentWizardStep(
     ConfirmableWizardStep[CDWSM],
 ):
     """A confirmable dependent wizard step."""
+
+
+class WizardModel(Model, HasModels[WizardStepModel]):
+    state = tl.UseEnum(State, default_value=State.INIT)
+    selected_index = tl.Int(None, allow_none=True)
+    loading = tl.Bool(False)
+
+    def load_from_state(self, state: dict):
+        pass
+
+    def auto_advance(self):
+        if self.selected_index is None:
+            return
+
+        model_list = list(self._models.values())
+        index = t.cast(int, self.selected_index)
+
+        if (
+            (selected_step := model_list[index]).auto_advance
+            and not (index + 1 == len(model_list))
+            and selected_step.is_successful
+        ):
+            self.selected_index += 1
+
+
+class Wizard(ipw.Accordion):
+    """A wizard widget that manages multiple steps."""
+
+    def __init__(
+        self,
+        model: WizardModel,
+        titles: dict[str, str],
+        icons: dict[str, str],
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.add_class("wizard")
+
+        self._model = model
+        self._titles = titles
+        self._icons = icons
+
+        self._models: list[WizardStepModel] = []
+        self._steps: list[WizardStep] = []
+
+        ipw.link(
+            (self._model, "selected_index"),
+            (self, "selected_index"),
+        )
+        self._model.observe(
+            self._on_state_change,
+            "state",
+        )
+        self._model.observe(
+            self._on_step_change,
+            "selected_index",
+        )
+
+        self.rendered = False
+
+    @property
+    def current_step(self) -> int:
+        return sum(
+            1
+            for _, model in self._model.get_models()
+            if model.is_configured or model.is_successful
+        )
+
+    def add_step(self, step: WizardStep, model: WizardStepModel):
+        if len(self._steps) > 0:
+            previous_model = self._models[-1]
+            ipw.dlink(
+                (previous_model, "state"),
+                (model, "previous_step_state"),
+            )
+        self._model.add_model(model.identifier, model)
+        self._models.append(model)
+        self._steps.append(step)
+
+    def render(self):
+        if self.rendered:
+            return
+
+        self.children = self._steps
+        self._update_titles()
+
+        self.rendered = True
+
+    def _render_step(self, step_index: int):
+        step: WizardStep = self.children[step_index]  # type: ignore
+        step.render()
+
+    def _on_state_change(self, change: dict):
+        self._model.load_from_state(change["new"] or {})
+
+    def _on_step_state_change(self, _=None):
+        self._update_titles()
+
+    def _on_step_change(self, change: dict):
+        if (step_index := change["new"]) is not None:
+            self._render_step(step_index)
+
+    def _update_titles(self):
+        for i, (identifier, title) in enumerate(self._titles.items()):
+            step_model = self._model.get_model(identifier)
+            icon = self._icons.get(step_model.state)
+            self.set_title(i, f"{icon} Step {i + 1}: {title}")

--- a/src/aiidalab_qe/common/wizard.py
+++ b/src/aiidalab_qe/common/wizard.py
@@ -309,22 +309,16 @@ class WizardModel(Model, HasModels[WizardStepModel]):
 class Wizard(ipw.Accordion):
     """A wizard widget that manages multiple steps."""
 
-    def __init__(
-        self,
-        model: WizardModel,
-        titles: dict[str, str],
-        icons: dict[str, str],
-        **kwargs,
-    ):
+    def __init__(self, model: WizardModel, icons: dict[str, str], **kwargs):
         super().__init__(**kwargs)
         self.add_class("wizard")
 
         self._model = model
-        self._titles = titles
         self._icons = icons
 
         self._models: list[WizardStepModel] = []
         self._steps: list[WizardStep] = []
+        self._titles: dict[str, str] = {}
 
         ipw.link(
             (self._model, "selected_index"),
@@ -349,7 +343,12 @@ class Wizard(ipw.Accordion):
             if model.is_configured or model.is_successful
         )
 
-    def add_step(self, step: WizardStep, model: WizardStepModel):
+    def add_step(
+        self,
+        step: WizardStep,
+        model: WizardStepModel,
+        title: str | None = None,
+    ):
         if len(self._steps) > 0:
             previous_model = self._models[-1]
             ipw.dlink(
@@ -359,6 +358,7 @@ class Wizard(ipw.Accordion):
         self._model.add_model(model.identifier, model)
         self._models.append(model)
         self._steps.append(step)
+        self._titles[model.identifier] = title or model.identifier
 
     def render(self):
         if self.rendered:
@@ -387,4 +387,7 @@ class Wizard(ipw.Accordion):
         for i, (identifier, title) in enumerate(self._titles.items()):
             step_model = self._model.get_model(identifier)
             icon = self._icons.get(step_model.state)
-            self.set_title(i, f"{icon} Step {i + 1}: {title}")
+            step_title = f"{icon} Step {i + 1}"
+            if title:
+                step_title += f": {title}"
+            self.set_title(i, step_title)

--- a/src/aiidalab_qe/common/wizard.py
+++ b/src/aiidalab_qe/common/wizard.py
@@ -386,7 +386,7 @@ class Wizard(ipw.Accordion):
     def _update_titles(self):
         for i, (identifier, title) in enumerate(self._titles.items()):
             step_model = self._model.get_model(identifier)
-            icon = self._icons.get(step_model.state)
+            icon = self._icons.get(step_model.state, "")
             step_title = f"{icon} Step {i + 1}"
             if title:
                 step_title += f": {title}"

--- a/src/aiidalab_qe/common/wizard.py
+++ b/src/aiidalab_qe/common/wizard.py
@@ -284,7 +284,7 @@ class ConfirmableDependentWizardStep(
 
 
 class WizardModel(Model, HasModels[WizardStepModel]):
-    state = tl.UseEnum(State, default_value=State.INIT)
+    state = tl.Dict(None, allow_none=True)
     selected_index = tl.Int(None, allow_none=True)
     loading = tl.Bool(False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ from aiidalab_qe.app.configuration.advanced import (
     SmearingConfigurationSettingsModel,
 )
 from aiidalab_qe.app.configuration.basic import BasicConfigurationSettingsModel
-from aiidalab_qe.app.wizard import Wizard, WizardModel
+from aiidalab_qe.app.wizard import QeWizard, QeWizardModel
 from aiidalab_qe.parameters import DEFAULT_PARAMETERS
 from aiidalab_qe.plugins.bands.bands_workchain import BandsWorkChain
 from aiidalab_qe.setup.pseudos import PSEUDODOJO_VERSION, SSSP_VERSION
@@ -366,16 +366,16 @@ def app(pw_code, dos_code, projwfc_code):
     DEFAULTS["codes"]["dos"]["code"] = dos_code.full_label
     DEFAULTS["codes"]["projwfc"]["code"] = projwfc_code.full_label
 
-    model = WizardModel()
-    app = Wizard(model=model, auto_setup=False)
+    model = QeWizardModel()
+    app = QeWizard(model=model, auto_setup=False)
 
     # Since we use `auto_setup=False`, which will skip the pseudo library
     # installation, we need to mock set the installation status to `True` to
     # avoid the blocker message pop up in the submission step.
     app.structure_model.installing_sssp = False
     app.structure_model.sssp_installed = True
-    app.submit_model.installing_qe = False
-    app.submit_model.qe_installed = True
+    app.submission_model.installing_qe = False
+    app.submission_model.qe_installed = True
 
     yield app
 
@@ -383,7 +383,7 @@ def app(pw_code, dos_code, projwfc_code):
 
 
 @pytest.fixture()
-def submit_app_generator(app: Wizard, generate_structure_data):
+def submit_app_generator(app: QeWizard, generate_structure_data):
     """Return a function that generates a submit step widget."""
 
     def _submit_app_generator(
@@ -412,11 +412,11 @@ def submit_app_generator(app: Wizard, generate_structure_data):
                 "protocol": workchain_protocol,
             }
         }
-        app.configure_model.set_model_state(parameters)
+        app.configuration_model.set_model_state(parameters)
 
         advanced_model = t.cast(
             AdvancedConfigurationSettingsModel,
-            app.configure_model.get_model("advanced"),
+            app.configuration_model.get_model("advanced"),
         )
 
         general_model = t.cast(
@@ -449,14 +449,14 @@ def submit_app_generator(app: Wizard, generate_structure_data):
         )
         magnetization_model.moments = dict(
             zip(
-                app.configure_model.input_structure.get_kind_names(),
+                app.configuration_model.input_structure.get_kind_names(),
                 initial_magnetic_moments,
             )
         )
 
-        app.configure_model.confirm()
+        app.configuration_model.confirm()
 
-        global_resources_model = app.submit_model.get_model("global")
+        global_resources_model = app.submission_model.get_model("global")
         global_resources_model.get_model("quantumespresso__pw").num_cpus = 2
 
         return app
@@ -465,15 +465,15 @@ def submit_app_generator(app: Wizard, generate_structure_data):
 
 
 @pytest.fixture
-def app_to_submit(app: Wizard, generate_structure_data):
+def app_to_submit(app: QeWizard, generate_structure_data):
     # Step 1: select structure from example
     app.structure_model.structure_uuid = generate_structure_data().uuid
     app.structure_model.confirm()
     # Step 2: configure calculation
     # TODO do we need to include bands and pdos here?
-    app.configure_model.get_model("bands").include = True
-    app.configure_model.get_model("pdos").include = True
-    app.configure_model.confirm()
+    app.configuration_model.get_model("bands").include = True
+    app.configuration_model.get_model("pdos").include = True
+    app.configuration_model.confirm()
     yield app
 
 
@@ -680,7 +680,7 @@ def generate_bands_workchain(
 
 @pytest.fixture
 def generate_qeapp_workchain(
-    app: Wizard,
+    app: QeWizard,
     projwfc_code,
     generate_structure_data,
     generate_workchain,
@@ -713,15 +713,15 @@ def generate_qeapp_workchain(
         # step 2 configure
         basic_model = t.cast(
             BasicConfigurationSettingsModel,
-            app.configure_model.get_model("workchain"),
+            app.configuration_model.get_model("workchain"),
         )
 
-        app.configure_model.relax_type = relax_type
+        app.configuration_model.relax_type = relax_type
 
         # In order to prepare complete inputs, I set all the properties to true
         # this can be overridden later
-        app.configure_model.get_model("bands").include = run_bands
-        app.configure_model.get_model("pdos").include = run_pdos
+        app.configuration_model.get_model("bands").include = run_bands
+        app.configuration_model.get_model("pdos").include = run_pdos
 
         basic_model.protocol = "fast"
         basic_model.spin_type = spin_type
@@ -729,7 +729,7 @@ def generate_qeapp_workchain(
 
         advanced_model = t.cast(
             AdvancedConfigurationSettingsModel,
-            app.configure_model.get_model("advanced"),
+            app.configuration_model.get_model("advanced"),
         )
 
         if spin_type == "collinear":
@@ -757,14 +757,14 @@ def generate_qeapp_workchain(
         )
         pseudos.functional = functional
 
-        app.configure_model.confirm()
+        app.configuration_model.confirm()
 
         # step 3 setup code and resources
-        global_resources_model = app.submit_model.get_model("global")
+        global_resources_model = app.submission_model.get_model("global")
         global_resources_model.get_model("quantumespresso__pw").num_cpus = 4
-        parameters = shallow_copy_nested_dict(app.submit_model.input_parameters)
-        parameters |= {"codes": app.submit_model.get_model_state()}
-        builder = app.submit_model._create_builder(parameters)
+        parameters = shallow_copy_nested_dict(app.submission_model.input_parameters)
+        parameters |= {"codes": app.submission_model.get_model_state()}
+        builder = app.submission_model._create_builder(parameters)
 
         inputs = builder._inputs()
         if "relax" in inputs:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,12 +22,14 @@ class TestApp:
         self.model.process_uuid = workchain.node.uuid
         self.controller.load_wizard()
         wizard = self.controller.wizard
-        assert wizard.configure_model.relax_type == "positions"
-        assert wizard.configure_model.get_model("workchain").spin_type == "collinear"
-        assert wizard.configure_model.get_model("bands").include is True
-        assert wizard.configure_model.get_model("pdos").include is False
-        assert wizard.configure_model.state == State.SUCCESS
-        advanced_model = wizard.configure_model.get_model("advanced")
+        assert wizard.configuration_model.relax_type == "positions"
+        assert (
+            wizard.configuration_model.get_model("workchain").spin_type == "collinear"
+        )
+        assert wizard.configuration_model.get_model("bands").include is True
+        assert wizard.configuration_model.get_model("pdos").include is False
+        assert wizard.configuration_model.state == State.SUCCESS
+        advanced_model = wizard.configuration_model.get_model("advanced")
         pseudos_model = advanced_model.get_model("pseudos")
         assert len(pseudos_model.dictionary) > 0
         assert pseudos_model.functional == "PBE"

--- a/tests/test_codes.py
+++ b/tests/test_codes.py
@@ -3,7 +3,7 @@ import typing as t
 from aiida import orm
 from aiidalab_qe.app.submission import SubmissionStep, SubmissionStepModel
 from aiidalab_qe.app.submission.global_settings import GlobalResourceSettingsModel
-from aiidalab_qe.app.wizard import Wizard
+from aiidalab_qe.app.wizard import QeWizard
 from aiidalab_qe.common.code import PwCodeModel
 from aiidalab_qe.common.code.model import CodeModel
 from aiidalab_qe.common.panel import ResourceSettingsModel, ResourceSettingsPanel
@@ -14,35 +14,35 @@ from aiidalab_qe.utils import shallow_copy_nested_dict
 
 def test_code_not_selected(submit_app_generator):
     """Test if there is an error when the code is not selected."""
-    app: Wizard = submit_app_generator(properties=["dos"])
-    model = app.submit_model
+    app: QeWizard = submit_app_generator(properties=["dos"])
+    model = app.submission_model
     model.get_model("global").get_model("quantumespresso__dos").selected = None
     # Check builder construction passes without an error
-    parameters = shallow_copy_nested_dict(app.submit_model.input_parameters)
-    parameters |= {"codes": app.submit_model.get_model_state()}
+    parameters = shallow_copy_nested_dict(app.submission_model.input_parameters)
+    parameters |= {"codes": app.submission_model.get_model_state()}
     model._create_builder(parameters)
 
 
 def test_set_codes(submit_app_generator):
     """Test setting codes (in practice, from a loaded process)."""
-    app: Wizard = submit_app_generator()
-    resources = app.submit_model.get_model_state()
+    app: QeWizard = submit_app_generator()
+    resources = app.submission_model.get_model_state()
     model = SubmissionStepModel()
     _ = SubmissionStep(model=model, auto_setup=False)
-    for identifier, code_model in app.submit_model.get_model("global").get_models():
+    for identifier, code_model in app.submission_model.get_model("global").get_models():
         model.get_model("global").get_model(identifier).is_active = code_model.is_active
     model.get_model("global").set_model_state(resources["global"])  # type: ignore
     model.previous_step_state = State.SUCCESS
-    assert model.get_model_state() == app.submit_model.get_model_state()
+    assert model.get_model_state() == app.submission_model.get_model_state()
 
 
-def test_global_code_toggle(app: Wizard):
+def test_global_code_toggle(app: QeWizard):
     """Test that global codes toggle on/off based on their activity."""
     global_resources_model = t.cast(
         GlobalResourceSettingsModel,
-        app.submit_model.get_model("global"),
+        app.submission_model.get_model("global"),
     )
-    global_resources = app.submit_step.global_resources
+    global_resources = app.submission_step.global_resources
     global_resources.render()
 
     dos_code_model = global_resources_model.get_model("quantumespresso__dos")
@@ -57,9 +57,9 @@ def test_global_code_toggle(app: Wizard):
     assert global_resources.code_widgets["dos"].layout.display == "none"
 
 
-def test_check_blockers(app_to_submit: Wizard):
+def test_check_blockers(app_to_submit: QeWizard):
     """Test check_submission_blockers method."""
-    model = app_to_submit.submit_model
+    model = app_to_submit.submission_model
 
     assert len(model.blockers) == 0
 
@@ -83,11 +83,11 @@ def test_check_blockers(app_to_submit: Wizard):
     assert "input parameters" in model.blockers[1]  # type: ignore
 
 
-def test_qeapp_computational_resources_widget(app: Wizard):
+def test_qeapp_computational_resources_widget(app: QeWizard):
     """Test QEAppComputationalResourcesWidget."""
-    app.submit_step.render()
-    global_model = app.submit_model.get_model("global")
-    global_resources = app.submit_step.global_resources
+    app.submission_step.render()
+    global_model = app.submission_model.get_model("global")
+    global_resources = app.submission_step.global_resources
     pw_code_model = t.cast(
         PwCodeModel,
         global_model.get_model("quantumespresso__pw"),
@@ -138,7 +138,7 @@ def test_parameters_aware_codes():
     assert panel.code_widgets["test"].layout.display == "none"
 
 
-def test_filter_codes_for_user(app: Wizard, aiida_computer_ssh, aiida_code_installed):
+def test_filter_codes_for_user(app: QeWizard, aiida_computer_ssh, aiida_code_installed):
     unconfigured_computer = aiida_computer_ssh(
         label="unconfigured_computer",
         configure=False,
@@ -148,17 +148,17 @@ def test_filter_codes_for_user(app: Wizard, aiida_computer_ssh, aiida_code_insta
         computer=unconfigured_computer,
     ).store()
 
-    global_model = app.submit_model.get_model("global")
+    global_model = app.submission_model.get_model("global")
 
     # In general, we filter out unconfigured codes so the user can't submit with them
-    app.submit_model.refresh_codes(filter_codes_for_user=True)
+    app.submission_model.refresh_codes(filter_codes_for_user=True)
     assert new_code.uuid not in [
         code_uuid
         for _, code_uuid in global_model.get_model("quantumespresso__pw").options
     ]
 
     # We allow for these codes when loading from a process, since the user can no longer submit
-    app.submit_model.refresh_codes(filter_codes_for_user=False)
+    app.submission_model.refresh_codes(filter_codes_for_user=False)
     assert new_code.uuid in [
         code_uuid
         for _, code_uuid in global_model.get_model("quantumespresso__pw").options

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -13,14 +13,14 @@ from aiidalab_qe.app.result.components.viewer.structure import (
     StructureResultsModel,
     StructureResultsPanel,
 )
-from aiidalab_qe.app.wizard import Wizard
+from aiidalab_qe.app.wizard import QeWizard
 from aiidalab_qe.common.wizard import State
 
 
 def test_result_step(app_to_submit, generate_qeapp_workchain):
     """Test the result step is properly updated when the process
     is running."""
-    app: Wizard = app_to_submit
+    app: QeWizard = app_to_submit
     step: ResultsStep = app.results_step
     model: ResultsStepModel = app.results_model
     model.process_uuid = generate_qeapp_workchain().node.uuid
@@ -38,7 +38,7 @@ def test_result_step(app_to_submit, generate_qeapp_workchain):
 def test_kill_and_clean_buttons(app_to_submit, generate_qeapp_workchain):
     """Test the kill and clean_scratch button are properly displayed when the process
     is in different states."""
-    app: Wizard = app_to_submit
+    app: QeWizard = app_to_submit
     model: ResultsStepModel = app.results_model
     step: ResultsStep = app.results_step
     step.render()

--- a/tests/test_submit_qe_workchain.py
+++ b/tests/test_submit_qe_workchain.py
@@ -1,7 +1,7 @@
 import typing as t
 
 from aiidalab_qe.app.submission.global_settings import GlobalResourceSettingsModel
-from aiidalab_qe.app.wizard import Wizard
+from aiidalab_qe.app.wizard import QeWizard
 from aiidalab_qe.utils import shallow_copy_nested_dict
 
 
@@ -14,11 +14,11 @@ def test_create_builder_default(
     metal, non-magnetic
     """
 
-    app: Wizard = submit_app_generator(properties=["bands", "pdos"])
+    app: QeWizard = submit_app_generator(properties=["bands", "pdos"])
 
-    parameters = shallow_copy_nested_dict(app.submit_model.input_parameters)
-    parameters |= {"codes": app.submit_model.get_model_state()}
-    app.submit_model._create_builder(parameters)
+    parameters = shallow_copy_nested_dict(app.submission_model.input_parameters)
+    parameters |= {"codes": app.submission_model.get_model_state()}
+    app.submission_model._create_builder(parameters)
     # since uuid is specific to each run, we remove it from the output
     ui_parameters = remove_uuid_fields(parameters)
     remove_code_options(ui_parameters)
@@ -26,31 +26,31 @@ def test_create_builder_default(
     # this parameters are passed to the workchain
     data_regression.check(ui_parameters)
     # test if create builder successfully
-    # app.submit_model._create_builder(ui_parameters)  # TODO what are we doing here?
+    # app.submission_model._create_builder(ui_parameters)  # TODO what are we doing here?
     # In the future, we will check the builder parameters using regresion test
 
 
 def test_create_process_label(submit_app_generator):
     """Test the creation of the correct process label."""
-    app: Wizard = submit_app_generator(properties=["bands", "pdos"])
-    app.submit_model.update_process_label()
+    app: QeWizard = submit_app_generator(properties=["bands", "pdos"])
+    app.submission_model.update_process_label()
 
     assert (
-        app.submit_model.process_label
+        app.submission_model.process_label
         == "Si2 [relax: atoms+cell, balanced protocol] → bands, pdos"
     )
     # suppose we change the label of the structure:
-    app.submit_model.input_structure.label = "Si2, unit cell"
-    app.submit_model.update_process_label()
+    app.submission_model.input_structure.label = "Si2, unit cell"
+    app.submission_model.update_process_label()
     assert (
-        app.submit_model.process_label
+        app.submission_model.process_label
         == "Si2, unit cell [relax: atoms+cell, balanced protocol] → bands, pdos"
     )
     # suppose by mistake we provide an empty label, we then fallback to use the formula:
-    app.submit_model.input_structure.label = ""
-    app.submit_model.update_process_label()
+    app.submission_model.input_structure.label = ""
+    app.submission_model.update_process_label()
     assert (
-        app.submit_model.process_label
+        app.submission_model.process_label
         == "Si2 [relax: atoms+cell, balanced protocol] → bands, pdos"
     )
 
@@ -63,12 +63,12 @@ def test_create_builder_insulator(
     insulator, non-magnetic, no smearing
     the occupation type is set to fixed, smearing and degauss should not be set"""
 
-    app: Wizard = submit_app_generator(
+    app: QeWizard = submit_app_generator(
         electronic_type="insulator", properties=["bands", "pdos"]
     )
-    parameters = shallow_copy_nested_dict(app.submit_model.input_parameters)
-    parameters |= {"codes": app.submit_model.get_model_state()}
-    builder = app.submit_model._create_builder(parameters)
+    parameters = shallow_copy_nested_dict(app.submission_model.input_parameters)
+    parameters |= {"codes": app.submission_model.get_model_state()}
+    builder = app.submission_model._create_builder(parameters)
 
     # check and validate the builder
     got = builder_to_readable_dict(builder)
@@ -94,7 +94,7 @@ def test_create_builder_advanced_settings(
     -properties: bands, pdos
     """
 
-    app: Wizard = submit_app_generator(
+    app: QeWizard = submit_app_generator(
         electronic_type="metal",
         spin_type="collinear",
         tot_charge=1.0,
@@ -103,9 +103,9 @@ def test_create_builder_advanced_settings(
         electron_maxstep=100,
         properties=["bands", "pdos"],
     )
-    parameters = shallow_copy_nested_dict(app.submit_model.input_parameters)
-    parameters |= {"codes": app.submit_model.get_model_state()}
-    builder = app.submit_model._create_builder(parameters)
+    parameters = shallow_copy_nested_dict(app.submission_model.input_parameters)
+    parameters |= {"codes": app.submission_model.get_model_state()}
+    builder = app.submission_model._create_builder(parameters)
 
     # check if the AiiDA nodes are passed to the plugins instead of copied, take psuedos as an example
     assert (
@@ -160,11 +160,11 @@ def test_warning_messages(
         "avoid_overloading": "Reduce the number of CPUs to avoid the overloading of the local machine",
     }
 
-    app: Wizard = submit_app_generator(properties=["bands", "pdos"])
-    submit_model = app.submit_model
+    app: QeWizard = submit_app_generator(properties=["bands", "pdos"])
+    submission_model = app.submission_model
     global_model = t.cast(
         GlobalResourceSettingsModel,
-        submit_model.get_model("global"),
+        submission_model.get_model("global"),
     )
 
     pw_code = global_model.get_model("quantumespresso__pw")
@@ -173,11 +173,11 @@ def test_warning_messages(
     pw_code.num_cpus = len(os.sched_getaffinity(0))
     global_model.check_resources()
     for suggestion in ["avoid_overloading", "go_remote"]:
-        assert suggestions[suggestion] in submit_model.warning_messages
+        assert suggestions[suggestion] in submission_model.warning_messages
 
     # now we use a large structure, so we should have the Warning-1 (and 2 if not on localhost)
     structure = generate_structure_data("H2O-larger")
-    submit_model.structure_uuid = structure.uuid
+    submission_model.structure_uuid = structure.uuid
     pw_code.num_cpus = 1
     global_model.check_resources()
     num_sites = len(structure.sites)
@@ -185,7 +185,7 @@ def test_warning_messages(
     estimated_CPUs = global_model._estimate_min_cpus(num_sites, volume)
     assert estimated_CPUs == 2
     for suggestion in ["more_resources", "change_configuration"]:
-        assert suggestions[suggestion] in submit_model.warning_messages
+        assert suggestions[suggestion] in submission_model.warning_messages
 
 
 def builder_to_readable_dict(builder):

--- a/tests/widgets/test_wizard.py
+++ b/tests/widgets/test_wizard.py
@@ -1,0 +1,121 @@
+import ipywidgets as ipw
+
+from aiidalab_qe.common.wizard import (
+    ConfirmableWizardStepModel,
+    DependentWizardStep,
+    DependentWizardStepModel,
+    State,
+    Wizard,
+    WizardModel,
+    WizardStep,
+    WizardStepModel,
+)
+
+
+class DummyStepModel(WizardStepModel):
+    def __init__(self, identifier: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.identifier = identifier
+
+    def update_state(self):
+        pass
+
+
+class DummyStep(WizardStep[DummyStepModel]):
+    def _render(self):
+        self.content = ipw.Label("dummy content")
+
+
+class DummyDependentModel(DependentWizardStepModel):
+    _dependencies = ["ready"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ready = False
+
+    def update_state(self):
+        if self.previous_step_state is State.SUCCESS and self.ready:
+            self.state = State.SUCCESS
+        else:
+            self.state = State.INIT
+
+
+class DummyDependentStep(DependentWizardStep[DummyDependentModel]):
+    def _render(self):
+        self.content = ipw.Label("dependent content")
+
+
+class DummyConfirmableModel(ConfirmableWizardStepModel):
+    def update_state(self):
+        if self.confirmed:
+            self.state = State.SUCCESS
+        else:
+            self.state = State.INIT
+
+
+def test_wizard_auto_advance_between_successful_steps():
+    model = WizardModel()
+
+    first = DummyStepModel("first")
+    second = DummyStepModel("second")
+    third = DummyStepModel("third")
+
+    model.add_model(first.identifier, first)
+    model.add_model(second.identifier, second)
+    model.add_model(third.identifier, third)
+
+    model.selected_index = 0
+    first.state = State.SUCCESS
+
+    model.auto_advance()
+    assert model.selected_index == 1
+
+    model.selected_index = 1
+    second.state = State.SUCCESS
+
+    model.auto_advance()
+    assert model.selected_index == 2
+
+
+def test_dependent_step_shows_warning_until_dependencies_are_met():
+    model = DummyDependentModel()
+    step = DummyDependentStep(model)
+    step.render()
+
+    assert step.children[0] is step.missing_message
+
+    model.previous_step_state = State.SUCCESS
+    model.ready = True
+    step._update_content()
+    assert step.children[0] is step.content
+
+
+def test_confirmable_model_keeps_confirmation_when_state_changes():
+    model = DummyConfirmableModel()
+
+    model.confirm()
+    assert model.confirmed is True
+
+    model.state = State.SUCCESS
+    assert model.confirmed is True
+
+
+def test_wizard_sets_titles_and_tracks_current_step_progress():
+    model = WizardModel()
+    wizard = Wizard(model, icons={})
+
+    first = DummyStepModel("first")
+    second = DummyDependentModel()
+    second.identifier = "second"
+
+    wizard.add_step(DummyStep(first), first, title="First")
+    wizard.add_step(DummyDependentStep(second), second, title="Second")
+    wizard.render()
+
+    assert wizard.get_title(0).endswith("First")
+    assert wizard.get_title(1).endswith("Second")
+
+    first.state = State.SUCCESS
+    second.previous_step_state = State.SUCCESS
+    second.state = State.CONFIGURED
+    assert wizard.current_step == 2


### PR DESCRIPTION
https://github.com/aiidalab/aiidalab-qe/pull/1427 detached from the AWB wizard and developed a generalized MVC-based  wizard, but only its steps. Here I add also classes for the entire Wizard (and model), with a dedicated "wizard" CSS class, which I then leverage to color-coordinate the wizard steps instead of relying on Jupyter CSS class names.