### PR TITLE
Set `structure_name` in structure step from process

### DIFF
--- a/src/aiidalab_qe/app/structure/model.py
+++ b/src/aiidalab_qe/app/structure/model.py
@@ -28,6 +28,8 @@ class StructureStepModel(
 
     def set_model_state(self, state: dict):
         self.structure_uuid = state.get("uuid")
+        structure = self.input_structure
+        self.structure_name = structure.get_formula() if structure else ""
 
     def update_state(self):
         if self.confirmed:


### PR DESCRIPTION
This PR sets the `structure_name` in `StructureStepModel.set_model_state` when loading a process (completed or duplicated workflow). Without it set, the link between the structure manager and the step that keeps these in sync may fire on first render (if the step is not locked), which will reset the step, effectively defeating the duplication feature. Setting the trait resolves this issue, and more generally, was simply missed - it SHOULD be set!